### PR TITLE
Add evaluateTx to Provider

### DIFF
--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -56,10 +56,12 @@ library
   build-depends:
     , base
     , bytestring
+    , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-byron
     , cardano-ledger-conway
     , cardano-ledger-core
+    , cardano-slotting
     , cardano-strict-containers
     , containers
     , contra-tracer
@@ -73,3 +75,5 @@ library
     , ouroboros-network-framework
     , ouroboros-network-protocols
     , stm
+    , text
+    , transformers

--- a/docs/modules/provider.md
+++ b/docs/modules/provider.md
@@ -10,8 +10,28 @@ Protocol-agnostic interface for querying the Cardano blockchain.
 data Provider m = Provider
     { queryUTxOs         :: Addr -> m [(TxIn, TxOut ConwayEra)]
     , queryProtocolParams :: m (PParams ConwayEra)
+    , evaluateTx         :: Tx ConwayEra -> m (EvaluateTxResult ConwayEra)
     }
 ```
+
+## Fields
+
+| Field | Description |
+|-------|-------------|
+| `queryUTxOs` | Look up UTxOs at an address |
+| `queryProtocolParams` | Fetch current protocol parameters |
+| `evaluateTx` | Evaluate script execution units for a transaction |
+
+### `evaluateTx`
+
+Evaluates Plutus script execution units for a fully-built transaction.
+The implementation resolves all transaction inputs (spending, collateral,
+and reference) from the node, fetches protocol parameters, system start,
+and the hard-fork interpreter, then calls the ledger's `evalTxExUnits`
+locally.
+
+Returns a `Map` from each script purpose to either a
+`TransactionScriptFailure` or the computed `ExUnits`.
 
 ## Constructors
 
@@ -26,6 +46,7 @@ import Cardano.Node.Client.N2C.Provider (mkN2CProvider)
 
 let provider = mkN2CProvider lsqChannel
 
-utxos <- queryUTxOs provider myAddress
-pp    <- queryProtocolParams provider
+utxos  <- queryUTxOs provider myAddress
+pp     <- queryProtocolParams provider
+exUnits <- evaluateTx provider mySignedTx
 ```

--- a/lib/Cardano/Node/Client/N2C/Provider.hs
+++ b/lib/Cardano/Node/Client/N2C/Provider.hs
@@ -17,20 +17,43 @@ module Cardano.Node.Client.N2C.Provider (
     mkN2CProvider,
 ) where
 
+import Data.Bifunctor (first)
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
+import Data.Text qualified as T
 
+import Control.Monad.Trans.Except (runExcept)
+import Lens.Micro ((^.))
+
+import Cardano.Ledger.Alonzo.Plutus.Evaluate (
+    evalTxExUnits,
+ )
+import Cardano.Ledger.Api.Tx.Body (
+    collateralInputsTxBodyL,
+    inputsTxBodyL,
+    referenceInputsTxBodyL,
+ )
+import Cardano.Ledger.Core (bodyTxL)
 import Cardano.Ledger.State (UTxO (..))
+import Cardano.Slotting.EpochInfo (hoistEpochInfo)
 
 import Ouroboros.Consensus.Cardano.Block (
     pattern QueryIfCurrentConway,
  )
+import Ouroboros.Consensus.HardFork.Combinator.Ledger.Query (
+    QueryHardFork (GetInterpreter),
+    pattern QueryHardFork,
+ )
+import Ouroboros.Consensus.HardFork.History.EpochInfo (
+    interpreterToEpochInfo,
+ )
 import Ouroboros.Consensus.Ledger.Query (
-    Query (BlockQuery),
+    Query (BlockQuery, GetSystemStart),
  )
 import Ouroboros.Consensus.Shelley.Ledger.Query (
     pattern GetCurrentPParams,
     pattern GetUTxOByAddress,
+    pattern GetUTxOByTxIn,
  )
 
 import Cardano.Node.Client.N2C.LocalStateQuery (
@@ -76,4 +99,60 @@ mkN2CProvider ch =
                     error
                         "queryUTxOs: era mismatch \
                         \— node not in Conway"
+        , evaluateTx = \tx -> do
+            let body = tx ^. bodyTxL
+                allInputs =
+                    Set.unions
+                        [ body ^. inputsTxBodyL
+                        , body
+                            ^. collateralInputsTxBodyL
+                        , body
+                            ^. referenceInputsTxBodyL
+                        ]
+            -- Resolve UTxOs for all inputs
+            utxoResult <-
+                queryLSQ ch $
+                    BlockQuery $
+                        QueryIfCurrentConway $
+                            GetUTxOByTxIn allInputs
+            utxo <- case utxoResult of
+                Right u -> pure u
+                Left _mismatch ->
+                    error
+                        "evaluateTx: era mismatch \
+                        \— node not in Conway"
+            -- Protocol parameters
+            ppResult <-
+                queryLSQ ch $
+                    BlockQuery $
+                        QueryIfCurrentConway
+                            GetCurrentPParams
+            pp <- case ppResult of
+                Right p -> pure p
+                Left _mismatch ->
+                    error
+                        "evaluateTx: era mismatch \
+                        \— node not in Conway"
+            -- System start
+            systemStart <-
+                queryLSQ ch GetSystemStart
+            -- Hard-fork interpreter → EpochInfo
+            interpreter <-
+                queryLSQ ch $
+                    BlockQuery $
+                        QueryHardFork GetInterpreter
+            let epochInfo =
+                    hoistEpochInfo
+                        ( first (T.pack . show)
+                            . runExcept
+                        )
+                        $ interpreterToEpochInfo
+                            interpreter
+            pure $
+                evalTxExUnits
+                    pp
+                    tx
+                    utxo
+                    epochInfo
+                    systemStart
         }

--- a/lib/Cardano/Node/Client/Provider.hs
+++ b/lib/Cardano/Node/Client/Provider.hs
@@ -10,13 +10,36 @@ constructors (e.g. 'Cardano.Node.Client.N2C.Provider.mkN2CProvider').
 module Cardano.Node.Client.Provider (
     -- * Provider interface
     Provider (..),
+
+    -- * Result types
+    EvaluateTxResult,
 ) where
 
+import Data.Map.Strict (Map)
+
 import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Alonzo.Plutus.Evaluate (
+    TransactionScriptFailure,
+ )
+import Cardano.Ledger.Alonzo.Scripts (
+    AsIx,
+    PlutusPurpose,
+ )
+import Cardano.Ledger.Api.Tx (Tx)
 import Cardano.Ledger.Api.Tx.Out (TxOut)
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core (PParams)
+import Cardano.Ledger.Plutus (ExUnits)
 import Cardano.Ledger.TxIn (TxIn)
+
+-- | Per-script evaluation result.
+type EvaluateTxResult era =
+    Map
+        (PlutusPurpose AsIx era)
+        ( Either
+            (TransactionScriptFailure era)
+            ExUnits
+        )
 
 {- | Interface for querying the blockchain.
 All era-specific types are fixed to 'ConwayEra'.
@@ -29,4 +52,8 @@ data Provider m = Provider
     , queryProtocolParams ::
         m (PParams ConwayEra)
     -- ^ Fetch current protocol parameters
+    , evaluateTx ::
+        Tx ConwayEra ->
+        m (EvaluateTxResult ConwayEra)
+    -- ^ Evaluate script execution units
     }


### PR DESCRIPTION
## Summary
- Add `evaluateTx` field to `Provider` record and `EvaluateTxResult` type alias
- N2C implementation queries node for UTxOs, protocol params, system start, and hard-fork interpreter, then calls `evalTxExUnits` locally
- Update docs and cabal dependencies

Closes #5