### PR TITLE
chore: replace RocksDB with in-memory backend in E2E test

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,14 +20,14 @@ repository cardano-haskell-packages
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/chain-follower
-  tag: 61e9a34181ea7f34daf67463eaf8aeb7414854c0
-  --sha256: 0gc8sq8dwi1g5js8qrcmnka7p19qqviwmgx4iyp43qk56x7n4lap
+  tag: 371b5930976ac3bb4e8a4ef576d5098d706984ee
+  --sha256: 1rks78zmgmxz5cg4v82vnc6hwib8vrylwk2m7y82iqaymmnskdvf
 
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/rocksdb-kv-transactions
-  tag: 5ba20902f4e97bd0090f0f4a58f0b1e3ee64d3dc
-  --sha256: 0jylki9wmgn1xxaw096dfxks9c6vzzbv8bgs6vg8k4bhpbig0v77
+  tag: e2e77579888ebbd832ea750ebf2635dfc3307025
+  --sha256: 0nd1yz6k3xh1p7nlswp2jbw74bzqr7bvz11kcfyhhimqmjhkqvwm
 
 source-repository-package
   type: git

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -144,13 +144,9 @@ test-suite e2e-tests
     , cardano-node-clients:devnet
     , chain-follower
     , contra-tracer
-    , data-default
     , hspec
     , lens
     , microlens
     , ouroboros-network-api
-    , rocksdb-haskell-jprupp
-    , rocksdb-kv-transactions
     , rocksdb-kv-transactions:kv-transactions
     , stm
-    , temporary

--- a/test/Cardano/Node/Client/E2E/ChainSyncSpec.hs
+++ b/test/Cardano/Node/Client/E2E/ChainSyncSpec.hs
@@ -42,8 +42,8 @@ import Control.Concurrent.STM (
  )
 import Control.Lens (prism')
 import Control.Tracer (nullTracer)
+import Data.ByteString (ByteString)
 import Data.ByteString.Char8 qualified as BS8
-import Data.Default (Default (..))
 import Data.IORef (
     IORef,
     modifyIORef',
@@ -56,7 +56,7 @@ import Database.KV.Database (
     KV,
     mkColumns,
  )
-import Database.KV.RocksDB (mkRocksDBDatabase)
+import Database.KV.InMemory (mkInMemoryDatabase)
 import Database.KV.Transaction (
     Codecs (..),
     DSum ((:=>)),
@@ -67,20 +67,12 @@ import Database.KV.Transaction (
     fromPairList,
     runTransactionUnguarded,
  )
-import Database.RocksDB (
-    BatchOp,
-    ColumnFamily,
-    Config (createIfMissing),
-    DB (..),
-    withDBCF,
- )
 import Ouroboros.Network.Block (
     Point (..),
     SlotNo (..),
     blockSlot,
  )
 import Ouroboros.Network.Point (WithOrigin (..))
-import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec (
     Spec,
     describe,
@@ -109,12 +101,13 @@ import Cardano.Node.Client.N2C.ChainSync (
 data NoOpInv = NoOpInv
     deriving stock (Show, Eq, Read)
 
+-- | In-memory transaction type.
 type T =
     Transaction
         IO
-        ColumnFamily
+        Int
         RollbackCols
-        BatchOp
+        (Int, ByteString, Maybe ByteString)
 
 -- | No-op restoring continuation.
 noOpRestoring :: Restoring IO T Fetched NoOpInv ()
@@ -170,30 +163,22 @@ rollbackCodecs =
 type RunTx =
     forall a. T a -> IO a
 
--- | Run with a temporary RocksDB.
+-- | Create an in-memory rollback database.
 withRollbackDB :: (RunTx -> IO a) -> IO a
-withRollbackDB action =
-    withSystemTempDirectory "chainsync-e2e" $ \dbPath ->
-        withDBCF
-            dbPath
-            def{createIfMissing = True}
-            [("rollbacks", def{createIfMissing = True})]
-            $ \db ->
-                action $
-                    runTransactionUnguarded $
-                        mkRocksDBDatabase db $
-                            mkColumns
-                                (columnFamilies db)
-                                (fromPairList rollbackCodecs)
+withRollbackDB action = do
+    db <-
+        mkInMemoryDatabase $
+            mkColumns [0 ..] (fromPairList rollbackCodecs)
+    action $ runTransactionUnguarded db
 
 -- * Follower wiring
 
 type TestPhase =
     Phase
         IO
-        ColumnFamily
+        Int
         RollbackCols
-        BatchOp
+        (Int, ByteString, Maybe ByteString)
         Fetched
         NoOpInv
         ()


### PR DESCRIPTION
## Summary

- Switch `ChainSyncSpec.withRollbackDB` from RocksDB temp directory to `mkInMemoryDatabase`
- Remove `rocksdb-haskell-jprupp`, `rocksdb-kv-transactions`, `data-default`, `temporary` from `e2e-tests` build-depends
- Update `chain-follower` and `rocksdb-kv-transactions` pins

Closes #24