### PR TITLE
fix: make devnet library public

### DIFF
--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -80,6 +80,7 @@ library
 
 library devnet
   import:           warnings
+  visibility:       public
   hs-source-dirs:   e2e-test
   default-language: GHC2021
   exposed-modules:


### PR DESCRIPTION
The devnet sub-library was private by default (Cabal 3.4+), making it unusable from external packages like cardano-mpfs-offchain.

Adds `visibility: public` so consumers can depend on `cardano-node-clients:devnet`.