### PR TITLE
feat: generic tx balancing helpers

### DIFF
--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -137,6 +137,7 @@ test-suite e2e-tests
   main-is:          main.hs
   default-language: GHC2021
   other-modules:
+    Cardano.Node.Client.E2E.BalanceSpec
     Cardano.Node.Client.E2E.ChainPopulatorSpec
     Cardano.Node.Client.E2E.ChainSyncSpec
     Cardano.Node.Client.E2E.ProviderSpec
@@ -153,6 +154,8 @@ test-suite e2e-tests
     , cardano-node-clients
     , cardano-node-clients:devnet
     , cardano-read-ledger
+    , cardano-strict-containers
+    , containers
     , chain-follower
     , contra-tracer
     , hspec

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -42,6 +42,7 @@ library
   default-language: GHC2021
   exposed-modules:
     Cardano.Node.Client.Balance
+    Cardano.Node.Client.Evaluate
     Cardano.Node.Client.N2C.ChainSync
     Cardano.Node.Client.N2C.Codecs
     Cardano.Node.Client.N2C.Connection

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -166,8 +166,8 @@ test-suite e2e-tests
     , cardano-node-clients:devnet
     , cardano-read-ledger
     , cardano-strict-containers
-    , containers
     , chain-follower
+    , containers
     , contra-tracer
     , hspec
     , lens

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -124,11 +124,21 @@ test-suite unit-tests
   hs-source-dirs:   test
   main-is:          unit-main.hs
   default-language: GHC2021
-  other-modules:    Data.List.SampleFibonacciSpec
+  other-modules:
+    Cardano.Node.Client.BalanceSpec
+    Data.List.SampleFibonacciSpec
+
   build-depends:
     , base
+    , cardano-crypto-class
+    , cardano-ledger-alonzo
+    , cardano-ledger-api
+    , cardano-ledger-conway
+    , cardano-ledger-core
     , cardano-node-clients
+    , containers
     , hspec
+    , plutus-core
     , QuickCheck
 
 test-suite e2e-tests

--- a/lib/Cardano/Node/Client/Balance.hs
+++ b/lib/Cardano/Node/Client/Balance.hs
@@ -21,6 +21,11 @@ module Cardano.Node.Client.Balance (
     balanceTx,
     balanceFeeLoop,
 
+    -- * Script helpers
+    computeScriptIntegrity,
+    spendingIndex,
+    placeholderExUnits,
+
     -- * Errors
     BalanceError (..),
     FeeLoopError (..),
@@ -29,6 +34,7 @@ module Cardano.Node.Client.Balance (
 import Data.Foldable (foldl')
 import Data.Sequence.Strict (StrictSeq, (|>))
 import Data.Set qualified as Set
+import Data.Word (Word32)
 import Lens.Micro ((&), (.~), (^.))
 
 import Cardano.Ledger.Address (Addr)
@@ -47,10 +53,27 @@ import Cardano.Ledger.Api.Tx.Out (
     coinTxOutL,
     mkBasicTxOut,
  )
-import Cardano.Ledger.BaseTypes (Inject (..))
+import Cardano.Ledger.Alonzo.PParams
+    ( LangDepView
+    , getLanguageView
+    )
+import Cardano.Ledger.Alonzo.Tx
+    ( ScriptIntegrityHash
+    , hashScriptIntegrity
+    )
+import Cardano.Ledger.Alonzo.TxWits
+    ( Redeemers
+    , TxDats (..)
+    )
+import Cardano.Ledger.BaseTypes
+    ( Inject (..)
+    , StrictMaybe
+    )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core (PParams)
+import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
+import Cardano.Ledger.Plutus.Language (Language)
 import Cardano.Ledger.TxIn (TxIn)
 
 -- | Fee-paying UTxO has insufficient ada.
@@ -250,3 +273,65 @@ balanceFeeLoop pp mkOutputs numWitnesses tx =
                      in if newFee <= currentFee
                             then Right candidate
                             else go (n + 1) newFee
+
+-- -----------------------------------------------------------
+-- Script helpers
+-- -----------------------------------------------------------
+
+{- | Compute the 'ScriptIntegrityHash' from protocol
+parameters, a set of 'Redeemers', and the Plutus
+language used.
+
+The hash covers the language cost model, redeemers,
+and an empty datum set (inline datums only — no
+datum map needed).
+
+@
+integrity <- computeScriptIntegrity PlutusV3 pp redeemers
+body & scriptIntegrityHashTxBodyL .~ integrity
+@
+-}
+computeScriptIntegrity ::
+    Language ->
+    PParams ConwayEra ->
+    Redeemers ConwayEra ->
+    StrictMaybe ScriptIntegrityHash
+computeScriptIntegrity lang pp rdmrs =
+    let langViews :: Set.Set LangDepView
+        langViews =
+            Set.singleton
+                (getLanguageView pp lang)
+        emptyDats = TxDats mempty
+     in hashScriptIntegrity langViews rdmrs emptyDats
+
+{- | Compute the spending index of a 'TxIn' within
+the sorted input set.
+
+Plutus spending redeemers reference inputs by their
+position in the sorted set of all transaction
+inputs. This function finds that position.
+
+@
+let allInputs = Set.fromList [stateIn, reqIn, feeIn]
+    stateIx = spendingIndex stateIn allInputs
+    -- redeemer: ConwaySpending (AsIx stateIx)
+@
+-}
+spendingIndex :: TxIn -> Set.Set TxIn -> Word32
+spendingIndex needle inputs =
+    let sorted = Set.toAscList inputs
+     in go 0 sorted
+  where
+    go _ [] =
+        error "spendingIndex: TxIn not in set"
+    go n (x : xs)
+        | x == needle = n
+        | otherwise = go (n + 1) xs
+
+{- | Zero execution units, used as placeholder when
+building a transaction before script evaluation.
+After calling 'evaluateTx', patch the redeemers
+with the real values.
+-}
+placeholderExUnits :: ExUnits
+placeholderExUnits = ExUnits 0 0

--- a/lib/Cardano/Node/Client/Balance.hs
+++ b/lib/Cardano/Node/Client/Balance.hs
@@ -38,6 +38,18 @@ import Data.Word (Word32)
 import Lens.Micro ((&), (.~), (^.))
 
 import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Alonzo.PParams (
+    LangDepView,
+    getLanguageView,
+ )
+import Cardano.Ledger.Alonzo.Tx (
+    ScriptIntegrityHash,
+    hashScriptIntegrity,
+ )
+import Cardano.Ledger.Alonzo.TxWits (
+    Redeemers,
+    TxDats (..),
+ )
 import Cardano.Ledger.Api.Tx (
     Tx,
     bodyTxL,
@@ -53,22 +65,10 @@ import Cardano.Ledger.Api.Tx.Out (
     coinTxOutL,
     mkBasicTxOut,
  )
-import Cardano.Ledger.Alonzo.PParams
-    ( LangDepView
-    , getLanguageView
-    )
-import Cardano.Ledger.Alonzo.Tx
-    ( ScriptIntegrityHash
-    , hashScriptIntegrity
-    )
-import Cardano.Ledger.Alonzo.TxWits
-    ( Redeemers
-    , TxDats (..)
-    )
-import Cardano.Ledger.BaseTypes
-    ( Inject (..)
-    , StrictMaybe
-    )
+import Cardano.Ledger.BaseTypes (
+    Inject (..),
+    StrictMaybe,
+ )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core (PParams)
@@ -184,13 +184,15 @@ balanceTx pp inputUtxos changeAddr tx =
                 Left (InsufficientFee fee inputCoin)
             else Right (buildTx fee)
 
--- | Output function rejected the fee, or the
--- iteration did not converge.
+{- | Output function rejected the fee, or the
+iteration did not converge.
+-}
 data FeeLoopError
     = -- | Fee did not converge in 10 iterations.
       FeeDidNotConverge
-    | -- | The output function returned an error
-      --   (e.g., insufficient funds for the fee).
+    | {- | The output function returned an error
+      (e.g., insufficient funds for the fee).
+      -}
       OutputError !String
     deriving (Eq, Show)
 
@@ -238,12 +240,14 @@ goes to the Cardano treasury.
 -}
 balanceFeeLoop ::
     PParams ConwayEra ->
-    -- | Compute outputs for a given fee. Return
-    --   'Left' to abort (e.g., fee exceeds
-    --   available funds).
+    {- | Compute outputs for a given fee. Return
+    'Left' to abort (e.g., fee exceeds
+    available funds).
+    -}
     (Coin -> Either String (StrictSeq (TxOut ConwayEra))) ->
-    -- | Number of key witnesses to assume for
-    --   fee estimation.
+    {- | Number of key witnesses to assume for
+    fee estimation.
+    -}
     Int ->
     -- | Template transaction.
     Tx ConwayEra ->

--- a/lib/Cardano/Node/Client/Balance.hs
+++ b/lib/Cardano/Node/Client/Balance.hs
@@ -19,13 +19,15 @@ and this module adds the fee delta.
 module Cardano.Node.Client.Balance (
     -- * Balancing
     balanceTx,
+    balanceFeeLoop,
 
     -- * Errors
     BalanceError (..),
+    FeeLoopError (..),
 ) where
 
 import Data.Foldable (foldl')
-import Data.Sequence.Strict ((|>))
+import Data.Sequence.Strict (StrictSeq, (|>))
 import Data.Set qualified as Set
 import Lens.Micro ((&), (.~), (^.))
 
@@ -158,3 +160,93 @@ balanceTx pp inputUtxos changeAddr tx =
             then
                 Left (InsufficientFee fee inputCoin)
             else Right (buildTx fee)
+
+-- | Output function rejected the fee, or the
+-- iteration did not converge.
+data FeeLoopError
+    = -- | Fee did not converge in 10 iterations.
+      FeeDidNotConverge
+    | -- | The output function returned an error
+      --   (e.g., insufficient funds for the fee).
+      OutputError !String
+    deriving (Eq, Show)
+
+{- | Find the fee fixed point for a transaction
+where output values depend on the fee.
+
+In standard balancing ('balanceTx'), outputs are
+fixed and only the fee varies. Some validators
+enforce conservation equations like:
+
+@sum(refunds) = sum(inputs) - fee - N * tip@
+
+where the refund output values depend on the fee.
+This creates a circular dependency: the fee depends
+on the tx size, which depends on the output values,
+which depend on the fee.
+
+'balanceFeeLoop' breaks this cycle by iterating:
+
+1. Compute outputs for the current fee estimate
+2. Build the tx with those outputs and fee
+3. Re-estimate the fee from the tx size
+4. If the fee changed, go to (1)
+
+Convergence is fast (2–3 rounds) because a fee
+change of @Δf@ changes output CBOR encoding by at
+most a few bytes, which changes the fee by
+@≈ a × (bytes changed)@ lovelace — well under @Δf@.
+
+The template transaction must have inputs,
+collateral, scripts, and redeemers already set.
+The fee and outputs will be overwritten.
+
+Unlike 'balanceTx', this does NOT add inputs or a
+change output. The fee is paid from the existing
+inputs; any excess (converged fee minus minimum)
+goes to the Cardano treasury.
+
+@
+  let mkOutputs fee =
+        let refund = inputValue - fee - tip
+        in  Right [stateOutput, mkRefundOutput refund]
+  in  balanceFeeLoop pp mkOutputs 1 templateTx
+@
+-}
+balanceFeeLoop ::
+    PParams ConwayEra ->
+    -- | Compute outputs for a given fee. Return
+    --   'Left' to abort (e.g., fee exceeds
+    --   available funds).
+    (Coin -> Either String (StrictSeq (TxOut ConwayEra))) ->
+    -- | Number of key witnesses to assume for
+    --   fee estimation.
+    Int ->
+    -- | Template transaction.
+    Tx ConwayEra ->
+    Either FeeLoopError (Tx ConwayEra)
+balanceFeeLoop pp mkOutputs numWitnesses tx =
+    go 0 (Coin 0)
+  where
+    go !n currentFee
+        | n > (10 :: Int) = Left FeeDidNotConverge
+        | otherwise =
+            case mkOutputs currentFee of
+                Left msg -> Left (OutputError msg)
+                Right outs ->
+                    let candidate =
+                            tx
+                                & bodyTxL . outputsTxBodyL
+                                    .~ outs
+                                & bodyTxL . feeTxBodyL
+                                    .~ currentFee
+                        newFee =
+                            estimateMinFeeTx
+                                pp
+                                candidate
+                                numWitnesses
+                                0 -- boot witnesses
+                                0 -- ref scripts bytes
+                     in if newFee <= currentFee
+                            then Right candidate
+                            else go (n + 1) newFee

--- a/lib/Cardano/Node/Client/Evaluate.hs
+++ b/lib/Cardano/Node/Client/Evaluate.hs
@@ -23,27 +23,27 @@ let signed = addKeyWitness sk tx
 submitTx submitter signed
 @
 -}
-module Cardano.Node.Client.Evaluate
-    ( evaluateAndBalance
-    ) where
+module Cardano.Node.Client.Evaluate (
+    evaluateAndBalance,
+) where
 
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Lens.Micro ((&), (.~), (^.))
 
 import Cardano.Ledger.Address (Addr)
-import Cardano.Ledger.Alonzo.TxBody
-    ( scriptIntegrityHashTxBodyL
-    )
+import Cardano.Ledger.Alonzo.TxBody (
+    scriptIntegrityHashTxBodyL,
+ )
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
-import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
-    , witsTxL
-    )
-import Cardano.Ledger.Api.Tx.Body
-    ( inputsTxBodyL
-    )
+import Cardano.Ledger.Api.Tx (
+    Tx,
+    bodyTxL,
+    witsTxL,
+ )
+import Cardano.Ledger.Api.Tx.Body (
+    inputsTxBodyL,
+ )
 import Cardano.Ledger.Api.Tx.Out (TxOut)
 import Cardano.Ledger.Api.Tx.Wits (rdmrsTxWitsL)
 import Cardano.Ledger.Conway (ConwayEra)
@@ -51,10 +51,10 @@ import Cardano.Ledger.Core (PParams)
 import Cardano.Ledger.Plutus.Language (Language)
 import Cardano.Ledger.TxIn (TxIn)
 
-import Cardano.Node.Client.Balance
-    ( balanceTx
-    , computeScriptIntegrity
-    )
+import Cardano.Node.Client.Balance (
+    balanceTx,
+    computeScriptIntegrity,
+ )
 import Cardano.Node.Client.Provider (Provider (..))
 
 {- | Evaluate Plutus scripts, patch execution units,
@@ -82,9 +82,10 @@ evaluateAndBalance ::
     Language ->
     Provider IO ->
     PParams ConwayEra ->
-    -- | All input UTxOs (fee-paying and script).
-    --   Their 'TxIn's are unioned with the body's
-    --   inputs.
+    {- | All input UTxOs (fee-paying and script).
+    Their 'TxIn's are unioned with the body's
+    inputs.
+    -}
     [(TxIn, TxOut ConwayEra)] ->
     -- | Change address
     Addr ->
@@ -119,9 +120,9 @@ evaluateAndBalance lang prov pp inputUtxos changeAddr tx =
         if null failures
             then pure ()
             else
-                error
-                    $ "evaluateAndBalance: \
-                      \script eval failed: "
+                error $
+                    "evaluateAndBalance: \
+                    \script eval failed: "
                         <> show failures
         -- Patch ExUnits from eval result
         let Redeemers rdmrMap =
@@ -156,7 +157,7 @@ evaluateAndBalance lang prov pp inputUtxos changeAddr tx =
             changeAddr
             patched' of
             Left err ->
-                error
-                    $ "evaluateAndBalance: "
+                error $
+                    "evaluateAndBalance: "
                         <> show err
             Right balanced -> pure balanced

--- a/lib/Cardano/Node/Client/Evaluate.hs
+++ b/lib/Cardano/Node/Client/Evaluate.hs
@@ -1,0 +1,162 @@
+{-# LANGUAGE BangPatterns #-}
+
+{- |
+Module      : Cardano.Node.Client.Evaluate
+Description : Evaluate scripts and balance in one step
+License     : Apache-2.0
+
+Combines script evaluation, execution unit patching,
+integrity hash recomputation, and transaction
+balancing into a single function.
+
+This is the standard workflow for submitting
+transactions with Plutus scripts:
+
+1. Build a tx with 'placeholderExUnits'
+2. Call 'evaluateAndBalance'
+3. Sign and submit
+
+@
+tx <- evaluateAndBalance PlutusV3 prov pp
+        [feeUtxo, scriptUtxo] changeAddr unbalancedTx
+let signed = addKeyWitness sk tx
+submitTx submitter signed
+@
+-}
+module Cardano.Node.Client.Evaluate
+    ( evaluateAndBalance
+    ) where
+
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Lens.Micro ((&), (.~), (^.))
+
+import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Alonzo.TxBody
+    ( scriptIntegrityHashTxBodyL
+    )
+import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
+import Cardano.Ledger.Api.Tx
+    ( Tx
+    , bodyTxL
+    , witsTxL
+    )
+import Cardano.Ledger.Api.Tx.Body
+    ( inputsTxBodyL
+    )
+import Cardano.Ledger.Api.Tx.Out (TxOut)
+import Cardano.Ledger.Api.Tx.Wits (rdmrsTxWitsL)
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core (PParams)
+import Cardano.Ledger.Plutus.Language (Language)
+import Cardano.Ledger.TxIn (TxIn)
+
+import Cardano.Node.Client.Balance
+    ( balanceTx
+    , computeScriptIntegrity
+    )
+import Cardano.Node.Client.Provider (Provider (..))
+
+{- | Evaluate Plutus scripts, patch execution units,
+recompute the script integrity hash, and balance the
+transaction.
+
+The workflow:
+
+1. Merge all input 'TxIn's into the body so the
+   evaluator sees the complete input set (spending
+   indices must match the redeemers).
+2. Call 'evaluateTx' via the 'Provider' to get
+   actual 'ExUnits' for each redeemer.
+3. Patch each redeemer's 'ExUnits' from the
+   evaluation result.
+4. Recompute 'scriptIntegrityHash' with the patched
+   redeemers.
+5. Call 'balanceTx' to add fee inputs and a change
+   output.
+
+Throws an error if script evaluation fails or
+balancing fails (insufficient funds).
+-}
+evaluateAndBalance ::
+    Language ->
+    Provider IO ->
+    PParams ConwayEra ->
+    -- | All input UTxOs (fee-paying and script).
+    --   Their 'TxIn's are unioned with the body's
+    --   inputs.
+    [(TxIn, TxOut ConwayEra)] ->
+    -- | Change address
+    Addr ->
+    -- | Unbalanced tx with 'placeholderExUnits'
+    Tx ConwayEra ->
+    IO (Tx ConwayEra)
+evaluateAndBalance lang prov pp inputUtxos changeAddr tx =
+    do
+        -- Pre-add all inputs so the evaluator sees
+        -- the complete input set and spending indices
+        -- match the redeemers.
+        let existingIns =
+                tx ^. bodyTxL . inputsTxBodyL
+            allIns =
+                foldl
+                    ( \s (tin, _) ->
+                        Set.insert tin s
+                    )
+                    existingIns
+                    inputUtxos
+            txForEval =
+                tx
+                    & bodyTxL . inputsTxBodyL
+                        .~ allIns
+        evalResult <- evaluateTx prov txForEval
+        -- Check for script evaluation failures
+        let failures =
+                [ (p, e)
+                | (p, Left e) <-
+                    Map.toList evalResult
+                ]
+        if null failures
+            then pure ()
+            else
+                error
+                    $ "evaluateAndBalance: \
+                      \script eval failed: "
+                        <> show failures
+        -- Patch ExUnits from eval result
+        let Redeemers rdmrMap =
+                tx ^. witsTxL . rdmrsTxWitsL
+            patched =
+                Map.mapWithKey
+                    ( \purpose (dat, eu) ->
+                        case Map.lookup
+                            purpose
+                            evalResult of
+                            Just (Right eu') ->
+                                (dat, eu')
+                            _ -> (dat, eu)
+                    )
+                    rdmrMap
+            newRedeemers = Redeemers patched
+            integrity =
+                computeScriptIntegrity
+                    lang
+                    pp
+                    newRedeemers
+            patched' =
+                tx
+                    & witsTxL . rdmrsTxWitsL
+                        .~ newRedeemers
+                    & bodyTxL
+                        . scriptIntegrityHashTxBodyL
+                        .~ integrity
+        case balanceTx
+            pp
+            inputUtxos
+            changeAddr
+            patched' of
+            Left err ->
+                error
+                    $ "evaluateAndBalance: "
+                        <> show err
+            Right balanced -> pure balanced

--- a/lib/Cardano/Node/Client/Evaluate.hs
+++ b/lib/Cardano/Node/Client/Evaluate.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-
 {- |
 Module      : Cardano.Node.Client.Evaluate
 Description : Evaluate scripts and balance in one step

--- a/test/Cardano/Node/Client/BalanceSpec.hs
+++ b/test/Cardano/Node/Client/BalanceSpec.hs
@@ -9,32 +9,32 @@ import Data.Set qualified as Set
 import Test.Hspec
 import Test.QuickCheck
 
+import Cardano.Crypto.Hash (hashFromStringAsHex)
 import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
 import Cardano.Ledger.Api.Scripts.Data (Data (..))
-import Cardano.Ledger.BaseTypes
-    ( StrictMaybe (..)
-    , TxIx (..)
-    )
+import Cardano.Ledger.BaseTypes (
+    StrictMaybe (..),
+    TxIx (..),
+ )
 import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Conway.Scripts
-    ( ConwayPlutusPurpose (..)
-    )
+import Cardano.Ledger.Conway.Scripts (
+    ConwayPlutusPurpose (..),
+ )
 import Cardano.Ledger.Core (emptyPParams)
-import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
-import Cardano.Ledger.Plutus.Language
-    ( Language (PlutusV3)
-    )
-import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
-import Cardano.Crypto.Hash (hashFromStringAsHex)
+import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
+import Cardano.Ledger.Plutus.Language (
+    Language (PlutusV3),
+ )
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import PlutusCore.Data qualified as PLC
 
-import Cardano.Node.Client.Balance
-    ( computeScriptIntegrity
-    , placeholderExUnits
-    , spendingIndex
-    )
+import Cardano.Node.Client.Balance (
+    computeScriptIntegrity,
+    placeholderExUnits,
+    spendingIndex,
+ )
 
 spec :: Spec
 spec = describe "Balance helpers" $ do
@@ -46,10 +46,11 @@ spec = describe "Balance helpers" $ do
 -- Test TxIn construction
 -- -----------------------------------------------------------
 
--- | Make a TxIn from an Int (deterministic, unique).
--- | Deterministic TxIn from an Int.
--- Uses the int as the last 2 bytes of a 32-byte
--- hash, producing unique sorted TxIds.
+{- | Make a TxIn from an Int (deterministic, unique).
+| Deterministic TxIn from an Int.
+Uses the int as the last 2 bytes of a 32-byte
+hash, producing unique sorted TxIds.
+-}
 mkTxIn :: Int -> TxIn
 mkTxIn n =
     let hexStr =
@@ -57,11 +58,11 @@ mkTxIn n =
                 ++ hexByte (n `div` 256)
                 ++ hexByte (n `mod` 256)
         h = fromJust (hashFromStringAsHex hexStr)
-    in  TxIn (TxId (unsafeMakeSafeHash h)) (TxIx 0)
+     in TxIn (TxId (unsafeMakeSafeHash h)) (TxIx 0)
   where
     hexByte b =
         let (hi, lo) = b `divMod` 16
-        in  [hexDigit hi, hexDigit lo]
+         in [hexDigit hi, hexDigit lo]
     hexDigit d
         | d < 10 = toEnum (fromEnum '0' + d)
         | otherwise = toEnum (fromEnum 'a' + d - 10)
@@ -81,8 +82,10 @@ spendingIndexSpec = describe "spendingIndex" $ do
         let tins = map mkTxIn [1 .. 5]
             s = Set.fromList tins
             sorted = Set.toAscList s
-        mapM_ (\(tin, expected) ->
-            spendingIndex tin s `shouldBe` expected)
+        mapM_
+            ( \(tin, expected) ->
+                spendingIndex tin s `shouldBe` expected
+            )
             (zip sorted [0 ..])
 
     it "index < set size (property)" $
@@ -124,8 +127,8 @@ spendingIndexSpec = describe "spendingIndex" $ do
 -- | Build a Redeemers with a spending entry.
 mkRedeemers :: Integer -> Redeemers ConwayEra
 mkRedeemers seed =
-    Redeemers
-        $ Map.singleton
+    Redeemers $
+        Map.singleton
             (ConwaySpending (AsIx 0))
             ( Data (PLC.I seed)
             , ExUnits 1000 10000

--- a/test/Cardano/Node/Client/BalanceSpec.hs
+++ b/test/Cardano/Node/Client/BalanceSpec.hs
@@ -1,0 +1,187 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+module Cardano.Node.Client.BalanceSpec (spec) where
+
+import Data.List (nub, sort)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromJust)
+import Data.Set qualified as Set
+import Test.Hspec
+import Test.QuickCheck
+
+import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
+import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
+import Cardano.Ledger.Api.Scripts.Data (Data (..))
+import Cardano.Ledger.BaseTypes
+    ( StrictMaybe (..)
+    , TxIx (..)
+    )
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway.Scripts
+    ( ConwayPlutusPurpose (..)
+    )
+import Cardano.Ledger.Core (emptyPParams)
+import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
+import Cardano.Ledger.Plutus.Language
+    ( Language (PlutusV3)
+    )
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
+import Cardano.Crypto.Hash (hashFromStringAsHex)
+import PlutusCore.Data qualified as PLC
+
+import Cardano.Node.Client.Balance
+    ( computeScriptIntegrity
+    , placeholderExUnits
+    , spendingIndex
+    )
+
+spec :: Spec
+spec = describe "Balance helpers" $ do
+    spendingIndexSpec
+    computeScriptIntegritySpec
+    placeholderExUnitsSpec
+
+-- -----------------------------------------------------------
+-- Test TxIn construction
+-- -----------------------------------------------------------
+
+-- | Make a TxIn from an Int (deterministic, unique).
+-- | Deterministic TxIn from an Int.
+-- Uses the int as the last 2 bytes of a 32-byte
+-- hash, producing unique sorted TxIds.
+mkTxIn :: Int -> TxIn
+mkTxIn n =
+    let hexStr =
+            replicate 60 '0'
+                ++ hexByte (n `div` 256)
+                ++ hexByte (n `mod` 256)
+        h = fromJust (hashFromStringAsHex hexStr)
+    in  TxIn (TxId (unsafeMakeSafeHash h)) (TxIx 0)
+  where
+    hexByte b =
+        let (hi, lo) = b `divMod` 16
+        in  [hexDigit hi, hexDigit lo]
+    hexDigit d
+        | d < 10 = toEnum (fromEnum '0' + d)
+        | otherwise = toEnum (fromEnum 'a' + d - 10)
+
+-- -----------------------------------------------------------
+-- spendingIndex
+-- -----------------------------------------------------------
+
+spendingIndexSpec :: Spec
+spendingIndexSpec = describe "spendingIndex" $ do
+    it "returns 0 for a singleton set" $ do
+        let tin = mkTxIn 1
+            s = Set.singleton tin
+        spendingIndex tin s `shouldBe` 0
+
+    it "returns correct index for sorted position" $ do
+        let tins = map mkTxIn [1 .. 5]
+            s = Set.fromList tins
+            sorted = Set.toAscList s
+        mapM_ (\(tin, expected) ->
+            spendingIndex tin s `shouldBe` expected)
+            (zip sorted [0 ..])
+
+    it "index < set size (property)" $
+        property $
+            forAll (choose (1, 20)) $ \n -> do
+                let tins = map mkTxIn [1 .. n]
+                    s = Set.fromList tins
+                all
+                    ( \tin ->
+                        spendingIndex tin s
+                            < fromIntegral (Set.size s)
+                    )
+                    tins
+
+    it "is monotonic (property)" $
+        property $
+            forAll (choose (2, 15)) $ \n -> do
+                let tins = map mkTxIn [1 .. n]
+                    s = Set.fromList tins
+                    sorted = Set.toAscList s
+                    indices =
+                        map (`spendingIndex` s) sorted
+                indices == sort indices
+                    && length (nub indices)
+                        == length indices
+
+    it "adding an element shifts later indices" $ do
+        let tins = map mkTxIn [1, 3, 5]
+            s = Set.fromList tins
+            ix3 = spendingIndex (mkTxIn 3) s
+            s' = Set.insert (mkTxIn 2) s
+            ix3' = spendingIndex (mkTxIn 3) s'
+        ix3' `shouldBe` ix3 + 1
+
+-- -----------------------------------------------------------
+-- computeScriptIntegrity
+-- -----------------------------------------------------------
+
+-- | Build a Redeemers with a spending entry.
+mkRedeemers :: Integer -> Redeemers ConwayEra
+mkRedeemers seed =
+    Redeemers
+        $ Map.singleton
+            (ConwaySpending (AsIx 0))
+            ( Data (PLC.I seed)
+            , ExUnits 1000 10000
+            )
+
+computeScriptIntegritySpec :: Spec
+computeScriptIntegritySpec =
+    describe "computeScriptIntegrity" $ do
+        it "returns SJust for non-empty redeemers" $ do
+            let pp = emptyPParams @ConwayEra
+                result =
+                    computeScriptIntegrity
+                        PlutusV3
+                        pp
+                        (mkRedeemers 42)
+            case result of
+                SJust _ -> pure ()
+                SNothing ->
+                    expectationFailure "expected SJust"
+
+        it "is deterministic" $ do
+            let pp = emptyPParams @ConwayEra
+                r1 =
+                    computeScriptIntegrity
+                        PlutusV3
+                        pp
+                        (mkRedeemers 42)
+                r2 =
+                    computeScriptIntegrity
+                        PlutusV3
+                        pp
+                        (mkRedeemers 42)
+            r1 `shouldBe` r2
+
+        it "different data ⇒ different hash" $ do
+            let pp = emptyPParams @ConwayEra
+                r1 =
+                    computeScriptIntegrity
+                        PlutusV3
+                        pp
+                        (mkRedeemers 1)
+                r2 =
+                    computeScriptIntegrity
+                        PlutusV3
+                        pp
+                        (mkRedeemers 2)
+            r1 `shouldNotBe` r2
+
+-- -----------------------------------------------------------
+-- placeholderExUnits
+-- -----------------------------------------------------------
+
+placeholderExUnitsSpec :: Spec
+placeholderExUnitsSpec =
+    describe "placeholderExUnits" $
+        it "has zero mem and steps" $ do
+            let ExUnits mem steps = placeholderExUnits
+            mem `shouldBe` 0
+            steps `shouldBe` 0

--- a/test/Cardano/Node/Client/BalanceSpec.hs
+++ b/test/Cardano/Node/Client/BalanceSpec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NumericUnderscores #-}
-
 module Cardano.Node.Client.BalanceSpec (spec) where
 
 import Data.List (nub, sort)

--- a/test/Cardano/Node/Client/E2E/BalanceSpec.hs
+++ b/test/Cardano/Node/Client/E2E/BalanceSpec.hs
@@ -1,0 +1,208 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+module Cardano.Node.Client.E2E.BalanceSpec (spec) where
+
+import Data.Sequence.Strict qualified as StrictSeq
+import Data.Set qualified as Set
+import Lens.Micro ((&), (.~), (^.))
+import Test.Hspec
+
+import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Api.Tx
+    ( bodyTxL
+    , estimateMinFeeTx
+    , mkBasicTx
+    )
+import Cardano.Ledger.Api.Tx.Body
+    ( collateralInputsTxBodyL
+    , feeTxBodyL
+    , inputsTxBodyL
+    , mkBasicTxBody
+    , outputsTxBodyL
+    )
+import Cardano.Ledger.Api.Tx.Out
+    ( TxOut
+    , coinTxOutL
+    , mkBasicTxOut
+    )
+import Cardano.Ledger.BaseTypes (Inject (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core (PParams)
+import Cardano.Ledger.TxIn (TxIn)
+
+import Cardano.Node.Client.Balance
+    ( FeeLoopError (..)
+    , balanceFeeLoop
+    )
+import Cardano.Node.Client.E2E.Setup
+    ( genesisAddr
+    , withDevnet
+    )
+import Cardano.Node.Client.N2C.Provider (mkN2CProvider)
+import Cardano.Node.Client.Provider (Provider (..))
+
+spec :: Spec
+spec = around withProviderAndParams $ do
+    describe "balanceFeeLoop" $ do
+        it "converges for a single output" singleOutput
+        it "converges for multiple outputs" multiOutput
+        it "reports negative refund" negativeRefund
+        it "fee ≥ estimated min fee" feeIsSufficient
+
+type Env = (PParams ConwayEra, Addr, [(TxIn, TxOut ConwayEra)])
+
+withProviderAndParams :: (Env -> IO ()) -> IO ()
+withProviderAndParams action =
+    withDevnet $ \lsq _ltxs -> do
+        let prov = mkN2CProvider lsq
+        pp <- queryProtocolParams prov
+        utxos <- queryUTxOs prov genesisAddr
+        action (pp, genesisAddr, utxos)
+
+-- | Fee converges with a single conservation output.
+singleOutput :: Env -> IO ()
+singleOutput (pp, addr, utxos) = do
+    (seedIn, seedOut) <- case utxos of
+        (u : _) -> pure u
+        [] -> fail "no UTxOs"
+    let
+        Coin inputVal = seedOut ^. coinTxOutL
+        tip = 100_000
+        mkOutputs (Coin fee) =
+            let refund = inputVal - fee - tip
+            in  if refund < 0
+                    then Left "insufficient"
+                    else
+                        Right
+                            $ StrictSeq.singleton
+                            $ mkBasicTxOut
+                                addr
+                                (inject (Coin refund))
+        template =
+            mkBasicTx
+                ( mkBasicTxBody
+                    & inputsTxBodyL
+                        .~ Set.singleton seedIn
+                    & collateralInputsTxBodyL
+                        .~ Set.singleton seedIn
+                )
+    case balanceFeeLoop pp mkOutputs 1 template of
+        Left err -> fail $ "balanceFeeLoop: " <> show err
+        Right tx -> do
+            let Coin fee = tx ^. bodyTxL . feeTxBodyL
+            fee `shouldSatisfy` (> 0)
+            -- Verify conservation: input = output + fee + tip
+            let outs = tx ^. bodyTxL . outputsTxBodyL
+                Coin outVal =
+                    foldl
+                        (\(Coin a) o -> let Coin c = o ^. coinTxOutL in Coin (a + c))
+                        (Coin 0)
+                        outs
+            (outVal + fee + tip) `shouldBe` inputVal
+
+-- | Fee converges with 5 outputs (different tx size).
+multiOutput :: Env -> IO ()
+multiOutput (pp, addr, utxos) = do
+    (seedIn, seedOut) <- case utxos of
+        (u : _) -> pure u
+        [] -> fail "no UTxOs"
+    let
+        Coin inputVal = seedOut ^. coinTxOutL
+        n = 5
+        tipPerOutput = 50_000
+        mkOutputs (Coin fee) =
+            let totalRefund = inputVal - fee - n * tipPerOutput
+                perOutput = totalRefund `div` n
+                remainder = totalRefund `mod` n
+            in  if totalRefund < 0
+                    then Left "insufficient"
+                    else
+                        Right
+                            $ StrictSeq.fromList
+                                [ mkBasicTxOut addr
+                                    ( inject
+                                        ( Coin
+                                            ( perOutput
+                                                + if i == (0 :: Integer)
+                                                    then remainder
+                                                    else 0
+                                            )
+                                        )
+                                    )
+                                | i <- [0 .. n - 1]
+                                ]
+        template =
+            mkBasicTx
+                ( mkBasicTxBody
+                    & inputsTxBodyL
+                        .~ Set.singleton seedIn
+                    & collateralInputsTxBodyL
+                        .~ Set.singleton seedIn
+                )
+    case balanceFeeLoop pp mkOutputs 1 template of
+        Left err -> fail $ "balanceFeeLoop: " <> show err
+        Right tx -> do
+            let Coin fee = tx ^. bodyTxL . feeTxBodyL
+                outs = tx ^. bodyTxL . outputsTxBodyL
+                Coin outVal =
+                    foldl
+                        (\(Coin a) o -> let Coin c = o ^. coinTxOutL in Coin (a + c))
+                        (Coin 0)
+                        outs
+            fee `shouldSatisfy` (> 0)
+            -- Conservation: input = outputs + fee + tips
+            (outVal + fee + n * tipPerOutput) `shouldBe` inputVal
+
+-- | Output function returning Left propagates as OutputError.
+negativeRefund :: Env -> IO ()
+negativeRefund (pp, _addr, utxos) = do
+    (seedIn, _) <- case utxos of
+        (u : _) -> pure u
+        [] -> fail "no UTxOs"
+    let
+        -- Always fail regardless of fee
+        mkOutputs _ = Left "not enough funds"
+        template =
+            mkBasicTx
+                ( mkBasicTxBody
+                    & inputsTxBodyL
+                        .~ Set.singleton seedIn
+                )
+    balanceFeeLoop pp mkOutputs 1 template
+        `shouldBe` Left (OutputError "not enough funds")
+
+-- | The converged fee is ≥ the estimated minimum.
+feeIsSufficient :: Env -> IO ()
+feeIsSufficient (pp, addr, utxos) = do
+    (seedIn, seedOut) <- case utxos of
+        (u : _) -> pure u
+        [] -> fail "no UTxOs"
+    let
+        Coin inputVal = seedOut ^. coinTxOutL
+        mkOutputs (Coin fee) =
+            let refund = inputVal - fee
+            in  if refund < 0
+                    then Left "insufficient"
+                    else
+                        Right
+                            $ StrictSeq.singleton
+                            $ mkBasicTxOut
+                                addr
+                                (inject (Coin refund))
+        template =
+            mkBasicTx
+                ( mkBasicTxBody
+                    & inputsTxBodyL
+                        .~ Set.singleton seedIn
+                    & collateralInputsTxBodyL
+                        .~ Set.singleton seedIn
+                )
+    case balanceFeeLoop pp mkOutputs 1 template of
+        Left err -> fail $ "balanceFeeLoop: " <> show err
+        Right tx -> do
+            let Coin fee = tx ^. bodyTxL . feeTxBodyL
+                -- Re-estimate to verify
+                Coin minFee =
+                    estimateMinFeeTx pp tx 1 0 0
+            fee `shouldSatisfy` (>= minFee)

--- a/test/Cardano/Node/Client/E2E/BalanceSpec.hs
+++ b/test/Cardano/Node/Client/E2E/BalanceSpec.hs
@@ -8,37 +8,37 @@ import Lens.Micro ((&), (.~), (^.))
 import Test.Hspec
 
 import Cardano.Ledger.Address (Addr)
-import Cardano.Ledger.Api.Tx
-    ( bodyTxL
-    , estimateMinFeeTx
-    , mkBasicTx
-    )
-import Cardano.Ledger.Api.Tx.Body
-    ( collateralInputsTxBodyL
-    , feeTxBodyL
-    , inputsTxBodyL
-    , mkBasicTxBody
-    , outputsTxBodyL
-    )
-import Cardano.Ledger.Api.Tx.Out
-    ( TxOut
-    , coinTxOutL
-    , mkBasicTxOut
-    )
+import Cardano.Ledger.Api.Tx (
+    bodyTxL,
+    estimateMinFeeTx,
+    mkBasicTx,
+ )
+import Cardano.Ledger.Api.Tx.Body (
+    collateralInputsTxBodyL,
+    feeTxBodyL,
+    inputsTxBodyL,
+    mkBasicTxBody,
+    outputsTxBodyL,
+ )
+import Cardano.Ledger.Api.Tx.Out (
+    TxOut,
+    coinTxOutL,
+    mkBasicTxOut,
+ )
 import Cardano.Ledger.BaseTypes (Inject (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core (PParams)
 import Cardano.Ledger.TxIn (TxIn)
 
-import Cardano.Node.Client.Balance
-    ( FeeLoopError (..)
-    , balanceFeeLoop
-    )
-import Cardano.Node.Client.E2E.Setup
-    ( genesisAddr
-    , withDevnet
-    )
+import Cardano.Node.Client.Balance (
+    FeeLoopError (..),
+    balanceFeeLoop,
+ )
+import Cardano.Node.Client.E2E.Setup (
+    genesisAddr,
+    withDevnet,
+ )
 import Cardano.Node.Client.N2C.Provider (mkN2CProvider)
 import Cardano.Node.Client.Provider (Provider (..))
 
@@ -71,14 +71,14 @@ singleOutput (pp, addr, utxos) = do
         tip = 100_000
         mkOutputs (Coin fee) =
             let refund = inputVal - fee - tip
-            in  if refund < 0
+             in if refund < 0
                     then Left "insufficient"
                     else
-                        Right
-                            $ StrictSeq.singleton
-                            $ mkBasicTxOut
-                                addr
-                                (inject (Coin refund))
+                        Right $
+                            StrictSeq.singleton $
+                                mkBasicTxOut
+                                    addr
+                                    (inject (Coin refund))
         template =
             mkBasicTx
                 ( mkBasicTxBody
@@ -115,12 +115,13 @@ multiOutput (pp, addr, utxos) = do
             let totalRefund = inputVal - fee - n * tipPerOutput
                 perOutput = totalRefund `div` n
                 remainder = totalRefund `mod` n
-            in  if totalRefund < 0
+             in if totalRefund < 0
                     then Left "insufficient"
                     else
-                        Right
-                            $ StrictSeq.fromList
-                                [ mkBasicTxOut addr
+                        Right $
+                            StrictSeq.fromList
+                                [ mkBasicTxOut
+                                    addr
                                     ( inject
                                         ( Coin
                                             ( perOutput
@@ -182,14 +183,14 @@ feeIsSufficient (pp, addr, utxos) = do
         Coin inputVal = seedOut ^. coinTxOutL
         mkOutputs (Coin fee) =
             let refund = inputVal - fee
-            in  if refund < 0
+             in if refund < 0
                     then Left "insufficient"
                     else
-                        Right
-                            $ StrictSeq.singleton
-                            $ mkBasicTxOut
-                                addr
-                                (inject (Coin refund))
+                        Right $
+                            StrictSeq.singleton $
+                                mkBasicTxOut
+                                    addr
+                                    (inject (Coin refund))
         template =
             mkBasicTx
                 ( mkBasicTxBody

--- a/test/main.hs
+++ b/test/main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Test.Hspec (hspec)
 
+import Cardano.Node.Client.E2E.BalanceSpec qualified as BalanceSpec
 import Cardano.Node.Client.E2E.ChainPopulatorSpec qualified as ChainPopulatorSpec
 import Cardano.Node.Client.E2E.ChainSyncSpec qualified as ChainSyncSpec
 import Cardano.Node.Client.E2E.ProviderSpec qualified as ProviderSpec
@@ -9,5 +10,6 @@ import Cardano.Node.Client.E2E.ProviderSpec qualified as ProviderSpec
 main :: IO ()
 main = hspec $ do
     ProviderSpec.spec
+    BalanceSpec.spec
     ChainSyncSpec.spec
     ChainPopulatorSpec.spec

--- a/test/unit-main.hs
+++ b/test/unit-main.hs
@@ -2,7 +2,10 @@ module Main (main) where
 
 import Test.Hspec (hspec)
 
+import Cardano.Node.Client.BalanceSpec qualified as BalanceSpec
 import Data.List.SampleFibonacciSpec qualified as SampleFibonacciSpec
 
 main :: IO ()
-main = hspec SampleFibonacciSpec.spec
+main = hspec $ do
+    SampleFibonacciSpec.spec
+    BalanceSpec.spec


### PR DESCRIPTION
## Summary
- `balanceFeeLoop`: fee-output fixed point for conservation-aware transactions
- `computeScriptIntegrity`: integrity hash from PParams + Language + Redeemers
- `spendingIndex`: sorted position of TxIn for Plutus spending redeemer indices
- `placeholderExUnits`: ExUnits 0 0 constant
- `evaluateAndBalance`: evaluate scripts + patch ExUnits + recompute integrity + balance

## Test plan
- [x] 19 unit tests (including 200 QuickCheck properties for spendingIndex)
- [x] 9 E2E tests (including 4 for balanceFeeLoop convergence)