### PR TITLE
feat: expose devnet genesis as flake output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,9 @@
             };
           };
         in {
+          packages.devnet-genesis = pkgs.runCommand "devnet-genesis" {} ''
+            cp -r ${./e2e-test/genesis} $out
+          '';
           devShells.default = project.shell;
         };
     };


### PR DESCRIPTION
## Summary

- Add `packages.devnet-genesis` flake output containing the e2e genesis files

Needed by the MPFS devnet server when run from external repos.