### PR TITLE
Transaction builder DSL (Slices 1-6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist-newstyle/
 .llm/
 cabal.project.local
 result
+site/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# cardano-node-clients-tx-builder Development Guidelines
+
+Auto-generated from all feature plans. Last updated: 2026-04-10
+
+## Active Technologies
+
+- Haskell (GHC 9.6+, same as cardano-node-clients) + cardano-ledger-api, cardano-ledger-conway, plutus-ledger-api, plutus-tx (ToData/FromData) (003-tx-builder-dsl)
+
+## Project Structure
+
+```text
+src/
+tests/
+```
+
+## Commands
+
+# Add commands for Haskell (GHC 9.6+, same as cardano-node-clients)
+
+## Code Style
+
+Haskell (GHC 9.6+, same as cardano-node-clients): Follow standard conventions
+
+## Recent Changes
+
+- 003-tx-builder-dsl: Added Haskell (GHC 9.6+, same as cardano-node-clients) + cardano-ledger-api, cardano-ledger-conway, plutus-ledger-api, plutus-tx (ToData/FromData)
+
+<!-- MANUAL ADDITIONS START -->
+<!-- MANUAL ADDITIONS END -->

--- a/WIP.md
+++ b/WIP.md
@@ -1,7 +1,7 @@
 # WIP: Transaction Builder DSL
 
 ## Status
-Slices 1-4 done, unit tests green. Next: Slice 5 (Valid).
+Slices 1-5 done, unit tests green. Next: Slice 6 (Reference + Validity).
 
 ## Links
 - PR: lambdasistemi/cardano-node-clients#38
@@ -36,14 +36,21 @@ Slices 1-4 done, unit tests green. Next: Slice 5 (Valid).
 - `build` now takes `InterpretIO q`
 - Test query GADT coverage in `TxBuildSpec`
 
+### Slice 5: Valid + library checkers
+- `Valid :: (Tx ConwayEra -> Check e) -> TxInstr q e ()`
+- `Check e = Pass | LedgerFail LedgerCheck | CustomFail e`
+- `LedgerCheck` includes min-UTxO and tx-size failures
+- `valid`, `checkMinUtxo`, `checkTxSize`
+- `build` now returns `Left (ChecksFailed [...])` after convergence
+- Tests for custom failure, min-UTxO failure, tx-size failure, and all-pass
+
 ## Next
 
-### Slice 5: Valid + library checkers
 ### Slice 6: Reference inputs + validity intervals
 ### Slices 7-9: MPFS migrations
 
 ## Tests
-18 `TxBuild` examples passing
+23 `TxBuild` examples passing
 
 ## Key files
 - `lib/Cardano/Node/Client/TxBuild.hs`

--- a/WIP.md
+++ b/WIP.md
@@ -1,0 +1,52 @@
+# WIP: Transaction Builder DSL
+
+## Status
+Slices 1-4 done, unit tests green. Next: Slice 5 (Valid).
+
+## Links
+- PR: lambdasistemi/cardano-node-clients#38
+- Issue: lambdasistemi/cardano-node-clients#36
+- Branch: `003-tx-builder-dsl`
+- Worktree: `/code/cardano-node-clients-tx-builder`
+
+## Done
+
+### Slice 1: Simple spend + draft
+- `TxInstr q e a` GADT with `Spend`, `Send`, `Collateral`, `Peek`
+- `Convergence a = Iterate a | Ok a`
+- `spend` returns `Word32` via `Peek`, `payTo`, `collateral`
+- `draft` interpreter (two-pass, pure)
+- `Interpret`/`InterpretIO` newtypes
+
+### Slice 2: Script spend + mint + redeemer indices
+- `ScriptWitness` existential, `MintWitness`
+- `spendScript`, `mint`, `payTo'`, `attachScript`, `requireSignature`
+- Auto redeemer index computation (spending + minting)
+- Script integrity hash, script witnesses
+
+### Slice 3: Build loop + Peek convergence
+- `build` interpreter: iterate Peek, evaluate scripts, patch ExUnits, balance
+- `BuildError e` type
+- Convergence: all Peek Ok + Tx body stable
+
+### Slice 4: Ctx + pluggable queries
+- `Ctx :: q a -> TxInstr q e a`
+- `ctx` smart constructor
+- `draftWith :: PParams ConwayEra -> Interpret q -> TxBuild q e a -> Tx ConwayEra`
+- `build` now takes `InterpretIO q`
+- Test query GADT coverage in `TxBuildSpec`
+
+## Next
+
+### Slice 5: Valid + library checkers
+### Slice 6: Reference inputs + validity intervals
+### Slices 7-9: MPFS migrations
+
+## Tests
+18 `TxBuild` examples passing
+
+## Key files
+- `lib/Cardano/Node/Client/TxBuild.hs`
+- `test/Cardano/Node/Client/TxBuildSpec.hs`
+- `specs/003-tx-builder-dsl/spec-design.md`
+- `specs/003-tx-builder-dsl/tasks.md`

--- a/WIP.md
+++ b/WIP.md
@@ -1,7 +1,7 @@
 # WIP: Transaction Builder DSL
 
 ## Status
-Slices 1-6 done, unit tests green. Next: Slices 7-9 (MPFS migrations).
+Slices 1-6 done, unit tests green. Branch scope complete.
 
 ## Links
 - PR: lambdasistemi/cardano-node-clients#38
@@ -51,10 +51,6 @@ Slices 1-6 done, unit tests green. Next: Slices 7-9 (MPFS migrations).
 - `reference`, `validFrom`, `validTo`
 - `assembleTx` now fills `referenceInputsTxBodyL` and `vldtTxBodyL`
 - Retract-shaped assembly coverage in `TxBuildSpec`
-
-## Next
-
-### Slices 7-9: MPFS migrations
 
 ## Tests
 24 `TxBuild` examples passing

--- a/WIP.md
+++ b/WIP.md
@@ -1,7 +1,7 @@
 # WIP: Transaction Builder DSL
 
 ## Status
-Slices 1-5 done, unit tests green. Next: Slice 6 (Reference + Validity).
+Slices 1-6 done, unit tests green. Next: Slices 7-9 (MPFS migrations).
 
 ## Links
 - PR: lambdasistemi/cardano-node-clients#38
@@ -44,13 +44,20 @@ Slices 1-5 done, unit tests green. Next: Slice 6 (Reference + Validity).
 - `build` now returns `Left (ChecksFailed [...])` after convergence
 - Tests for custom failure, min-UTxO failure, tx-size failure, and all-pass
 
+### Slice 6: Reference inputs + validity intervals
+- `Reference :: TxIn -> TxInstr q e ()`
+- `SetValidFrom :: SlotNo -> TxInstr q e ()`
+- `SetValidTo :: SlotNo -> TxInstr q e ()`
+- `reference`, `validFrom`, `validTo`
+- `assembleTx` now fills `referenceInputsTxBodyL` and `vldtTxBodyL`
+- Retract-shaped assembly coverage in `TxBuildSpec`
+
 ## Next
 
-### Slice 6: Reference inputs + validity intervals
 ### Slices 7-9: MPFS migrations
 
 ## Tests
-23 `TxBuild` examples passing
+24 `TxBuild` examples passing
 
 ## Key files
 - `lib/Cardano/Node/Client/TxBuild.hs`

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -44,7 +44,6 @@ library
     Cardano.Node.Client.Balance
     Cardano.Node.Client.Evaluate
     Cardano.Node.Client.N2C.ChainSync
-    Cardano.Node.Client.TxBuild
     Cardano.Node.Client.N2C.Codecs
     Cardano.Node.Client.N2C.Connection
     Cardano.Node.Client.N2C.LocalStateQuery
@@ -55,6 +54,7 @@ library
     Cardano.Node.Client.Provider
     Cardano.Node.Client.SampleList
     Cardano.Node.Client.Submitter
+    Cardano.Node.Client.TxBuild
     Cardano.Node.Client.Types
     Data.List.SampleFibonacci
 

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -82,6 +82,8 @@ library
     , ouroboros-network-api
     , ouroboros-network-framework
     , ouroboros-network-protocols
+    , plutus-core
+    , plutus-tx
     , serialise
     , stm
     , text
@@ -140,6 +142,7 @@ test-suite unit-tests
     , cardano-ledger-api
     , cardano-ledger-conway
     , cardano-ledger-core
+    , cardano-ledger-mary
     , cardano-node-clients
     , containers
     , hspec

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -61,6 +61,7 @@ library
   build-depends:
     , base
     , bytestring
+    , cardano-binary
     , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-byron

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -44,6 +44,7 @@ library
     Cardano.Node.Client.Balance
     Cardano.Node.Client.Evaluate
     Cardano.Node.Client.N2C.ChainSync
+    Cardano.Node.Client.TxBuild
     Cardano.Node.Client.N2C.Codecs
     Cardano.Node.Client.N2C.Connection
     Cardano.Node.Client.N2C.LocalStateQuery
@@ -65,6 +66,7 @@ library
     , cardano-ledger-byron
     , cardano-ledger-conway
     , cardano-ledger-core
+    , cardano-ledger-mary
     , cardano-slotting
     , cardano-strict-containers
     , chain-follower
@@ -72,6 +74,7 @@ library
     , contra-tracer
     , microlens
     , network-mux
+    , operational
     , ouroboros-consensus
     , ouroboros-consensus-cardano
     , ouroboros-consensus-protocol
@@ -126,10 +129,12 @@ test-suite unit-tests
   default-language: GHC2021
   other-modules:
     Cardano.Node.Client.BalanceSpec
+    Cardano.Node.Client.TxBuildSpec
     Data.List.SampleFibonacciSpec
 
   build-depends:
     , base
+    , bytestring
     , cardano-crypto-class
     , cardano-ledger-alonzo
     , cardano-ledger-api
@@ -138,6 +143,7 @@ test-suite unit-tests
     , cardano-node-clients
     , containers
     , hspec
+    , microlens
     , plutus-core
     , QuickCheck
 

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -62,6 +62,7 @@ library
     , base
     , bytestring
     , cardano-binary
+    , cardano-ledger-allegra
     , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-byron
@@ -139,12 +140,14 @@ test-suite unit-tests
     , base
     , bytestring
     , cardano-crypto-class
+    , cardano-ledger-allegra
     , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-mary
     , cardano-node-clients
+    , cardano-slotting
     , containers
     , hspec
     , microlens

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,3 @@ Current implemented pieces:
   `TxBody`
 - `draft` and `draftWith` for pure assembly
 - `build` for script evaluation, `ExUnits` patching, and balancing
-
-Not implemented yet in this branch:
-
-- the MPFS builder migrations

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,11 +70,11 @@ Current implemented pieces:
 - `Peek` for fixpoint values derived from the assembled transaction
 - `Ctx` for pluggable domain queries resolved by `Interpret` or
   `InterpretIO`
+- `Valid` for opt-in post-convergence transaction checks
 - `draft` and `draftWith` for pure assembly
 - `build` for script evaluation, `ExUnits` patching, and balancing
 
 Not implemented yet in this branch:
 
-- `Valid` checks and library-provided checkers
 - reference inputs
 - validity interval instructions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,6 +11,7 @@ Cardano.Node.Client
 ├── Provider       -- query interface (record-of-functions)
 ├── Submitter      -- submit interface (record-of-functions)
 ├── Balance        -- transaction balancing
+├── TxBuild        -- transaction builder DSL
 └── N2C
     ├── Types              -- LSQChannel, LTxSChannel
     ├── Codecs             -- N2C codec config
@@ -55,3 +56,25 @@ with `async`.
 adding fee-paying inputs and a change output. It converges in at
 most 10 rounds. Only ADA-only inputs are supported; multi-asset
 coin selection is out of scope.
+
+## Transaction builder DSL
+
+`Cardano.Node.Client.TxBuild` sits one layer above raw transaction
+assembly. It lets callers describe a transaction as a monadic program
+instead of manually building lens-heavy `TxBody` values.
+
+Current implemented pieces:
+
+- fixed transaction instructions for spends, outputs, collateral,
+  minting, required signers, and attached scripts
+- `Peek` for fixpoint values derived from the assembled transaction
+- `Ctx` for pluggable domain queries resolved by `Interpret` or
+  `InterpretIO`
+- `draft` and `draftWith` for pure assembly
+- `build` for script evaluation, `ExUnits` patching, and balancing
+
+Not implemented yet in this branch:
+
+- `Valid` checks and library-provided checkers
+- reference inputs
+- validity interval instructions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,10 +71,11 @@ Current implemented pieces:
 - `Ctx` for pluggable domain queries resolved by `Interpret` or
   `InterpretIO`
 - `Valid` for opt-in post-convergence transaction checks
+- reference inputs and explicit validity intervals in the assembled
+  `TxBody`
 - `draft` and `draftWith` for pure assembly
 - `build` for script evaluation, `ExUnits` patching, and balancing
 
 Not implemented yet in this branch:
 
-- reference inputs
-- validity interval instructions
+- the MPFS builder migrations

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ protocol supplies its own constructor:
 ## Current TxBuild status
 
 The transaction builder DSL is under active development and currently
-implements Slices 1-5:
+implements Slices 1-6:
 
 - spending, outputs, collateral, and minting combinators
 - `Peek`-driven fixpoint values for indices and fee-dependent assembly
@@ -31,9 +31,9 @@ implements Slices 1-5:
 - effectful building with `build` and `InterpretIO`
 - pluggable context queries through `Ctx`
 - opt-in final-transaction validation via `Valid`
+- reference inputs and explicit validity intervals
 
-The next planned slices are reference inputs and validity interval
-support.
+The next planned slices are the MPFS migrations.
 
 ## Quick start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ protocol supplies its own constructor:
 ## Current TxBuild status
 
 The transaction builder DSL is under active development and currently
-implements Slices 1-6:
+implements the first complete branch scope:
 
 - spending, outputs, collateral, and minting combinators
 - `Peek`-driven fixpoint values for indices and fee-dependent assembly
@@ -32,8 +32,6 @@ implements Slices 1-6:
 - pluggable context queries through `Ctx`
 - opt-in final-transaction validation via `Valid`
 - reference inputs and explicit validity intervals
-
-The next planned slices are the MPFS migrations.
 
 ## Quick start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ Cardano node:
 - **Provider** -- query UTxOs and protocol parameters
 - **Submitter** -- submit signed transactions
 - **Balance** -- iterative fee estimation and transaction balancing
+- **TxBuild** -- Conway-era transaction builder DSL with `Peek` fixpoints and pluggable `Ctx` queries
 
 The interfaces are protocol-agnostic records-of-functions. Each transport
 protocol supplies its own constructor:
@@ -18,6 +19,20 @@ protocol supplies its own constructor:
 |----------|----------|-----------|
 | N2C (Unix socket) | `mkN2CProvider` | `mkN2CSubmitter` |
 | N2N (TCP) | planned | planned |
+
+## Current TxBuild status
+
+The transaction builder DSL is under active development and currently
+implements Slices 1-4:
+
+- spending, outputs, collateral, and minting combinators
+- `Peek`-driven fixpoint values for indices and fee-dependent assembly
+- pure drafting with `draft` and `draftWith`
+- effectful building with `build` and `InterpretIO`
+- pluggable context queries through `Ctx`
+
+The next planned slices are `Valid` checks, reference inputs, and
+validity interval support.
 
 ## Quick start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,16 +23,17 @@ protocol supplies its own constructor:
 ## Current TxBuild status
 
 The transaction builder DSL is under active development and currently
-implements Slices 1-4:
+implements Slices 1-5:
 
 - spending, outputs, collateral, and minting combinators
 - `Peek`-driven fixpoint values for indices and fee-dependent assembly
 - pure drafting with `draft` and `draftWith`
 - effectful building with `build` and `InterpretIO`
 - pluggable context queries through `Ctx`
+- opt-in final-transaction validation via `Valid`
 
-The next planned slices are `Valid` checks, reference inputs, and
-validity interval support.
+The next planned slices are reference inputs and validity interval
+support.
 
 ## Quick start
 

--- a/docs/modules/txbuild.md
+++ b/docs/modules/txbuild.md
@@ -1,0 +1,128 @@
+# TxBuild
+
+::: {.module}
+`Cardano.Node.Client.TxBuild`
+:::
+
+Operational transaction builder DSL for Conway-era transactions.
+
+## What exists today
+
+The current implementation covers the first four slices of the DSL:
+
+- spend, script spend, collateral, output, mint, signer, and script
+  attachment instructions
+- `Peek` for fixpoint-dependent values such as spend indices, output
+  indices, and fee-driven outputs
+- `Ctx` for pluggable domain queries
+- pure interpreters with `draft` and `draftWith`
+- effectful building with `build`, including script evaluation,
+  `ExUnits` patching, and balancing
+
+The next planned slices add `Valid`, reference inputs, and validity
+interval support. Those APIs are described in the spec, but they are
+not implemented in the module yet.
+
+## Core types
+
+```haskell
+type TxBuild q e = Program (TxInstr q e)
+
+data Convergence a
+    = Iterate a
+    | Ok a
+
+newtype Interpret q = Interpret
+    { runInterpret :: forall x. q x -> x
+    }
+
+newtype InterpretIO q = InterpretIO
+    { runInterpretIO :: forall x. q x -> IO x
+    }
+```
+
+`q` is the query GADT used by `Ctx`. `e` is reserved for custom
+validation errors in later slices.
+
+## Main entry points
+
+```haskell
+draft
+    :: PParams ConwayEra
+    -> TxBuild q e a
+    -> Tx ConwayEra
+
+draftWith
+    :: PParams ConwayEra
+    -> Interpret q
+    -> TxBuild q e a
+    -> Tx ConwayEra
+
+build
+    :: PParams ConwayEra
+    -> InterpretIO q
+    -> (Tx ConwayEra -> IO (Map (ConwayPlutusPurpose AsIx ConwayEra) (Either String ExUnits)))
+    -> [(TxIn, TxOut ConwayEra)]
+    -> Addr
+    -> TxBuild q e a
+    -> IO (Either (BuildError e) (Tx ConwayEra))
+```
+
+Use `draft` when the program has no `Ctx`. Use `draftWith` when it
+does. Use `build` when the transaction needs full script evaluation and
+balancing.
+
+## Smart constructors
+
+```haskell
+spend            :: TxIn -> TxBuild q e Word32
+spendScript      :: ToData r => TxIn -> r -> TxBuild q e Word32
+collateral       :: TxIn -> TxBuild q e ()
+payTo            :: Addr -> MaryValue -> TxBuild q e Word32
+payTo'           :: ToData d => Addr -> MaryValue -> d -> TxBuild q e Word32
+output           :: TxOut ConwayEra -> TxBuild q e Word32
+mint             :: ToData r => PolicyID -> Map AssetName Integer -> r -> TxBuild q e ()
+requireSignature :: KeyHash 'Witness -> TxBuild q e ()
+attachScript     :: Script ConwayEra -> TxBuild q e ()
+peek             :: (Tx ConwayEra -> Convergence a) -> TxBuild q e a
+ctx              :: q a -> TxBuild q e a
+```
+
+Position-dependent combinators such as `spend` and `payTo` use `Peek`
+internally so the caller gets the final index after assembly.
+
+## Example
+
+```haskell
+{-# LANGUAGE GADTs #-}
+
+data TestQ a where
+    GetLovelace :: TestQ Integer
+
+example :: TxBuild TestQ e ()
+example = do
+    amount <- ctx GetLovelace
+    _ <- payTo someAddr (inject (Coin amount))
+    pure ()
+
+tx :: Tx ConwayEra
+tx =
+    draftWith emptyPParams
+        (Interpret (\GetLovelace -> 7_000_000))
+        example
+```
+
+The same `TestQ` program can run through `build` by supplying an
+`InterpretIO TestQ`.
+
+## Testing status
+
+`TxBuildSpec` currently covers:
+
+- spend and pay-to assembly
+- collateral handling
+- spend index ordering
+- script-spend redeemers
+- mint and burn redeemers
+- `Peek` through `build`
+- `Ctx` through both `draftWith` and `build`

--- a/docs/modules/txbuild.md
+++ b/docs/modules/txbuild.md
@@ -8,20 +8,21 @@ Operational transaction builder DSL for Conway-era transactions.
 
 ## What exists today
 
-The current implementation covers the first four slices of the DSL:
+The current implementation covers the first five slices of the DSL:
 
 - spend, script spend, collateral, output, mint, signer, and script
   attachment instructions
 - `Peek` for fixpoint-dependent values such as spend indices, output
   indices, and fee-driven outputs
 - `Ctx` for pluggable domain queries
+- `Valid` for post-convergence transaction checks
 - pure interpreters with `draft` and `draftWith`
 - effectful building with `build`, including script evaluation,
   `ExUnits` patching, and balancing
 
-The next planned slices add `Valid`, reference inputs, and validity
-interval support. Those APIs are described in the spec, but they are
-not implemented in the module yet.
+The next planned slices add reference inputs and validity interval
+support. Those APIs are described in the spec, but they are not
+implemented in the module yet.
 
 ## Core types
 
@@ -42,7 +43,7 @@ newtype InterpretIO q = InterpretIO
 ```
 
 `q` is the query GADT used by `Ctx`. `e` is reserved for custom
-validation errors in later slices.
+validation errors carried by `Valid`.
 
 ## Main entry points
 
@@ -86,6 +87,9 @@ requireSignature :: KeyHash 'Witness -> TxBuild q e ()
 attachScript     :: Script ConwayEra -> TxBuild q e ()
 peek             :: (Tx ConwayEra -> Convergence a) -> TxBuild q e a
 ctx              :: q a -> TxBuild q e a
+valid            :: (Tx ConwayEra -> Check e) -> TxBuild q e ()
+checkMinUtxo     :: PParams ConwayEra -> Word32 -> TxBuild q e ()
+checkTxSize      :: PParams ConwayEra -> TxBuild q e ()
 ```
 
 Position-dependent combinators such as `spend` and `payTo` use `Peek`
@@ -126,3 +130,7 @@ The same `TestQ` program can run through `build` by supplying an
 - mint and burn redeemers
 - `Peek` through `build`
 - `Ctx` through both `draftWith` and `build`
+- `Valid` custom failures
+- `checkMinUtxo` failures
+- `checkTxSize` failures
+- all-pass validation

--- a/docs/modules/txbuild.md
+++ b/docs/modules/txbuild.md
@@ -21,9 +21,6 @@ The current implementation covers the first six slices of the DSL:
 - effectful building with `build`, including script evaluation,
   `ExUnits` patching, and balancing
 
-The next planned slices are the MPFS migrations that move the existing
-offchain builders onto this DSL.
-
 ## Core types
 
 ```haskell
@@ -100,6 +97,30 @@ internally so the caller gets the final index after assembly.
 
 ## Example
 
+### Pure draft
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+
+import Cardano.Ledger.BaseTypes (Inject (inject))
+import Cardano.Ledger.Coin (Coin (..))
+
+simpleTransfer :: TxBuild q e ()
+simpleTransfer = do
+    _ <- spend walletInput
+    collateral collateralInput
+    _ <- payTo recipientAddr (inject (Coin 7_000_000))
+    pure ()
+
+tx :: Tx ConwayEra
+tx = draft emptyPParams simpleTransfer
+```
+
+This is the smallest useful shape: spend a wallet input, add
+collateral, and assemble a pure draft transaction.
+
+### Context-aware draft
+
 ```haskell
 {-# LANGUAGE GADTs #-}
 
@@ -119,8 +140,65 @@ tx =
         example
 ```
 
-The same `TestQ` program can run through `build` by supplying an
-`InterpretIO TestQ`.
+Use `draftWith` when the builder depends on domain queries but still
+needs a pure interpreter for testing.
+
+### Build with `Peek` and `Valid`
+
+```haskell
+{-# LANGUAGE GADTs #-}
+
+data WalletQ a where
+    GetProtocolParams :: WalletQ (PParams ConwayEra)
+
+checkedTx :: TxBuild WalletQ String ()
+checkedTx = do
+    pp <- ctx GetProtocolParams
+    outIx <- payTo recipientAddr (inject (Coin 2_000_000))
+    checkMinUtxo pp outIx
+    checkTxSize pp
+    fee <- peek $ \tx ->
+        Ok (tx ^. bodyTxL . feeTxBodyL)
+    valid $ \_tx ->
+        if fee >= Coin 0
+            then Pass
+            else CustomFail "negative fee"
+```
+
+`Peek` is for values that only exist after assembly or balancing, such
+as spending indices, output indices, and the final fee. `Valid` runs
+after convergence, so checks see the final balanced transaction.
+
+### Effectful build
+
+```haskell
+txOrErr <-
+    build
+        pp
+        (InterpretIO runWalletQuery)
+        evaluateTx
+        inputUtxos
+        changeAddr
+        checkedTx
+```
+
+The same program can move from pure tests to production by swapping the
+interpreter and calling `build` instead of `draftWith`.
+
+### Reference input and validity window
+
+```haskell
+windowedTx :: TxBuild q e ()
+windowedTx = do
+    reference oracleRef
+    validFrom lowerBound
+    validTo upperBound
+    requireSignature ownerWkh
+    pure ()
+```
+
+This covers the common "read but do not spend" pattern for reference
+inputs together with explicit validity bounds and signer requirements.
 
 ## Testing status
 

--- a/docs/modules/txbuild.md
+++ b/docs/modules/txbuild.md
@@ -8,7 +8,7 @@ Operational transaction builder DSL for Conway-era transactions.
 
 ## What exists today
 
-The current implementation covers the first five slices of the DSL:
+The current implementation covers the first six slices of the DSL:
 
 - spend, script spend, collateral, output, mint, signer, and script
   attachment instructions
@@ -16,13 +16,13 @@ The current implementation covers the first five slices of the DSL:
   indices, and fee-driven outputs
 - `Ctx` for pluggable domain queries
 - `Valid` for post-convergence transaction checks
+- reference inputs and validity interval instructions
 - pure interpreters with `draft` and `draftWith`
 - effectful building with `build`, including script evaluation,
   `ExUnits` patching, and balancing
 
-The next planned slices add reference inputs and validity interval
-support. Those APIs are described in the spec, but they are not
-implemented in the module yet.
+The next planned slices are the MPFS migrations that move the existing
+offchain builders onto this DSL.
 
 ## Core types
 
@@ -85,6 +85,9 @@ output           :: TxOut ConwayEra -> TxBuild q e Word32
 mint             :: ToData r => PolicyID -> Map AssetName Integer -> r -> TxBuild q e ()
 requireSignature :: KeyHash 'Witness -> TxBuild q e ()
 attachScript     :: Script ConwayEra -> TxBuild q e ()
+reference        :: TxIn -> TxBuild q e ()
+validFrom        :: SlotNo -> TxBuild q e ()
+validTo          :: SlotNo -> TxBuild q e ()
 peek             :: (Tx ConwayEra -> Convergence a) -> TxBuild q e a
 ctx              :: q a -> TxBuild q e a
 valid            :: (Tx ConwayEra -> Check e) -> TxBuild q e ()
@@ -134,3 +137,4 @@ The same `TestQ` program can run through `build` by supplying an
 - `checkMinUtxo` failures
 - `checkTxSize` failures
 - all-pass validation
+- reference-input and validity-interval assembly

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -38,6 +38,7 @@ module Cardano.Node.Client.TxBuild (
     -- * Input combinators
     spend,
     spendScript,
+    reference,
     collateral,
 
     -- * Output combinators
@@ -49,6 +50,8 @@ module Cardano.Node.Client.TxBuild (
     mint,
 
     -- * Constraints
+    validFrom,
+    validTo,
     requireSignature,
     attachScript,
 
@@ -96,6 +99,7 @@ import Data.Word (Word32)
 import Numeric.Natural (Natural)
 
 import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
 import Cardano.Ledger.Alonzo.PParams (getLanguageView)
 import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
 import Cardano.Ledger.Alonzo.Tx (hashScriptIntegrity)
@@ -124,7 +128,9 @@ import Cardano.Ledger.Api.Tx.Body (
     mintTxBodyL,
     mkBasicTxBody,
     outputsTxBodyL,
+    referenceInputsTxBodyL,
     reqSignerHashesTxBodyL,
+    vldtTxBodyL,
  )
 import Cardano.Ledger.Api.Tx.Out (
     TxOut,
@@ -137,7 +143,9 @@ import Cardano.Ledger.Api.Tx.Wits (
     rdmrsTxWitsL,
     scriptTxWitsL,
  )
-import Cardano.Ledger.BaseTypes (StrictMaybe (SNothing))
+import Cardano.Ledger.BaseTypes (
+    StrictMaybe (SJust, SNothing),
+ )
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Scripts (
@@ -168,6 +176,7 @@ import Cardano.Node.Client.Balance (
     BalanceError,
     balanceTx,
  )
+import Cardano.Slotting.Slot (SlotNo)
 import Lens.Micro ((&), (.~), (^.))
 import PlutusCore.Data qualified as PLC
 import PlutusTx.Builtins.Internal (
@@ -238,6 +247,8 @@ data TxInstr q e a where
     -- | Spend an input with a witness.
     Spend ::
         TxIn -> SpendWitness -> TxInstr q e ()
+    -- | Add a reference input.
+    Reference :: TxIn -> TxInstr q e ()
     -- | Add a collateral input.
     Collateral :: TxIn -> TxInstr q e ()
     -- | Add an output.
@@ -256,6 +267,10 @@ data TxInstr q e a where
     -- | Attach a Plutus script.
     AttachScript ::
         Script ConwayEra -> TxInstr q e ()
+    -- | Set the lower validity bound.
+    SetValidFrom :: SlotNo -> TxInstr q e ()
+    -- | Set the upper validity bound.
+    SetValidTo :: SlotNo -> TxInstr q e ()
     -- | Peek at the final Tx (fixpoint).
     Peek ::
         (Tx ConwayEra -> Convergence a) ->
@@ -299,6 +314,10 @@ spendScript txIn r = do
          in if Set.member txIn ins
                 then Ok (spendingIndex txIn ins)
                 else Iterate 0
+
+-- | Add a reference input.
+reference :: TxIn -> TxBuild q e ()
+reference = singleton . Reference
 
 -- | Add a collateral input.
 collateral :: TxIn -> TxBuild q e ()
@@ -382,6 +401,14 @@ mint pid assets r =
         , q /= 0
         ]
 
+-- | Set the lower validity bound.
+validFrom :: SlotNo -> TxBuild q e ()
+validFrom = singleton . SetValidFrom
+
+-- | Set the upper validity bound.
+validTo :: SlotNo -> TxBuild q e ()
+validTo = singleton . SetValidTo
+
 -- | Require a key signature.
 requireSignature ::
     KeyHash 'Witness -> TxBuild q e ()
@@ -452,6 +479,7 @@ checkTxSize pp =
 -- | Accumulated state from interpreting 'TxBuild'.
 data TxState e = TxState
     { tsSpends :: [(TxIn, SpendWitness)]
+    , tsRefIns :: [TxIn]
     , tsCollIns :: [TxIn]
     , tsOuts :: [TxOut ConwayEra]
     , tsMints ::
@@ -464,6 +492,8 @@ data TxState e = TxState
     , tsSigners :: Set (KeyHash 'Witness)
     , tsScripts ::
         Map ScriptHash (Script ConwayEra)
+    , tsValidFrom :: StrictMaybe SlotNo
+    , tsValidTo :: StrictMaybe SlotNo
     , tsChecks :: [Tx ConwayEra -> Check e]
     }
 
@@ -471,11 +501,14 @@ emptyState :: TxState e
 emptyState =
     TxState
         { tsSpends = []
+        , tsRefIns = []
         , tsCollIns = []
         , tsOuts = []
         , tsMints = []
         , tsSigners = Set.empty
         , tsScripts = Map.empty
+        , tsValidFrom = SNothing
+        , tsValidTo = SNothing
         , tsChecks = []
         }
 
@@ -510,6 +543,14 @@ interpretWithM runCtx currentTx = go emptyState True
                 st
                     { tsSpends =
                         tsSpends st ++ [(txIn, w)]
+                    }
+                conv
+                (k ())
+        Reference txIn :>>= k ->
+            go
+                st
+                    { tsRefIns =
+                        tsRefIns st ++ [txIn]
                     }
                 conv
                 (k ())
@@ -557,6 +598,20 @@ interpretWithM runCtx currentTx = go emptyState True
                     }
                 conv
                 (k ())
+        SetValidFrom slot :>>= k ->
+            go
+                st
+                    { tsValidFrom = SJust slot
+                    }
+                conv
+                (k ())
+        SetValidTo slot :>>= k ->
+            go
+                st
+                    { tsValidTo = SJust slot
+                    }
+                conv
+                (k ())
         Peek f :>>= k ->
             case f currentTx of
                 Ok a -> go st conv (k a)
@@ -580,6 +635,7 @@ assembleTx pp st =
     let
         allSpendIns =
             Set.fromList $ map fst (tsSpends st)
+        refIns = Set.fromList (tsRefIns st)
         collIns = Set.fromList (tsCollIns st)
         outs = StrictSeq.fromList (tsOuts st)
         mintMA = foldl' addMint mempty (tsMints st)
@@ -606,10 +662,16 @@ assembleTx pp st =
             mkBasicTxBody
                 & inputsTxBodyL .~ allSpendIns
                 & outputsTxBodyL .~ outs
+                & referenceInputsTxBodyL .~ refIns
                 & collateralInputsTxBodyL .~ collIns
                 & mintTxBodyL .~ mintMA
                 & reqSignerHashesTxBodyL
                     .~ tsSigners st
+                & vldtTxBodyL
+                    .~ ValidityInterval
+                        { invalidBefore = tsValidFrom st
+                        , invalidHereafter = tsValidTo st
+                        }
                 & scriptIntegrityHashTxBodyL
                     .~ integrity
      in

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -55,6 +55,10 @@ module Cardano.Node.Client.TxBuild (
 
     -- * Assembly
     draft,
+    build,
+
+    -- * Errors
+    BuildError (..),
 
     -- * Internal (for testing)
     interpretWith,
@@ -141,6 +145,10 @@ import Cardano.Ledger.Plutus.Language (
     Language (PlutusV3),
  )
 import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Node.Client.Balance (
+    BalanceError,
+    balanceTx,
+ )
 import Lens.Micro ((&), (.~), (^.))
 import PlutusCore.Data qualified as PLC
 import PlutusTx.Builtins.Internal (
@@ -525,6 +533,141 @@ draft pp prog =
         (st2, _, _) = interpretWith tx1 prog
      in
         assembleTx pp st2
+
+-- | Errors from 'build'.
+data BuildError e
+    = -- | Script evaluation failure.
+      EvalFailure
+        (ConwayPlutusPurpose AsIx ConwayEra)
+        String
+    | -- | Balance failure.
+      BalanceFailed BalanceError
+    deriving (Show)
+
+{- | Assemble, evaluate scripts, and balance.
+
+Iterates until all 'Peek' nodes return 'Ok' and
+the Tx body stabilizes:
+
+1. Interpret program with current Tx (resolve Peek)
+2. Assemble Tx from steps
+3. Add input UTxOs, evaluate scripts → ExUnits
+4. Patch redeemers, recompute integrity hash
+5. Balance (fee + change)
+6. If any Peek returned Iterate or Tx changed → 1
+-}
+build ::
+    PParams ConwayEra ->
+    -- | Script evaluator
+    ( Tx ConwayEra ->
+      IO
+        ( Map
+            ( ConwayPlutusPurpose
+                AsIx
+                ConwayEra
+            )
+            (Either String ExUnits)
+        )
+    ) ->
+    -- | All input UTxOs
+    [(TxIn, TxOut ConwayEra)] ->
+    -- | Change address
+    Addr ->
+    TxBuild q e a ->
+    IO (Either (BuildError e) (Tx ConwayEra))
+build pp evaluateTx inputUtxos changeAddr prog =
+    loop (mkBasicTx mkBasicTxBody)
+  where
+    loop prevTx = do
+        -- 1. Interpret with current Tx
+        let (st, _, converged) =
+                interpretWith prevTx prog
+            tx = assembleTx pp st
+        -- 2. Add all input TxIns for eval
+        let existingIns =
+                tx ^. bodyTxL . inputsTxBodyL
+            allIns =
+                foldl'
+                    ( \s (tin, _) ->
+                        Set.insert tin s
+                    )
+                    existingIns
+                    inputUtxos
+            txForEval =
+                tx
+                    & bodyTxL . inputsTxBodyL
+                        .~ allIns
+        -- 3. Evaluate scripts
+        evalResult <- evaluateTx txForEval
+        let failures =
+                [ (p, e)
+                | (p, Left e) <-
+                    Map.toList evalResult
+                ]
+        case failures of
+            ((p, e) : _) ->
+                pure $ Left $ EvalFailure p e
+            [] -> do
+                -- 4. Patch ExUnits
+                let Redeemers rdmrMap =
+                        tx ^. witsTxL . rdmrsTxWitsL
+                    patched =
+                        Map.mapWithKey
+                            ( \purpose (dat, eu) ->
+                                case Map.lookup
+                                    purpose
+                                    evalResult of
+                                    Just (Right eu') ->
+                                        (dat, eu')
+                                    _ -> (dat, eu)
+                            )
+                            rdmrMap
+                    newRdmrs = Redeemers patched
+                    integrity =
+                        if Map.null patched
+                            then SNothing
+                            else
+                                hashScriptIntegrity
+                                    ( Set.singleton
+                                        ( getLanguageView
+                                            pp
+                                            PlutusV3
+                                        )
+                                    )
+                                    newRdmrs
+                                    (TxDats mempty)
+                    patchedTx =
+                        tx
+                            & witsTxL . rdmrsTxWitsL
+                                .~ newRdmrs
+                            & bodyTxL
+                                . scriptIntegrityHashTxBodyL
+                                .~ integrity
+                -- 5. Balance
+                case balanceTx
+                    pp
+                    inputUtxos
+                    changeAddr
+                    patchedTx of
+                    Left err ->
+                        pure $
+                            Left $
+                                BalanceFailed err
+                    Right balanced
+                        -- 6. Converged?
+                        | converged
+                            && txBodyEq
+                                balanced
+                                prevTx ->
+                            pure $ Right balanced
+                        | otherwise ->
+                            loop balanced
+
+-- | Compare Tx bodies for convergence.
+txBodyEq ::
+    Tx ConwayEra -> Tx ConwayEra -> Bool
+txBodyEq a b =
+    (a ^. bodyTxL) == (b ^. bodyTxL)
 
 -- ----------------------------------------------------
 -- Internal helpers

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -52,9 +52,11 @@ module Cardano.Node.Client.TxBuild (
 
     -- * Deferred
     peek,
+    ctx,
 
     -- * Assembly
     draft,
+    draftWith,
     build,
 
     -- * Errors
@@ -72,6 +74,9 @@ import Control.Monad.Operational (
     view,
  )
 import Data.Foldable (foldl')
+import Data.Functor.Identity (
+    runIdentity,
+ )
 import Data.List (elemIndex)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -223,6 +228,8 @@ data TxInstr q e a where
     Peek ::
         (Tx ConwayEra -> Convergence a) ->
         TxInstr q e a
+    -- | Query external context.
+    Ctx :: q a -> TxInstr q e a
 
 -- | Monadic transaction builder.
 type TxBuild q e = Program (TxInstr q e)
@@ -354,6 +361,10 @@ peek ::
     TxBuild q e a
 peek = singleton . Peek
 
+-- | Query pluggable build context.
+ctx :: q a -> TxBuild q e a
+ctx = singleton . Ctx
+
 -- ----------------------------------------------------
 -- Interpreter state
 -- ----------------------------------------------------
@@ -390,19 +401,28 @@ emptyState =
 The 'Tx' argument resolves 'Peek' nodes.
 -}
 interpretWith ::
+    Interpret q ->
     Tx ConwayEra ->
     TxBuild q e a ->
     -- | (state, result, all converged?)
     (TxState, a, Bool)
-interpretWith currentTx = go emptyState True
+interpretWith interpret currentTx prog =
+    runIdentity $
+        interpretWithM
+            (pure . runInterpret interpret)
+            currentTx
+            prog
+
+interpretWithM ::
+    (Monad m) =>
+    (forall x. q x -> m x) ->
+    Tx ConwayEra ->
+    TxBuild q e a ->
+    m (TxState, a, Bool)
+interpretWithM runCtx currentTx = go emptyState True
   where
-    go ::
-        TxState ->
-        Bool ->
-        TxBuild q' e' b ->
-        (TxState, b, Bool)
     go st conv prog = case view prog of
-        Return a -> (st, a, conv)
+        Return a -> pure (st, a, conv)
         Spend txIn w :>>= k ->
             go
                 st
@@ -460,6 +480,9 @@ interpretWith currentTx = go emptyState True
                 Ok a -> go st conv (k a)
                 Iterate a ->
                     go st False (k a)
+        Ctx q :>>= k -> do
+            a <- runCtx q
+            go st conv (k a)
 
 -- | Assemble a 'Tx' from interpreter state.
 assembleTx :: PParams ConwayEra -> TxState -> Tx ConwayEra
@@ -521,16 +544,32 @@ draft ::
     PParams ConwayEra ->
     TxBuild q e a ->
     Tx ConwayEra
-draft pp prog =
+draft pp = draftWith pp noCtxInterpret
+
+noCtxInterpret :: Interpret q
+noCtxInterpret =
+    Interpret $
+        const $
+            error
+                "draft: encountered ctx without draftWith interpreter"
+
+draftWith ::
+    PParams ConwayEra ->
+    Interpret q ->
+    TxBuild q e a ->
+    Tx ConwayEra
+draftWith pp interpret prog =
     let
         -- Pass 1: collect steps with bogus Tx
         initialTx = mkBasicTx mkBasicTxBody
-        (st1, _, _) = interpretWith initialTx prog
+        (st1, _, _) =
+            interpretWith interpret initialTx prog
         -- Assemble from pass 1
         tx1 = assembleTx pp st1
         -- Pass 2: re-interpret with real Tx for
         -- Peek resolution
-        (st2, _, _) = interpretWith tx1 prog
+        (st2, _, _) =
+            interpretWith interpret tx1 prog
      in
         assembleTx pp st2
 
@@ -558,6 +597,7 @@ the Tx body stabilizes:
 -}
 build ::
     PParams ConwayEra ->
+    InterpretIO q ->
     -- | Script evaluator
     ( Tx ConwayEra ->
       IO
@@ -575,13 +615,17 @@ build ::
     Addr ->
     TxBuild q e a ->
     IO (Either (BuildError e) (Tx ConwayEra))
-build pp evaluateTx inputUtxos changeAddr prog =
+build pp interpret evaluateTx inputUtxos changeAddr prog =
     loop (mkBasicTx mkBasicTxBody)
   where
     loop prevTx = do
         -- 1. Interpret with current Tx
-        let (st, _, converged) =
-                interpretWith prevTx prog
+        (st, _, converged) <-
+            interpretWithM
+                (runInterpretIO interpret)
+                prevTx
+                prog
+        let
             tx = assembleTx pp st
         -- 2. Add all input TxIns for eval
         let existingIns =

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -31,14 +31,24 @@ module Cardano.Node.Client.TxBuild (
 
     -- * Witnesses
     SpendWitness (..),
+    MintWitness (..),
 
     -- * Input combinators
     spend,
+    spendScript,
     collateral,
 
     -- * Output combinators
     payTo,
+    payTo',
     output,
+
+    -- * Minting
+    mint,
+
+    -- * Constraints
+    requireSignature,
+    attachScript,
 
     -- * Deferred
     peek,
@@ -57,33 +67,86 @@ import Control.Monad.Operational (
     singleton,
     view,
  )
+import Data.Foldable (foldl')
 import Data.List (elemIndex)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
 import Data.Sequence.Strict qualified as StrictSeq
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Word (Word32)
 
 import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Alonzo.PParams (getLanguageView)
+import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
+import Cardano.Ledger.Alonzo.Tx (hashScriptIntegrity)
+import Cardano.Ledger.Alonzo.TxBody (
+    scriptIntegrityHashTxBodyL,
+ )
+import Cardano.Ledger.Alonzo.TxWits (
+    Redeemers (..),
+    TxDats (..),
+ )
+import Cardano.Ledger.Api.Scripts.Data (
+    Data (..),
+    Datum (..),
+    dataToBinaryData,
+ )
 import Cardano.Ledger.Api.Tx (
     Tx,
     bodyTxL,
     mkBasicTx,
+    witsTxL,
  )
 import Cardano.Ledger.Api.Tx.Body (
     collateralInputsTxBodyL,
     inputsTxBodyL,
+    mintTxBodyL,
     mkBasicTxBody,
     outputsTxBodyL,
+    reqSignerHashesTxBodyL,
  )
 import Cardano.Ledger.Api.Tx.Out (
     TxOut,
+    datumTxOutL,
     mkBasicTxOut,
  )
+import Cardano.Ledger.Api.Tx.Wits (
+    rdmrsTxWitsL,
+    scriptTxWitsL,
+ )
+import Cardano.Ledger.BaseTypes (StrictMaybe (SNothing))
 import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Core (PParams)
-import Cardano.Ledger.Mary.Value (MaryValue)
+import Cardano.Ledger.Conway.Scripts (
+    ConwayPlutusPurpose (..),
+ )
+import Cardano.Ledger.Core (
+    PParams,
+    Script,
+    hashScript,
+ )
+import Cardano.Ledger.Hashes (ScriptHash)
+import Cardano.Ledger.Keys (
+    KeyHash,
+    KeyRole (..),
+ )
+import Cardano.Ledger.Mary.Value (
+    AssetName,
+    MaryValue,
+    MultiAsset (..),
+    PolicyID,
+ )
+import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
+import Cardano.Ledger.Plutus.Language (
+    Language (PlutusV3),
+ )
 import Cardano.Ledger.TxIn (TxIn)
 import Lens.Micro ((&), (.~), (^.))
+import PlutusCore.Data qualified as PLC
+import PlutusTx.Builtins.Internal (
+    BuiltinData (..),
+ )
+import PlutusTx.IsData.Class (ToData (..))
 
 -- ----------------------------------------------------
 -- Core types
@@ -103,6 +166,13 @@ data Convergence a
 data SpendWitness
     = -- | Pub-key input, no redeemer needed.
       PubKeyWitness
+    | -- | Script input with a typed redeemer.
+      forall r. (ToData r) => ScriptWitness r
+
+-- | How a minting operation is witnessed.
+data MintWitness
+    = -- | Plutus script with a typed redeemer.
+      forall r. (ToData r) => PlutusScriptWitness r
 
 -- | Pure query interpreter.
 newtype Interpret q = Interpret
@@ -128,6 +198,19 @@ data TxInstr q e a where
     -- | Add an output.
     Send ::
         TxOut ConwayEra -> TxInstr q e ()
+    -- | Mint or burn tokens.
+    MintI ::
+        PolicyID ->
+        AssetName ->
+        Integer ->
+        MintWitness ->
+        TxInstr q e ()
+    -- | Require a key signature.
+    ReqSignature ::
+        KeyHash 'Witness -> TxInstr q e ()
+    -- | Attach a Plutus script.
+    AttachScript ::
+        Script ConwayEra -> TxInstr q e ()
     -- | Peek at the final Tx (fixpoint).
     Peek ::
         (Tx ConwayEra -> Convergence a) ->
@@ -147,6 +230,19 @@ via 'Peek').
 spend :: TxIn -> TxBuild q e Word32
 spend txIn = do
     singleton $ Spend txIn PubKeyWitness
+    singleton $ Peek $ \tx ->
+        let ins = tx ^. bodyTxL . inputsTxBodyL
+         in if Set.member txIn ins
+                then Ok (spendingIndex txIn ins)
+                else Iterate 0
+
+{- | Spend a script UTxO with a typed redeemer.
+Returns the spending index.
+-}
+spendScript ::
+    (ToData r) => TxIn -> r -> TxBuild q e Word32
+spendScript txIn r = do
+    singleton $ Spend txIn (ScriptWitness r)
     singleton $ Peek $ \tx ->
         let ins = tx ^. bodyTxL . inputsTxBodyL
          in if Set.member txIn ins
@@ -187,6 +283,63 @@ output txOut = do
   where
     toList = foldr (:) []
 
+{- | Pay value with a typed inline datum.
+Returns the output index.
+-}
+payTo' ::
+    (ToData d) =>
+    Addr ->
+    MaryValue ->
+    d ->
+    TxBuild q e Word32
+payTo' addr val datum = do
+    singleton $
+        Send $
+            mkBasicTxOut addr val
+                & datumTxOutL
+                    .~ mkInlineDatum (toPlcData datum)
+    singleton $ Peek $ \tx ->
+        let outs = tx ^. bodyTxL . outputsTxBodyL
+            target =
+                mkBasicTxOut addr val
+                    & datumTxOutL
+                        .~ mkInlineDatum
+                            (toPlcData datum)
+         in case elemIndex target (toList outs) of
+                Just i -> Ok (fromIntegral i)
+                Nothing -> Iterate 0
+  where
+    toList = foldr (:) []
+
+{- | Mint or burn tokens. Positive = mint,
+negative = burn. Zero-amount entries are skipped.
+-}
+mint ::
+    (ToData r) =>
+    PolicyID ->
+    Map AssetName Integer ->
+    r ->
+    TxBuild q e ()
+mint pid assets r =
+    mapM_
+        ( \(name, qty) ->
+            singleton $
+                MintI pid name qty (PlutusScriptWitness r)
+        )
+        [ (n, q)
+        | (n, q) <- Map.toList assets
+        , q /= 0
+        ]
+
+-- | Require a key signature.
+requireSignature ::
+    KeyHash 'Witness -> TxBuild q e ()
+requireSignature = singleton . ReqSignature
+
+-- | Attach a Plutus script to the transaction.
+attachScript :: Script ConwayEra -> TxBuild q e ()
+attachScript = singleton . AttachScript
+
 -- | Peek at the final assembled Tx.
 peek ::
     (Tx ConwayEra -> Convergence a) ->
@@ -202,6 +355,16 @@ data TxState = TxState
     { tsSpends :: [(TxIn, SpendWitness)]
     , tsCollIns :: [TxIn]
     , tsOuts :: [TxOut ConwayEra]
+    , tsMints ::
+        [ ( PolicyID
+          , AssetName
+          , Integer
+          , MintWitness
+          )
+        ]
+    , tsSigners :: Set (KeyHash 'Witness)
+    , tsScripts ::
+        Map ScriptHash (Script ConwayEra)
     }
 
 emptyState :: TxState
@@ -210,6 +373,9 @@ emptyState =
         { tsSpends = []
         , tsCollIns = []
         , tsOuts = []
+        , tsMints = []
+        , tsSigners = Set.empty
+        , tsScripts = Map.empty
         }
 
 {- | Interpret a 'TxBuild' program into 'TxState'.
@@ -253,6 +419,34 @@ interpretWith currentTx = go emptyState True
                     }
                 conv
                 (k ())
+        MintI pid name qty w :>>= k ->
+            go
+                st
+                    { tsMints =
+                        tsMints st
+                            ++ [(pid, name, qty, w)]
+                    }
+                conv
+                (k ())
+        ReqSignature kh :>>= k ->
+            go
+                st
+                    { tsSigners =
+                        Set.insert kh (tsSigners st)
+                    }
+                conv
+                (k ())
+        AttachScript script :>>= k ->
+            go
+                st
+                    { tsScripts =
+                        Map.insert
+                            (hashScript script)
+                            script
+                            (tsScripts st)
+                    }
+                conv
+                (k ())
         Peek f :>>= k ->
             case f currentTx of
                 Ok a -> go st conv (k a)
@@ -260,20 +454,49 @@ interpretWith currentTx = go emptyState True
                     go st False (k a)
 
 -- | Assemble a 'Tx' from interpreter state.
-assembleTx :: TxState -> Tx ConwayEra
-assembleTx st =
+assembleTx :: PParams ConwayEra -> TxState -> Tx ConwayEra
+assembleTx pp st =
     let
         allSpendIns =
             Set.fromList $ map fst (tsSpends st)
         collIns = Set.fromList (tsCollIns st)
         outs = StrictSeq.fromList (tsOuts st)
+        mintMA = foldl' addMint mempty (tsMints st)
+        -- Build redeemers
+        spendRdmrs =
+            collectSpendRedeemers
+                allSpendIns
+                (tsSpends st)
+        mintRdmrs = collectMintRedeemers (tsMints st)
+        rdmrList = spendRdmrs ++ mintRdmrs
+        allRdmrs = Redeemers $ Map.fromList rdmrList
+        -- Integrity hash (skip if no scripts)
+        integrity =
+            if null rdmrList
+                then SNothing
+                else
+                    hashScriptIntegrity
+                        ( Set.singleton
+                            (getLanguageView pp PlutusV3)
+                        )
+                        allRdmrs
+                        (TxDats mempty)
         body =
             mkBasicTxBody
                 & inputsTxBodyL .~ allSpendIns
                 & outputsTxBodyL .~ outs
                 & collateralInputsTxBodyL .~ collIns
+                & mintTxBodyL .~ mintMA
+                & reqSignerHashesTxBodyL
+                    .~ tsSigners st
+                & scriptIntegrityHashTxBodyL
+                    .~ integrity
      in
         mkBasicTx body
+            & witsTxL . scriptTxWitsL
+                .~ tsScripts st
+            & witsTxL . rdmrsTxWitsL
+                .~ allRdmrs
 
 -- ----------------------------------------------------
 -- Assembly
@@ -290,18 +513,18 @@ draft ::
     PParams ConwayEra ->
     TxBuild q e a ->
     Tx ConwayEra
-draft _pp prog =
+draft pp prog =
     let
         -- Pass 1: collect steps with bogus Tx
         initialTx = mkBasicTx mkBasicTxBody
         (st1, _, _) = interpretWith initialTx prog
         -- Assemble from pass 1
-        tx1 = assembleTx st1
+        tx1 = assembleTx pp st1
         -- Pass 2: re-interpret with real Tx for
         -- Peek resolution
         (st2, _, _) = interpretWith tx1 prog
      in
-        assembleTx st2
+        assembleTx pp st2
 
 -- ----------------------------------------------------
 -- Internal helpers
@@ -319,3 +542,82 @@ spendingIndex needle inputs =
     go n (x : xs)
         | x == needle = n
         | otherwise = go (n + 1) xs
+
+-- | Collect spending redeemers from steps.
+collectSpendRedeemers ::
+    Set TxIn ->
+    [(TxIn, SpendWitness)] ->
+    [ ( ConwayPlutusPurpose AsIx ConwayEra
+      , (Data ConwayEra, ExUnits)
+      )
+    ]
+collectSpendRedeemers allIns spends =
+    [ ( ConwaySpending (AsIx ix)
+      , (toLedgerData r, ExUnits 0 0)
+      )
+    | (txIn, ScriptWitness r) <- spends
+    , let ix = spendingIndex txIn allIns
+    ]
+
+-- | Collect minting redeemers. First per policy.
+collectMintRedeemers ::
+    [(PolicyID, AssetName, Integer, MintWitness)] ->
+    [ ( ConwayPlutusPurpose AsIx ConwayEra
+      , (Data ConwayEra, ExUnits)
+      )
+    ]
+collectMintRedeemers mints =
+    let
+        allPolicies =
+            Set.fromList
+                [pid | (pid, _, _, _) <- mints]
+        policyIdx pid =
+            go 0 (Set.toAscList allPolicies)
+          where
+            go _ [] = error "policyIdx: not found"
+            go n (x : xs)
+                | x == pid = n
+                | otherwise = go (n + 1) xs
+        seenData =
+            foldl' addP Map.empty mints
+        addP acc (pid, _, _, PlutusScriptWitness r)
+            | Map.member pid acc = acc
+            | otherwise =
+                Map.insert pid (toLedgerData r) acc
+     in
+        [ ( ConwayMinting (AsIx (policyIdx pid))
+          , (d, ExUnits 0 0)
+          )
+        | (pid, d) <- Map.toList seenData
+        ]
+
+-- | Accumulate 'MultiAsset' from mint entries.
+addMint ::
+    MultiAsset ->
+    (PolicyID, AssetName, Integer, MintWitness) ->
+    MultiAsset
+addMint acc (pid, name, qty, _) =
+    acc
+        <> MultiAsset
+            ( Map.singleton
+                pid
+                (Map.singleton name qty)
+            )
+
+-- | Convert a 'ToData' value to ledger 'Data'.
+toLedgerData :: (ToData a) => a -> Data ConwayEra
+toLedgerData x =
+    let BuiltinData d = toBuiltinData x
+     in Data d
+
+-- | Convert a 'ToData' value to 'PlutusCore.Data'.
+toPlcData :: (ToData a) => a -> PLC.Data
+toPlcData x =
+    let BuiltinData d = toBuiltinData x in d
+
+-- | Wrap 'PlutusCore.Data' as an inline 'Datum'.
+mkInlineDatum :: PLC.Data -> Datum ConwayEra
+mkInlineDatum d =
+    Datum $
+        dataToBinaryData
+            (Data d :: Data ConwayEra)

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -24,6 +24,8 @@ module Cardano.Node.Client.TxBuild (
 
     -- * Convergence
     Convergence (..),
+    Check (..),
+    LedgerCheck (..),
 
     -- * Interpreters
     Interpret (..),
@@ -52,7 +54,12 @@ module Cardano.Node.Client.TxBuild (
 
     -- * Deferred
     peek,
+    valid,
     ctx,
+
+    -- * Checkers
+    checkMinUtxo,
+    checkTxSize,
 
     -- * Assembly
     draft,
@@ -67,12 +74,14 @@ module Cardano.Node.Client.TxBuild (
     assembleTx,
 ) where
 
+import Cardano.Binary (serialize')
 import Control.Monad.Operational (
     Program,
     ProgramViewT (Return, (:>>=)),
     singleton,
     view,
  )
+import Data.ByteString qualified as BS
 import Data.Foldable (foldl')
 import Data.Functor.Identity (
     runIdentity,
@@ -84,6 +93,7 @@ import Data.Sequence.Strict qualified as StrictSeq
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Word (Word32)
+import Numeric.Natural (Natural)
 
 import Cardano.Ledger.Address (Addr)
 import Cardano.Ledger.Alonzo.PParams (getLanguageView)
@@ -96,6 +106,7 @@ import Cardano.Ledger.Alonzo.TxWits (
     Redeemers (..),
     TxDats (..),
  )
+import Cardano.Ledger.Api.PParams (ppMaxTxSizeL)
 import Cardano.Ledger.Api.Scripts.Data (
     Data (..),
     Datum (..),
@@ -117,7 +128,9 @@ import Cardano.Ledger.Api.Tx.Body (
  )
 import Cardano.Ledger.Api.Tx.Out (
     TxOut,
+    coinTxOutL,
     datumTxOutL,
+    getMinCoinTxOut,
     mkBasicTxOut,
  )
 import Cardano.Ledger.Api.Tx.Wits (
@@ -125,6 +138,7 @@ import Cardano.Ledger.Api.Tx.Wits (
     scriptTxWitsL,
  )
 import Cardano.Ledger.BaseTypes (StrictMaybe (SNothing))
+import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Scripts (
     ConwayPlutusPurpose (..),
@@ -174,6 +188,24 @@ data Convergence a
     | -- | Converged; use this value and stop.
       Ok a
     deriving (Show, Eq, Functor)
+
+-- | Validation result for the final transaction.
+data Check e
+    = -- | Validation passed.
+      Pass
+    | -- | One of the library-provided checks failed.
+      LedgerFail LedgerCheck
+    | -- | A user-provided check failed.
+      CustomFail e
+    deriving (Show, Eq)
+
+-- | Closed set of library-provided validation failures.
+data LedgerCheck
+    = MinUtxoViolation Word32 Coin Coin
+    | TxSizeExceeded Natural Natural
+    | ValueNotConserved MaryValue MaryValue
+    | CollateralInsufficient Coin Coin
+    deriving (Show, Eq)
 
 -- | How a spent input is witnessed.
 data SpendWitness
@@ -228,6 +260,10 @@ data TxInstr q e a where
     Peek ::
         (Tx ConwayEra -> Convergence a) ->
         TxInstr q e a
+    -- | Validate the final Tx after convergence.
+    Valid ::
+        (Tx ConwayEra -> Check e) ->
+        TxInstr q e ()
     -- | Query external context.
     Ctx :: q a -> TxInstr q e a
 
@@ -361,16 +397,60 @@ peek ::
     TxBuild q e a
 peek = singleton . Peek
 
+-- | Validate the final converged transaction.
+valid ::
+    (Tx ConwayEra -> Check e) ->
+    TxBuild q e ()
+valid = singleton . Valid
+
 -- | Query pluggable build context.
 ctx :: q a -> TxBuild q e a
 ctx = singleton . Ctx
+
+-- | Check that the indexed output meets the min-UTxO threshold.
+checkMinUtxo ::
+    PParams ConwayEra ->
+    Word32 ->
+    TxBuild q e ()
+checkMinUtxo pp outIx =
+    valid $ \tx ->
+        case txOutAt outIx (tx ^. bodyTxL . outputsTxBodyL) of
+            Nothing -> Pass
+            Just txOut ->
+                let actual = txOut ^. coinTxOutL
+                    required = getMinCoinTxOut pp txOut
+                 in if actual >= required
+                        then Pass
+                        else
+                            LedgerFail $
+                                MinUtxoViolation
+                                    outIx
+                                    actual
+                                    required
+
+-- | Check that the CBOR-encoded transaction fits within max size.
+checkTxSize :: PParams ConwayEra -> TxBuild q e ()
+checkTxSize pp =
+    valid $ \tx ->
+        let actual =
+                fromIntegral $
+                    BS.length $
+                        serialize' tx
+            limit =
+                fromIntegral $
+                    pp ^. ppMaxTxSizeL
+         in if actual <= limit
+                then Pass
+                else
+                    LedgerFail $
+                        TxSizeExceeded actual limit
 
 -- ----------------------------------------------------
 -- Interpreter state
 -- ----------------------------------------------------
 
 -- | Accumulated state from interpreting 'TxBuild'.
-data TxState = TxState
+data TxState e = TxState
     { tsSpends :: [(TxIn, SpendWitness)]
     , tsCollIns :: [TxIn]
     , tsOuts :: [TxOut ConwayEra]
@@ -384,9 +464,10 @@ data TxState = TxState
     , tsSigners :: Set (KeyHash 'Witness)
     , tsScripts ::
         Map ScriptHash (Script ConwayEra)
+    , tsChecks :: [Tx ConwayEra -> Check e]
     }
 
-emptyState :: TxState
+emptyState :: TxState e
 emptyState =
     TxState
         { tsSpends = []
@@ -395,6 +476,7 @@ emptyState =
         , tsMints = []
         , tsSigners = Set.empty
         , tsScripts = Map.empty
+        , tsChecks = []
         }
 
 {- | Interpret a 'TxBuild' program into 'TxState'.
@@ -405,7 +487,7 @@ interpretWith ::
     Tx ConwayEra ->
     TxBuild q e a ->
     -- | (state, result, all converged?)
-    (TxState, a, Bool)
+    (TxState e, a, Bool)
 interpretWith interpret currentTx prog =
     runIdentity $
         interpretWithM
@@ -418,7 +500,7 @@ interpretWithM ::
     (forall x. q x -> m x) ->
     Tx ConwayEra ->
     TxBuild q e a ->
-    m (TxState, a, Bool)
+    m (TxState e, a, Bool)
 interpretWithM runCtx currentTx = go emptyState True
   where
     go st conv prog = case view prog of
@@ -480,12 +562,20 @@ interpretWithM runCtx currentTx = go emptyState True
                 Ok a -> go st conv (k a)
                 Iterate a ->
                     go st False (k a)
+        Valid chk :>>= k ->
+            go
+                st
+                    { tsChecks =
+                        tsChecks st ++ [chk]
+                    }
+                conv
+                (k ())
         Ctx q :>>= k -> do
             a <- runCtx q
             go st conv (k a)
 
 -- | Assemble a 'Tx' from interpreter state.
-assembleTx :: PParams ConwayEra -> TxState -> Tx ConwayEra
+assembleTx :: PParams ConwayEra -> TxState e -> Tx ConwayEra
 assembleTx pp st =
     let
         allSpendIns =
@@ -581,6 +671,8 @@ data BuildError e
         String
     | -- | Balance failure.
       BalanceFailed BalanceError
+    | -- | Validation failures on the final Tx.
+      ChecksFailed [Check e]
     deriving (Show)
 
 {- | Assemble, evaluate scripts, and balance.
@@ -703,7 +795,15 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
                             && txBodyEq
                                 balanced
                                 prevTx ->
-                            pure $ Right balanced
+                            case failedChecks
+                                (tsChecks st)
+                                balanced of
+                                [] ->
+                                    pure $ Right balanced
+                                errs ->
+                                    pure $
+                                        Left $
+                                            ChecksFailed errs
                         | otherwise ->
                             loop balanced
 
@@ -808,3 +908,27 @@ mkInlineDatum d =
     Datum $
         dataToBinaryData
             (Data d :: Data ConwayEra)
+
+failedChecks ::
+    [Tx ConwayEra -> Check e] ->
+    Tx ConwayEra ->
+    [Check e]
+failedChecks checks tx =
+    [ result
+    | check <- checks
+    , let result = check tx
+    , case result of
+        Pass -> False
+        _ -> True
+    ]
+
+txOutAt ::
+    Word32 ->
+    StrictSeq.StrictSeq (TxOut ConwayEra) ->
+    Maybe (TxOut ConwayEra)
+txOutAt ix =
+    go (fromIntegral ix :: Int) . foldr (:) []
+  where
+    go _ [] = Nothing
+    go 0 (txOut : _) = Just txOut
+    go n (_ : rest) = go (n - 1) rest

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -1,0 +1,321 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+
+{- |
+Module      : Cardano.Node.Client.TxBuild
+Description : Operational monad transaction builder DSL
+License     : Apache-2.0
+
+Monadic transaction builder for Conway-era Cardano
+transactions. Instructions are a GADT interpreted
+by 'draft' and 'build'. Three non-building
+instructions: 'Peek' (fixpoint values from the
+assembled Tx), 'Valid' (opt-in validation checks),
+and 'Ctx' (pluggable domain queries).
+
+Parameterized by @q@ (query GADT for domain
+context) and @e@ (custom validation error type).
+-}
+module Cardano.Node.Client.TxBuild (
+    -- * Monad
+    TxBuild,
+    TxInstr (..),
+
+    -- * Convergence
+    Convergence (..),
+
+    -- * Interpreters
+    Interpret (..),
+    InterpretIO (..),
+
+    -- * Witnesses
+    SpendWitness (..),
+
+    -- * Input combinators
+    spend,
+    collateral,
+
+    -- * Output combinators
+    payTo,
+    output,
+
+    -- * Deferred
+    peek,
+
+    -- * Assembly
+    draft,
+
+    -- * Internal (for testing)
+    interpretWith,
+    assembleTx,
+) where
+
+import Control.Monad.Operational (
+    Program,
+    ProgramViewT (Return, (:>>=)),
+    singleton,
+    view,
+ )
+import Data.List (elemIndex)
+import Data.Sequence.Strict qualified as StrictSeq
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Word (Word32)
+
+import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Api.Tx (
+    Tx,
+    bodyTxL,
+    mkBasicTx,
+ )
+import Cardano.Ledger.Api.Tx.Body (
+    collateralInputsTxBodyL,
+    inputsTxBodyL,
+    mkBasicTxBody,
+    outputsTxBodyL,
+ )
+import Cardano.Ledger.Api.Tx.Out (
+    TxOut,
+    mkBasicTxOut,
+ )
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core (PParams)
+import Cardano.Ledger.Mary.Value (MaryValue)
+import Cardano.Ledger.TxIn (TxIn)
+import Lens.Micro ((&), (.~), (^.))
+
+-- ----------------------------------------------------
+-- Core types
+-- ----------------------------------------------------
+
+-- | Fixpoint convergence signal.
+data Convergence a
+    = {- | Not converged yet; use this value and
+      keep iterating.
+      -}
+      Iterate a
+    | -- | Converged; use this value and stop.
+      Ok a
+    deriving (Show, Eq, Functor)
+
+-- | How a spent input is witnessed.
+data SpendWitness
+    = -- | Pub-key input, no redeemer needed.
+      PubKeyWitness
+
+-- | Pure query interpreter.
+newtype Interpret q = Interpret
+    { runInterpret :: forall x. q x -> x
+    }
+
+-- | Effectful query interpreter.
+newtype InterpretIO q = InterpretIO
+    { runInterpretIO :: forall x. q x -> IO x
+    }
+
+-- ----------------------------------------------------
+-- Instruction GADT
+-- ----------------------------------------------------
+
+-- | Transaction building instructions.
+data TxInstr q e a where
+    -- | Spend an input with a witness.
+    Spend ::
+        TxIn -> SpendWitness -> TxInstr q e ()
+    -- | Add a collateral input.
+    Collateral :: TxIn -> TxInstr q e ()
+    -- | Add an output.
+    Send ::
+        TxOut ConwayEra -> TxInstr q e ()
+    -- | Peek at the final Tx (fixpoint).
+    Peek ::
+        (Tx ConwayEra -> Convergence a) ->
+        TxInstr q e a
+
+-- | Monadic transaction builder.
+type TxBuild q e = Program (TxInstr q e)
+
+-- ----------------------------------------------------
+-- Smart constructors
+-- ----------------------------------------------------
+
+{- | Spend a pub-key UTxO. Returns the spending
+index in the final sorted input set (resolved
+via 'Peek').
+-}
+spend :: TxIn -> TxBuild q e Word32
+spend txIn = do
+    singleton $ Spend txIn PubKeyWitness
+    singleton $ Peek $ \tx ->
+        let ins = tx ^. bodyTxL . inputsTxBodyL
+         in if Set.member txIn ins
+                then Ok (spendingIndex txIn ins)
+                else Iterate 0
+
+-- | Add a collateral input.
+collateral :: TxIn -> TxBuild q e ()
+collateral txIn = singleton $ Collateral txIn
+
+{- | Pay value to an address. Returns the output
+index in the final output list (resolved via
+'Peek').
+-}
+payTo ::
+    Addr -> MaryValue -> TxBuild q e Word32
+payTo addr val = do
+    singleton $ Send $ mkBasicTxOut addr val
+    singleton $ Peek $ \tx ->
+        let outs = tx ^. bodyTxL . outputsTxBodyL
+            target = mkBasicTxOut addr val
+         in case elemIndex target (toList outs) of
+                Just i -> Ok (fromIntegral i)
+                Nothing -> Iterate 0
+  where
+    toList = foldr (:) []
+
+-- | Add a raw output. Returns the output index.
+output ::
+    TxOut ConwayEra -> TxBuild q e Word32
+output txOut = do
+    singleton $ Send txOut
+    singleton $ Peek $ \tx ->
+        let outs = tx ^. bodyTxL . outputsTxBodyL
+         in case elemIndex txOut (toList outs) of
+                Just i -> Ok (fromIntegral i)
+                Nothing -> Iterate 0
+  where
+    toList = foldr (:) []
+
+-- | Peek at the final assembled Tx.
+peek ::
+    (Tx ConwayEra -> Convergence a) ->
+    TxBuild q e a
+peek = singleton . Peek
+
+-- ----------------------------------------------------
+-- Interpreter state
+-- ----------------------------------------------------
+
+-- | Accumulated state from interpreting 'TxBuild'.
+data TxState = TxState
+    { tsSpends :: [(TxIn, SpendWitness)]
+    , tsCollIns :: [TxIn]
+    , tsOuts :: [TxOut ConwayEra]
+    }
+
+emptyState :: TxState
+emptyState =
+    TxState
+        { tsSpends = []
+        , tsCollIns = []
+        , tsOuts = []
+        }
+
+{- | Interpret a 'TxBuild' program into 'TxState'.
+The 'Tx' argument resolves 'Peek' nodes.
+-}
+interpretWith ::
+    Tx ConwayEra ->
+    TxBuild q e a ->
+    -- | (state, result, all converged?)
+    (TxState, a, Bool)
+interpretWith currentTx = go emptyState True
+  where
+    go ::
+        TxState ->
+        Bool ->
+        TxBuild q' e' b ->
+        (TxState, b, Bool)
+    go st conv prog = case view prog of
+        Return a -> (st, a, conv)
+        Spend txIn w :>>= k ->
+            go
+                st
+                    { tsSpends =
+                        tsSpends st ++ [(txIn, w)]
+                    }
+                conv
+                (k ())
+        Collateral txIn :>>= k ->
+            go
+                st
+                    { tsCollIns =
+                        tsCollIns st ++ [txIn]
+                    }
+                conv
+                (k ())
+        Send txOut :>>= k ->
+            go
+                st
+                    { tsOuts =
+                        tsOuts st ++ [txOut]
+                    }
+                conv
+                (k ())
+        Peek f :>>= k ->
+            case f currentTx of
+                Ok a -> go st conv (k a)
+                Iterate a ->
+                    go st False (k a)
+
+-- | Assemble a 'Tx' from interpreter state.
+assembleTx :: TxState -> Tx ConwayEra
+assembleTx st =
+    let
+        allSpendIns =
+            Set.fromList $ map fst (tsSpends st)
+        collIns = Set.fromList (tsCollIns st)
+        outs = StrictSeq.fromList (tsOuts st)
+        body =
+            mkBasicTxBody
+                & inputsTxBodyL .~ allSpendIns
+                & outputsTxBodyL .~ outs
+                & collateralInputsTxBodyL .~ collIns
+     in
+        mkBasicTx body
+
+-- ----------------------------------------------------
+-- Assembly
+-- ----------------------------------------------------
+
+{- | Assemble a 'TxBuild' program into a 'Tx'
+without evaluation or balancing.
+
+Runs one pass: interprets with the initial (empty)
+Tx, then assembles from collected steps. 'Peek'
+nodes see the draft Tx on a second internal pass.
+-}
+draft ::
+    PParams ConwayEra ->
+    TxBuild q e a ->
+    Tx ConwayEra
+draft _pp prog =
+    let
+        -- Pass 1: collect steps with bogus Tx
+        initialTx = mkBasicTx mkBasicTxBody
+        (st1, _, _) = interpretWith initialTx prog
+        -- Assemble from pass 1
+        tx1 = assembleTx st1
+        -- Pass 2: re-interpret with real Tx for
+        -- Peek resolution
+        (st2, _, _) = interpretWith tx1 prog
+     in
+        assembleTx st2
+
+-- ----------------------------------------------------
+-- Internal helpers
+-- ----------------------------------------------------
+
+{- | Compute the spending index of a 'TxIn' in the
+sorted input set.
+-}
+spendingIndex :: TxIn -> Set TxIn -> Word32
+spendingIndex needle inputs =
+    go 0 (Set.toAscList inputs)
+  where
+    go _ [] =
+        error "spendingIndex: TxIn not in set"
+    go n (x : xs)
+        | x == needle = n
+        | otherwise = go (n + 1) xs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: cardano-node-clients
 site_url: https://paolino.github.io/cardano-node-clients/
-repo_url: https://github.com/paolino/cardano-node-clients
+repo_url: https://github.com/lambdasistemi/cardano-node-clients
 
 theme:
   name: material
@@ -38,4 +38,5 @@ nav:
       - Provider: modules/provider.md
       - Submitter: modules/submitter.md
       - Balance: modules/balance.md
+      - TxBuild: modules/txbuild.md
       - N2C: modules/n2c.md

--- a/specs/003-tx-builder-dsl/checklists/requirements.md
+++ b/specs/003-tx-builder-dsl/checklists/requirements.md
@@ -1,0 +1,30 @@
+# Specification Quality Checklist: Transaction Builder DSL
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification

--- a/specs/003-tx-builder-dsl/data-model.md
+++ b/specs/003-tx-builder-dsl/data-model.md
@@ -1,0 +1,45 @@
+# Data Model: Transaction Builder DSL
+
+## TxBuilder
+
+Immutable accumulator. Each combinator appends a step and returns a new value.
+
+- **steps**: ordered list of TxStep
+- **scripts**: map from ScriptHash to Script (attached scripts)
+
+## TxStep (sum type)
+
+- **Spend**: TxIn + SpendWitness
+- **ReferenceOutput**: TxIn
+- **AddCollateral**: TxIn
+- **Send**: TxOut ConwayEra
+- **Mint**: PolicyID + AssetName + Integer + MintWitness
+- **ValidityStart**: SlotNo
+- **ValidityEnd**: SlotNo
+- **RequireSignature**: KeyHash 'Witness
+
+## SpendWitness (sum type)
+
+- **PubKeyWitness**: no additional data
+- **ScriptWitness**: existential `r` with `ToData r` constraint — the typed redeemer
+
+## MintWitness
+
+- **PlutusScriptWitness**: existential `r` with `ToData r` constraint — the typed redeemer
+
+## State Transitions
+
+```
+txBuilder (empty)
+  → spend/spendScript/references/collaterals/payTo/mint/validFrom/validTo/requireSignature (accumulate steps)
+    → build (assemble + evaluate + balance → Tx ConwayEra)
+    → complete (query UTxOs + build → Tx ConwayEra)
+    → draft (assemble only → Tx ConwayEra)
+```
+
+## Relationships to Existing Types
+
+- TxBuilder produces `Tx ConwayEra` (cardano-ledger)
+- `build` consumes `Provider IO` (cardano-mpfs-offchain) and `PParams ConwayEra` (cardano-ledger)
+- `build` delegates to `balanceTx` (cardano-node-clients)
+- SpendWitness/MintWitness use `ToData` from plutus-tx

--- a/specs/003-tx-builder-dsl/plan.md
+++ b/specs/003-tx-builder-dsl/plan.md
@@ -1,0 +1,56 @@
+# Implementation Plan: Transaction Builder DSL
+
+**Branch**: `003-tx-builder-dsl` | **Date**: 2026-04-10 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/003-tx-builder-dsl/spec.md`
+
+## Summary
+
+Add a Scalus-inspired transaction builder DSL to `cardano-node-clients`. The builder is an immutable step accumulator with typed combinators for script spends, minting, reference inputs, validity intervals, and inline datums. A single `build` function absorbs all mechanical boilerplate: redeemer index computation, script integrity hashing, ExUnits evaluation/patching, and fee balancing. The technical spec is at `/code/cardano-tx-sim-spec.md`.
+
+## Technical Context
+
+**Language/Version**: Haskell (GHC 9.6+, same as cardano-node-clients)
+**Primary Dependencies**: cardano-ledger-api, cardano-ledger-conway, plutus-ledger-api, plutus-tx (ToData/FromData)
+**Storage**: N/A
+**Testing**: hspec, existing e2e devnet tests
+**Target Platform**: Linux (same as cardano-node-clients)
+**Project Type**: Library module within cardano-node-clients
+**Constraints**: No cardano-api dependency. Must work with existing Provider and Balance modules.
+
+## Constitution Check
+
+No constitution file found. Proceeding with project conventions:
+- Function records, not typeclasses
+- Existential `ToData` for typed redeemers/datums
+- cardano-ledger types directly, no cardano-api
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-tx-builder-dsl/
+├── plan.md
+├── research.md
+├── data-model.md
+├── tasks.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+lib/Cardano/Node/Client/
+├── TxBuild.hs          # TxBuilder type, steps, combinators
+├── TxBuild/
+│   └── Build.hs        # build, complete, draft (assembly + evaluation)
+├── Balance.hs          # Existing — no changes
+├── Provider.hs         # Existing — no changes
+└── ...
+
+test/Cardano/Node/Client/
+└── TxBuildSpec.hs      # Unit tests for builder combinators + assembly
+```
+
+**Structure Decision**: Single new module `TxBuild.hs` with a submodule for the assembly logic. Keeps the public API (combinators) separate from the internal machinery (index computation, integrity hash, evaluation patching).

--- a/specs/003-tx-builder-dsl/research.md
+++ b/specs/003-tx-builder-dsl/research.md
@@ -1,0 +1,41 @@
+# Research: Transaction Builder DSL
+
+## Decision: Builder pattern
+
+**Chosen**: Immutable record with step list, combinators return new record via `&` pipeline.
+**Rationale**: Mirrors Scalus TxBuilder (proven API), fits Haskell idioms (no OOP chaining, use `&` instead).
+**Alternatives**: Monadic builder (State monad) — rejected because `&` is simpler and doesn't require do-notation for pure construction.
+
+## Decision: Redeemer/datum typing
+
+**Chosen**: Existential `ToData` constraint captured in `SpendWitness` / `MintWitness` constructors.
+**Rationale**: Type-safe at call sites (callers pass typed values), erased at assembly time. No raw `PLC.Data` in public API.
+**Alternatives**: Store `PLC.Data` directly (simpler but loses type safety at construction).
+
+## Decision: Index computation
+
+**Chosen**: Compute `spendingIndex` and minting index inside `build` from the sorted input/policy sets.
+**Rationale**: This is the primary boilerplate. Every MPFS builder computes these manually.
+**Source**: `spendingIndex` in `Cardano.MPFS.TxBuilder.Real.Internal` (lines 508-517).
+
+## Decision: Integrity hash
+
+**Chosen**: Compute inside `build` from `PParams` + assembled `Redeemers`.
+**Rationale**: Currently computed manually in every builder. Uses `hashScriptIntegrity` from cardano-ledger-alonzo.
+**Source**: `computeScriptIntegrity` in Internal.hs (lines 521-533).
+
+## Decision: Evaluation + balancing
+
+**Chosen**: `build` calls evaluateTx (via Provider), patches ExUnits, recomputes integrity hash, then calls existing `balanceTx`.
+**Rationale**: This is the `evaluateAndBalance` function from Internal.hs — moved into the builder as the final step.
+**Source**: `evaluateAndBalance` in Internal.hs (lines 188-267).
+
+## Decision: No separate burn combinator
+
+**Chosen**: `mint` handles both minting (positive) and burning (negative), following Scalus.
+**Rationale**: Simpler API, no semantic distinction needed — the sign of the quantity determines the operation.
+
+## Decision: PlutusV3 only (for now)
+
+**Chosen**: Hardcode PlutusV3 in integrity hash computation (language views).
+**Rationale**: All MPFS transactions are PlutusV3. Can be parameterized later if needed.

--- a/specs/003-tx-builder-dsl/spec-design.md
+++ b/specs/003-tx-builder-dsl/spec-design.md
@@ -466,22 +466,6 @@ Vertical slices — each delivers one working end-to-end feature with types, log
 - `reference`, `validFrom`, `validTo`
 - Test: Retract-shaped tx (reference input + validity window + required signer)
 
-### Slice 7: MPFS Boot migration
-- Define `CageQ` and `CageErr` in MPFS offchain
-- Rewrite `bootTokenImpl` as `TxBuild CageQ CageErr ()`
-- Production `InterpretIO CageQ` + test `Interpret CageQ`
-- Verify e2e Boot test passes
-
-### Slice 8: MPFS Update/Reject migration (conservation)
-- Rewrite `updateTokenImpl` / `rejectRequestsImpl` using `peek` for fee
-- Verify conservation e2e tests pass
-- Delete `balanceFeeLoop`, `evaluateAndBalance` from Internal.hs
-
-### Slice 9: Remaining MPFS migrations
-- Rewrite End, Retract, Request builders
-- Delete `spendingIndex`, `computeScriptIntegrity`, `placeholderExUnits`
-- All e2e tests pass, Internal.hs cleaned up
-
 ### Phase 4: Transaction Logic Tester (separate ticket)
 
 Not an emulator — a transaction logic tester. It validates that a sequence of `TxBuild` programs produces valid transactions against `cardano-ledger`'s `applyTx`. It does NOT replicate the production infrastructure (chain sync, RocksDB, concurrent queries, rollbacks).

--- a/specs/003-tx-builder-dsl/spec-design.md
+++ b/specs/003-tx-builder-dsl/spec-design.md
@@ -1,0 +1,614 @@
+# Transaction Builder DSL for cardano-node-clients
+
+**Location:** new module(s) inside `cardano-node-clients`
+**Inspired by:** [Scalus](https://scalus.org) TxBuilder
+**Scope:** Cover the transaction shapes used in MPFS offchain — no more, no less
+
+## Problem
+
+Every MPFS transaction builder (`Boot`, `Update`, `End`, `Retract`, `Reject`, `Request`) follows the same pattern:
+
+1. Start with `mkBasicTxBody`
+2. Set inputs via `& inputsTxBodyL .~ Set.fromList [...]`
+3. Set outputs via `& outputsTxBodyL .~ StrictSeq.fromList [...]`
+4. Maybe set mint via `& mintTxBodyL .~ mintMA`
+5. Set collateral via `& collateralInputsTxBodyL .~ ...`
+6. Maybe set reference inputs, required signers, validity interval
+7. Build redeemers map with manual `spendingIndex` computation and `placeholderExUnits`
+8. Compute `scriptIntegrityHash` from pp + redeemers
+9. Assemble `mkBasicTx body & witsTxL . scriptTxWitsL .~ ... & witsTxL . rdmrsTxWitsL .~ ...`
+10. Call `evaluateAndBalance prov pp inputUtxos changeAddr tx`
+
+Steps 7–10 are identical boilerplate across all 7 builders. Steps 1–6 are lens plumbing that obscures intent. The DSL should absorb the mechanical parts (index computation, integrity hash, ExUnits patching, redeemer assembly) while keeping the domain logic explicit.
+
+## Transaction Shapes to Cover
+
+Derived from MPFS offchain code:
+
+| Tx type | Inputs | Ref inputs | Outputs | Mint | Redeemers | Validity | Req signers |
+|---------|--------|------------|---------|------|-----------|----------|-------------|
+| **Boot** | 1 seed UTxO | — | 1 state (script addr, token+datum) | +1 token (Minting redeemer) | 1 mint | — | — |
+| **Request** (insert/delete/update) | wallet UTxOs | — | 1 request (script addr, datum) | — | — | — | — |
+| **Update** | state + N requests + fee | — | 1 new state + N refunds | — | 1 spend (Modify) + N spend (Contribute) | upper bound | owner |
+| **Retract** | request + fee | state (ref) | — | — | 1 spend (Retract) | lower + upper | request owner |
+| **Reject** | state + N requests + fee | — | 1 new state + N refunds | — | 1 spend + N spend (Reject) | lower + upper | owner |
+| **End** | state + fee | — | — | -1 token (Burning redeemer) | 1 spend (End) + 1 mint (Burning) | — | owner |
+| **Simple transfer** | 1 UTxO | — | 1 recipient | — | — | — | — |
+
+## DSL Design
+
+Operational monad parameterized by pluggable context `q` and error type `e`. Three non-building instructions: `Peek` (fixpoint values from the Tx), `Valid` (ledger and custom checks), and `Ctx` (domain queries). Scalus's three deferred mechanisms collapse into `Peek` + `Ctx`; validation is a new axis no other library has as a composable instruction.
+
+### Instruction GADT
+
+```haskell
+data TxInstr q e a where
+    -- Transaction building (fixed, we define these)
+    Spend        :: TxIn -> SpendWitness -> TxInstr q e ()
+    Reference    :: TxIn -> TxInstr q e ()
+    Collateral   :: TxIn -> TxInstr q e ()
+    Send         :: TxOut ConwayEra -> TxInstr q e ()
+    MintI        :: PolicyID -> AssetName -> Integer -> MintWitness -> TxInstr q e ()
+    SetValidFrom :: SlotNo -> TxInstr q e ()
+    SetValidTo   :: SlotNo -> TxInstr q e ()
+    ReqSignature :: KeyHash 'Witness -> TxInstr q e ()
+    AttachScript :: Script ConwayEra -> TxInstr q e ()
+    -- Peek at the final Tx (fixpoint, produces values)
+    Peek         :: (Tx ConwayEra -> Convergence a) -> TxInstr q e a
+    -- Validate the final Tx (produces errors, not values)
+    Valid        :: (Tx ConwayEra -> Check e) -> TxInstr q e ()
+    -- Pluggable context: user-defined queries
+    Ctx          :: q a -> TxInstr q e a
+
+type TxBuild q e = Program (TxInstr q e)
+
+-- Fixpoint convergence
+data Convergence a = Iterate a | Ok a
+
+-- Validation result
+data Check e = Pass | LedgerFail LedgerCheck | CustomFail e
+
+-- Library-provided ledger checks (closed)
+data LedgerCheck
+    = MinUtxoViolation Word32 Coin Coin
+    | TxSizeExceeded Natural Natural
+    | ValueNotConserved Value Value
+    | CollateralInsufficient Coin Coin
+
+data SpendWitness
+    = PubKeyWitness
+    | forall r. ToData r => ScriptWitness r
+
+data MintWitness
+    = forall r. ToData r => PlutusScriptWitness r
+
+-- Interpreter newtypes (avoid impredicativity)
+newtype Interpret q = Interpret { runInterpret :: forall x. q x -> x }
+newtype InterpretIO q = InterpretIO { runInterpretIO :: forall x. q x -> IO x }
+```
+
+### Smart constructors
+
+Position-dependent instructions use `Peek` internally. The user binds the result naturally.
+
+```haskell
+-- Inputs: return spending index (resolved by fixpoint)
+spend        :: TxIn -> TxBuild q e Word32
+spendScript  :: ToData r => TxIn -> r -> TxBuild q e Word32
+
+-- Outputs: return output index (resolved by fixpoint)
+payTo        :: Addr -> MaryValue -> TxBuild q e Word32
+payTo'       :: ToData d => Addr -> MaryValue -> d -> TxBuild q e Word32
+output       :: TxOut ConwayEra -> TxBuild q e Word32
+
+-- These return ()
+reference        :: TxIn -> TxBuild q e ()
+collateral       :: TxIn -> TxBuild q e ()
+mint             :: ToData r => PolicyID -> Map AssetName Integer -> r -> TxBuild q e ()
+validFrom        :: SlotNo -> TxBuild q e ()
+validTo          :: SlotNo -> TxBuild q e ()
+requireSignature :: KeyHash 'Witness -> TxBuild q e ()
+attachScript     :: Script ConwayEra -> TxBuild q e ()
+
+-- Raw Peek (user controls convergence)
+peek :: (Tx ConwayEra -> Convergence a) -> TxBuild q e a
+
+-- Validation (user or library checks)
+valid :: (Tx ConwayEra -> Check e) -> TxBuild q e ()
+
+-- Pluggable context query
+ctx :: q a -> TxBuild q e a
+```
+
+Library-provided checkers:
+
+```haskell
+checkMinUtxo     :: PParams -> Word32 -> TxBuild q e ()
+checkTxSize      :: PParams -> TxBuild q e ()
+checkConservation :: TxBuild q e ()
+checkCollateral  :: PParams -> TxBuild q e ()
+```
+
+Each is a `valid` call that produces `LedgerFail` on failure. The user opts in by including them in their program — they're not mandatory.
+
+### The three axes
+
+**`Peek`** — extract a value from the final Tx (fixpoint). Replaces Scalus's `redeemerBuilder` and `datumBuilder`. Returns `Convergence a`: `Ok a` (done) or `Iterate a` (use this value, keep going). The build loop iterates until all `Peek`s return `Ok`.
+
+**`Valid`** — check a property of the final Tx. Returns `Check e`: `Pass`, `LedgerFail LedgerCheck`, or `CustomFail e`. Runs after convergence. The interpreter collects all failures.
+
+**`Ctx`** — query domain-specific context. Replaces Scalus's `Deferred(query, resolve)`. One-shot, not part of the fixpoint.
+
+They compose freely:
+
+```haskell
+updateTx :: TxBuild CageQ CageErr ()
+updateTx = do
+    -- Ctx: domain query
+    (stateIn, datum) <- ctx (FindState pid tid)
+    reqs <- ctx (FindReqs tid)
+
+    -- Pure computation
+    let newRoot = computeRoot datum proofs
+
+    -- Tx building (spend returns index via Peek)
+    stateIdx <- spendScript stateIn (Modify proofs)
+    forM_ reqs $ \(reqIn, _) ->
+        spendScript reqIn (Contribute (txInToRef stateIn))
+
+    -- Peek: fee-dependent refund (fixpoint)
+    Coin feeVal <- peek $ \tx ->
+        let fee = tx ^. bodyTxL . feeTxBodyL
+        in if fee > Coin 0 then Ok fee else Iterate (Coin 0)
+    let refund = totalIn - feeVal - numReqs * tip
+    payTo' scriptAddr stateValue (StateDatum newRoot)
+    forM_ (zip [0..] reqs) $ \(i, _) ->
+        payTo ownerAddr (inject (Coin (perReq i refund)))
+
+    -- Valid: opt-in checks
+    outIdx <- payTo' scriptAddr stateValue newDatum
+    checkMinUtxo pp outIdx
+
+    -- Valid: custom domain check
+    valid $ \tx -> if someInvariant tx then Pass
+                   else CustomFail InvalidStateTransition
+
+    collateral feeIn
+    requireSignature ownerKh
+    validTo upperSlot
+    attachScript script
+```
+
+### Interpreters
+
+```haskell
+-- Pure: no context, no Peek iteration, no Valid
+-- q = Void, e = Void
+draft
+    :: PParams ConwayEra
+    -> TxBuild Void Void a
+    -> Tx ConwayEra
+
+-- Pure with precomputed context answers
+draftWith
+    :: PParams ConwayEra
+    -> DMap q Identity
+    -> TxBuild q e a
+    -> Tx ConwayEra
+
+-- Full: context + Peek fixpoint + evaluation + balancing + Valid checks
+build
+    :: PParams ConwayEra
+    -> InterpretIO q          -- context interpreter
+    -> (Tx ConwayEra -> IO EvalResult)   -- script evaluator
+    -> [(TxIn, TxOut ConwayEra)]         -- input UTxOs
+    -> Addr                              -- change address
+    -> TxBuild q e a
+    -> IO (Either (BuildError e) (Tx ConwayEra))
+
+data BuildError e
+    = EvalFailure ScriptHash String [Text]
+    | BalanceFailed BalanceError
+    | ChecksFailed [Check e]   -- all failed Valid checks
+```
+
+Interpreter loop:
+1. Resolve `Ctx` queries (one-shot, via natural transformation)
+2. Interpret `Peek` nodes with current Tx → collect `Ok`/`Iterate`
+3. Assemble Tx from steps
+4. Evaluate scripts → ExUnits → patch → recompute integrity hash
+5. Balance (inner fee loop)
+6. If any `Peek` returned `Iterate` → goto 2 with new Tx
+7. All `Peek` returned `Ok` AND Tx stable → run `Valid` checks
+8. If any `Check` ≠ `Pass` → return `Left (ChecksFailed failures)`
+9. All pass → return `Right tx`
+
+### Example: MPFS queries and errors
+
+```haskell
+-- Queries (pluggable context)
+data CageQ a where
+    FindState :: PolicyID -> TokenId -> CageQ (TxIn, CageDatum)
+    FindReqs  :: TokenId -> CageQ [(TxIn, CageDatum)]
+    GetParams :: CageQ (PParams ConwayEra)
+
+-- Errors (custom failures)
+data CageErr
+    = InvalidStateTransition
+    | InsufficientTip Coin
+    | InvalidRoot ByteString
+
+-- Production interpreter
+cageInterpreter :: Provider IO -> CageQ a -> IO a
+cageInterpreter prov (FindState pid tid) = ...
+cageInterpreter prov (FindReqs tid) = ...
+cageInterpreter prov GetParams = queryProtocolParams prov
+
+-- Test interpreter
+testAnswers :: DMap CageQ Identity
+testAnswers = DMap.fromList
+    [ FindState pid tid :=> Identity (mockIn, mockDatum)
+    , FindReqs tid :=> Identity [(req1, d1), (req2, d2)]
+    , GetParams :=> Identity emptyPParams
+    ]
+```
+
+## What MPFS builders become
+
+### Boot
+
+**Before** (~120 lines): manual redeemer map, integrity hash, lens plumbing, evaluateAndBalance.
+
+**After** (~20 lines):
+```haskell
+bootTx :: TxBuild CageQ CageErr ()
+bootTx = do
+    pp <- ctx GetParams
+    (seedIn, _) <- ctx (FindFeeUtxo addr)
+    let onChainRef = txInToRef seedIn
+        assetName = deriveAssetName onChainRef
+    spend seedIn
+    payTo' scriptAddr (MaryValue 2_000_000 mintMA) stateDatum
+    mint policyId (Map.singleton assetName 1) (Minting (Mint onChainRef))
+    collateral seedIn
+    attachScript script
+```
+
+### End
+
+**Before** (~100 lines): dual redeemers (spend + mint), manual index computation.
+
+**After** (~15 lines):
+```haskell
+endTx :: TxBuild CageQ CageErr ()
+endTx = do
+    (stateIn, datum) <- ctx (FindState pid tid)
+    (feeIn, _) <- ctx (FindFeeUtxo addr)
+    let ownerKh = extractOwner datum
+    spendScript stateIn End
+    mint policyId (Map.singleton assetName (-1)) Burning
+    collateral feeIn
+    requireSignature ownerKh
+    attachScript script
+```
+
+### Modify/Reject (conservation-aware, fee-dependent outputs)
+
+**Before** (~250 lines in `buildConservationTx`): manual `balanceFeeLoop` with `mkOutputs` callback, two-phase evaluation, manual ExUnits patching, manual index computation.
+
+**After** (~30 lines):
+```haskell
+modifyTx :: TxBuild CageQ CageErr ()
+modifyTx = do
+    (stateIn, datum) <- ctx (FindState pid tid)
+    reqs <- ctx (FindReqs tid)
+    (feeIn, _) <- ctx (FindFeeUtxo addr)
+    let stateRef = txInToRef stateIn
+        proofs = computeProofs datum reqs
+        numReqs = length reqs
+        totalIn = sum [c | (_, out) <- reqs, let Coin c = out ^. coinTxOutL]
+    spendScript stateIn (Modify proofs)
+    forM_ reqs $ \(reqIn, _) ->
+        spendScript reqIn (Contribute stateRef)
+    -- Refunds depend on the final fee (fixpoint)
+    Coin feeVal <- peek $ \tx ->
+        tx ^. bodyTxL . feeTxBodyL
+    let totalRefund = totalIn - feeVal - numReqs * tip
+        perRequest = totalRefund `div` numReqs
+        remainder = totalRefund `mod` numReqs
+    payTo' scriptAddr (MaryValue (Coin (2_000_000 + numReqs * tip)) mint) newDatum
+    forM_ (zip [0..] reqs) $ \(i, _) ->
+        payTo ownerAddr (inject (Coin (perRequest + if i == 0 then remainder else 0)))
+    collateral (fst feeUtxo)
+    requireSignature (extractOwner datum)
+    validTo upperSlot
+    attachScript script
+```
+
+The `balanceFeeLoop` with its `mkOutputs` callback disappears entirely. `peek` reads the fee from the fixpoint, and the build loop converges naturally (2–3 iterations). This is the exact use case from [cardano-foundation/cardano-mpfs-onchain#37](https://github.com/cardano-foundation/cardano-mpfs-onchain/pull/37).
+
+### Retract (reference input + validity window)
+
+**Before** (~150 lines): reference input, validity computation, manual redeemer with state ref.
+
+**After** (~20 lines):
+```haskell
+retractTx :: TxBuild CageQ CageErr ()
+retractTx = do
+    (stateIn, stateDatum) <- ctx (FindState pid tid)
+    (reqIn, reqDatum) <- ctx (FindRequest reqTxIn)
+    (feeIn, _) <- ctx (FindFeeUtxo addr)
+    let ownerKh = extractRequestOwner reqDatum
+        stateRef = txInToRef stateIn
+    reference stateIn          -- not consumed
+    spendScript reqIn (Retract stateRef)
+    collateral feeIn
+    requireSignature ownerKh
+    validFrom lowerSlot
+    validTo upperSlot
+    attachScript script
+```
+
+### Simple transfer (no scripts)
+
+```haskell
+transferTx :: TxBuild Void ()
+transferTx = do
+    spend seedIn
+    payTo recipientAddr (inject (Coin 5_000_000))
+```
+
+Note: `q = Void` — no context needed, works with pure `draft`.
+
+### Composing two protocols in one transaction
+
+```haskell
+-- Two independent protocol interactions
+composedTx :: TxBuild AppQ ()
+composedTx = do
+    -- Protocol A: spend a cage state
+    (stateIn, datum) <- ctx (CageQuery (FindState pid tid))
+    spendScript stateIn (Modify proofs)
+    payTo' scriptAddr stateValue newDatum
+
+    -- Protocol B: mint an NFT
+    (seedIn, _) <- ctx (NftQuery (FindSeed addr))
+    let nftName = deriveNftName seedIn
+    spend seedIn
+    mint nftPolicyId (Map.singleton nftName 1) NftMint
+    payTo' nftAddr (MaryValue 2_000_000 nftMA) nftDatum
+
+    -- Shared concerns
+    (feeIn, _) <- ctx (WalletQuery (FindFeeUtxo addr))
+    collateral feeIn
+    attachScript cageScript
+    attachScript nftScript
+```
+
+Each protocol defines its own query constructors in a sum type `AppQ`. The interpreter handles all of them. Neither protocol knows about the other.
+
+## Crucial cases from ecosystem survey
+
+The [survey](/code/cardano-tx-builder-survey.md) identified 10 crucial cases across 25 libraries. Coverage:
+
+| Case | Covered | How |
+|------|---------|-----|
+| 1. Redeemer index computation | Yes | Auto in interpreter, returned via `Peek` |
+| 2. Fee-dependent outputs | Yes | `peek` reads fee, Modify example |
+| 3. Deferred redeemers | Yes | `Peek` (general, any type) |
+| 4. Deferred UTxO queries | Yes | `Ctx q a` (pluggable, typed) |
+| 5. Datum handling (inline) | Yes | `payTo'` with `ToData d` |
+| 5b. Datum handling (hash) | Deferred | Not needed for MPFS; add `payToHash` later |
+| 6. Coin selection | Delegated | Existing `balanceTx` (ADA-only largest-first) |
+| 7. Script evaluation | Yes | Evaluator function parameter to `build` |
+| 8. Composability | Yes | `Ctx` with sum-type queries, example above |
+| 9. Pay vs Lock safety | Deferred | Could add `lockAt` that requires datum; not blocking |
+| 10. Fee estimation | Yes | Two nested loops: inner (balanceTx), outer (`Peek`) |
+| 11. Tx validation | **New** | `Valid` with `Check e` — opt-in composable checkers |
+
+## What stays in MPFS
+
+Domain logic only — no transaction mechanics:
+
+- Query GADT definition (`CageQ`)
+- Query interpreter (production: node queries, test: DMap fixtures)
+- Datum types and construction
+- Proof generation (trie operations)
+- Validity interval computation (phase boundaries)
+- Business rules (fee calculation, refund amounts)
+
+## Integration with existing code
+
+- **`Balance.hs`** — unchanged, `build` calls it internally
+- **`Provider`** — used inside the `CageQ` interpreter, not by the DSL
+- **`evaluateAndBalance`** — absorbed into `build`, deprecated
+- **`spendingIndex`** — absorbed into interpreter, deprecated
+- **`computeScriptIntegrity`** — absorbed into interpreter, deprecated
+- **`placeholderExUnits`** — absorbed into interpreter, deprecated
+
+## Implementation plan
+
+Vertical slices — each delivers one working end-to-end feature with types, logic, interpreter support, and tests in one commit.
+
+### Slice 1: Simple pub-key spend + draft
+- `TxInstr q e a` GADT with `Spend`, `Send`, `Collateral`
+- `Convergence`, `Check`, `LedgerCheck`, `Interpret`, `InterpretIO` types
+- `spend` (returns `Word32` via `Peek`), `payTo`, `collateral`
+- `draft` interpreter (pure, `q = Void, e = Void`)
+- Test: build a simple transfer, verify inputs/outputs in assembled Tx
+
+### Slice 2: Script spend + mint + redeemer indices
+- Add `MintI`, `AttachScript`, `ReqSignature` to GADT
+- `spendScript`, `mint`, `attachScript`, `requireSignature`
+- `draft` handles redeemer index computation (spending + minting)
+- Test: Boot-shaped tx (spend + mint), End-shaped tx (spend + mint + burn), verify redeemer indices
+
+### Slice 3: Peek convergence + build loop
+- Add `Peek` instruction to GADT
+- `build` interpreter with fixpoint iteration + evaluator + balancing
+- `peek` smart constructor
+- Test: fee-dependent outputs (conservation case from onchain#37)
+
+### Slice 4: Ctx + pluggable queries
+- Add `Ctx` instruction to GADT
+- `Interpret`/`InterpretIO` wiring in `build`
+- `ctx` smart constructor
+- Test: define a test query GADT, use `ctx` in a builder, interpret with `Interpret`
+
+### Slice 5: Valid + library checkers
+- Add `Valid` instruction to GADT
+- `valid` smart constructor, `checkMinUtxo`, `checkTxSize`
+- Interpreter runs checks after `Peek` convergence
+- Test: output below min UTxO → `LedgerFail`, custom check → `CustomFail`
+
+### Slice 6: Reference inputs + validity intervals
+- Add `Reference`, `SetValidFrom`, `SetValidTo`
+- `reference`, `validFrom`, `validTo`
+- Test: Retract-shaped tx (reference input + validity window + required signer)
+
+### Slice 7: MPFS Boot migration
+- Define `CageQ` and `CageErr` in MPFS offchain
+- Rewrite `bootTokenImpl` as `TxBuild CageQ CageErr ()`
+- Production `InterpretIO CageQ` + test `Interpret CageQ`
+- Verify e2e Boot test passes
+
+### Slice 8: MPFS Update/Reject migration (conservation)
+- Rewrite `updateTokenImpl` / `rejectRequestsImpl` using `peek` for fee
+- Verify conservation e2e tests pass
+- Delete `balanceFeeLoop`, `evaluateAndBalance` from Internal.hs
+
+### Slice 9: Remaining MPFS migrations
+- Rewrite End, Retract, Request builders
+- Delete `spendingIndex`, `computeScriptIntegrity`, `placeholderExUnits`
+- All e2e tests pass, Internal.hs cleaned up
+
+### Phase 4: Transaction Logic Tester (separate ticket)
+
+Not an emulator — a transaction logic tester. It validates that a sequence of `TxBuild` programs produces valid transactions against `cardano-ledger`'s `applyTx`. It does NOT replicate the production infrastructure (chain sync, RocksDB, concurrent queries, rollbacks).
+
+#### Core: `applyTx` is pure
+
+```haskell
+applyTx :: Globals -> LedgerEnv era -> LedgerState era -> Tx era
+        -> Either (ApplyTxError era) (LedgerState era, Validated (Tx era))
+```
+
+Pure function, real ledger rules, real `PredicateFailure` errors. No node needed.
+
+#### Application state as a `Fold`
+
+The tester needs a `Ctx` interpreter that tracks application state across transactions. The state evolves with each submitted tx. We model this as a `Fold` (from the `foldl` package):
+
+```haskell
+data Fold a b = forall s. Fold
+    (s -> a -> s)  -- step
+    s              -- initial
+    (s -> b)       -- extract
+```
+
+The tester's fold consumes transactions and produces a `Ctx` interpreter:
+
+```haskell
+data Tester q = forall s. Tester
+    { tLedgerState :: LedgerState ConwayEra
+    , tGlobals     :: Globals
+    , tEnv         :: LedgerEnv ConwayEra
+    , tFold        :: Fold (Tx ConwayEra) (Interpret q)
+    }
+```
+
+The `s` is existential — hidden inside the `Fold`. The user provides step + initial + extract. The tester feeds transactions and extracts the `Ctx` interpreter when needed.
+
+#### Library-provided folds
+
+We ship standard folds for common UTxO tracking:
+
+```haskell
+-- Track all live UTxOs (created - consumed)
+utxoFold :: Fold (Tx ConwayEra) (Map TxIn (TxOut ConwayEra))
+
+-- Track UTxOs at a specific address
+utxoAtFold :: Addr -> Fold (Tx ConwayEra) (Map TxIn (TxOut ConwayEra))
+
+-- Track UTxOs holding a specific policy
+utxoByPolicyFold :: PolicyID -> Fold (Tx ConwayEra) (Map TxIn (TxOut ConwayEra))
+```
+
+The user composes them with domain-specific folds via `Applicative`:
+
+```haskell
+cageFold :: PolicyID -> Addr -> Fold (Tx ConwayEra) (forall x. CageQ x -> x)
+cageFold pid scriptAddr = mkCageCtx
+    <$> utxoByPolicyFold pid   -- state UTxOs (library)
+    <*> utxoAtFold scriptAddr  -- all cage UTxOs (library)
+    <*> trieFold               -- trie state (user's domain logic)
+```
+
+#### API
+
+```haskell
+initTester
+    :: Globals -> PParams ConwayEra
+    -> [(TxIn, TxOut ConwayEra)]       -- genesis funds
+    -> Fold (Tx ConwayEra) (Interpret q)
+    -> Tester q
+
+submitTx :: Tx ConwayEra -> Tester q
+         -> Either (ApplyTxError ConwayEra) (Tester q)
+
+ctxInterpreter :: Tester q -> Interpret q
+
+advanceSlot :: SlotNo -> Tester q -> Tester q
+```
+
+#### What it tests, what it doesn't
+
+**Tests:**
+- Transaction validity (same `applyTx` as the node)
+- Builder logic (redeemer indices, integrity hash, balancing)
+- Multi-step protocol flows (state machine transitions)
+- `Peek` convergence (fee-dependent outputs)
+- `Valid` checks (opt-in pre-flight validation)
+
+**Does NOT test:**
+- Chain sync / chain follower infrastructure
+- Database read/write path (RocksDB, CSMT-UTxO)
+- Concurrent query/submit races
+- Rollbacks / chain switches
+- Block-level semantics (tx ordering within blocks)
+
+The fold the user provides is *morally equivalent* to their production chain follower — same logic, different infrastructure. It's a specification of the fold, not a port of the production code. The gap (Case 11) is inherent and explicit.
+
+## Decided
+
+1. **`TxInstr q e a` — two user type parameters.** `q` for pluggable context queries, `e` for custom validation errors. The DSL handles tx building; `q` and `e` are the user's domain.
+
+2. **Three non-building instructions.** `Peek` for fixpoint values from the Tx. `Valid` for opt-in validation checks. `Ctx` for domain queries. Replaces Scalus's three deferred mechanisms and adds validation as a composable instruction.
+
+3. **`Peek` with `Convergence`.** `data Convergence a = Iterate a | Ok a`. The function controls convergence — returns `Iterate` with a best-effort value or `Ok` when satisfied. No artificial iteration cap. Non-convergence is the user's bug.
+
+4. **`Valid` with `Check e`.** `data Check e = Pass | LedgerFail LedgerCheck | CustomFail e`. `LedgerCheck` is closed (library-provided: min UTxO, tx size, conservation, collateral). `e` is open (user-provided). Checks run after `Peek` convergence.
+
+5. **Library checkers are opt-in.** `checkMinUtxo`, `checkTxSize`, `checkConservation`, `checkCollateral` are smart constructors the user includes in their program. Not mandatory, not baked into the interpreter.
+
+6. **Position-returning instructions.** `spend` returns `Word32` (input index), `payTo` returns `Word32` (output index). Resolved via `Peek` internally — one mechanism, no special cases.
+
+7. **Interpreter-polymorphic.** `draft` is pure (`q = Void, e = Void`). `draftWith` uses `DMap q Identity`. `build` uses `InterpretIO q`. Same program, different semantics.
+
+8. **Existential redeemers and datums.** `SpendWitness` and `MintWitness` use existentials with `ToData` constraint. Type-safe at construction, erased at assembly.
+
+9. **Lives in `cardano-node-clients`.** Module `Cardano.Node.Client.TxBuild`.
+
+10. **Two nested loops in `build`.** Inner: `balanceTx` iterates fee estimation. Outer: `Peek` fixpoint re-interprets the program. Convergence: inner is fee-monotonic; outer is user-controlled via `Convergence`.
+
+11. **Valid runs after convergence.** The interpreter first converges all `Peek` nodes, then runs all `Valid` checks on the final Tx. Checks see the fully balanced, converged transaction.
+
+12. **Transaction logic tester, not emulator.** Phase 4 provides `applyTx`-based validation, not a production replica. Application state is a `Fold (Tx ConwayEra) (Interpret q)` — existential state, `Applicative` composition, library UTxO folds + user domain folds. The fold is morally equivalent to the production chain follower but doesn't share code with it. The simulation gap (Case 11) is inherent and explicit.
+
+## Open Questions
+
+1. **`GCompare` for `q`.** `DMap` lookup requires `GCompare q`. Is this acceptable, or should `draftWith` use `Interpret q` instead?
+
+2. **Multi-asset coin selection.** Current `balanceTx` is ADA-only. Pluggable balancer (function record) can swap in `cardano-balance-tx` later.
+
+3. **Epoch boundaries in emulator.** Do we need epoch transitions, reward calculations, stake snapshots? For MPFS testing probably not — slot advancement + UTxO management suffices.

--- a/specs/003-tx-builder-dsl/spec.md
+++ b/specs/003-tx-builder-dsl/spec.md
@@ -1,0 +1,157 @@
+# Feature Specification: Transaction Builder DSL
+
+**Feature Branch**: `003-tx-builder-dsl`
+**Created**: 2026-04-10
+**Status**: Draft
+**Input**: Transaction builder DSL inspired by Scalus for cardano-node-clients
+**Issue**: lambdasistemi/cardano-node-clients#36
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Build a script-spending transaction with typed redeemers (Priority: P1)
+
+A dApp developer building Cardano transactions needs to spend script-protected UTxOs with typed redeemers, attach scripts, and get a balanced transaction with correct execution units — without manually computing redeemer indices, script integrity hashes, or iterating fee estimation.
+
+**Why this priority**: This is the core value proposition. Every MPFS transaction builder (Boot, Update, End, Retract, Reject) performs script spends with redeemers. The manual index computation and integrity hash boilerplate is the primary pain point.
+
+**Independent Test**: Can be tested by building a single script-spend transaction (e.g., the MPFS End transaction) and verifying it produces identical bytes to the current hand-built version.
+
+**Acceptance Scenarios**:
+
+1. **Given** a script UTxO, a typed redeemer value, and a Plutus script, **When** the developer uses `spendScript` + `attachScript` + `build`, **Then** the builder automatically computes the correct spending index, inserts placeholder ExUnits, evaluates the script, patches real ExUnits, computes the script integrity hash, and returns a balanced transaction.
+2. **Given** multiple script inputs with different redeemers, **When** the developer adds them via multiple `spendScript` calls, **Then** each gets the correct index relative to the sorted input set.
+3. **Given** a redeemer type with a `ToData` instance, **When** it is passed to `spendScript`, **Then** it is converted to ledger `Data` internally — the caller never touches raw data encoding.
+
+---
+
+### User Story 2 - Build a minting/burning transaction (Priority: P1)
+
+A developer needs to mint or burn native tokens with a typed minting redeemer, combined with script spends in the same transaction.
+
+**Why this priority**: Minting (Boot) and burning (End) are core MPFS operations. Both combine minting redeemers with spending redeemers in a single transaction.
+
+**Independent Test**: Build the MPFS Boot transaction (mint +1 token) and End transaction (burn -1 token with dual spend+mint redeemers) using the DSL, verify against current output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a policy ID, asset map, and typed minting redeemer, **When** the developer calls `mint`, **Then** the builder assigns the correct minting index and includes the minting redeemer in the witness set.
+2. **Given** a transaction with both spending and minting redeemers, **When** `build` is called, **Then** the script integrity hash covers all redeemers correctly.
+3. **Given** negative quantities in the asset map, **When** `mint` is called, **Then** tokens are burned (the builder does not distinguish mint from burn — sign of quantity determines it).
+
+---
+
+### User Story 3 - Pay to script address with typed inline datum (Priority: P1)
+
+A developer needs to create outputs at script addresses with inline datums derived from typed Haskell values.
+
+**Why this priority**: Every MPFS state and request output carries an inline datum. Currently requires manual encoding and lens setting.
+
+**Independent Test**: Build an output with a typed datum, decode the inline datum from the resulting output, verify roundtrip.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Haskell value with a `ToData` instance, **When** the developer pays to a script address with that datum, **Then** the output has the datum attached as an inline datum.
+2. **Given** an output with a datum, **When** `build` produces the transaction, **Then** the datum is decodable back to the original type.
+
+---
+
+### User Story 4 - Reference inputs, validity intervals, required signers (Priority: P2)
+
+A developer needs to add reference inputs (UTxOs read but not consumed), set time-based validity bounds, and require specific key signatures.
+
+**Why this priority**: Used by Retract (reference input + validity interval + required signer) and Update (validity interval + required signer). Not as painful as redeemer mechanics but still boilerplate.
+
+**Independent Test**: Build a Retract-shaped transaction with reference input, validity bounds, and required signer; verify all fields are set correctly in the resulting transaction body.
+
+**Acceptance Scenarios**:
+
+1. **Given** a UTxO reference, **When** `references` is called, **Then** it appears as a reference input, not a consumed input.
+2. **Given** slot numbers, **When** `validFrom` and `validTo` are called, **Then** the validity interval has both bounds set.
+3. **Given** a key hash, **When** `requireSignature` is called, **Then** it appears in the required signers set.
+
+---
+
+### User Story 5 - Complete: auto-select UTxOs and build (Priority: P2)
+
+A developer wants to build a transaction without manually querying UTxOs and picking fee inputs — the builder should query the provider, select inputs to cover the outputs, add collateral if scripts are present, and balance.
+
+**Why this priority**: Reduces boilerplate for the common case. Currently every builder manually queries wallet UTxOs, sorts by value, picks the largest.
+
+**Independent Test**: Call `complete` with a provider and sponsor address, verify it produces a valid balanced transaction without the caller providing input UTxOs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a provider and sponsor address, **When** `complete` is called, **Then** UTxOs are queried, sufficient inputs are selected, collateral is added if scripts are present, and the transaction is balanced.
+2. **Given** insufficient funds at the sponsor address, **When** `complete` is called, **Then** a clear error is returned indicating the shortfall.
+
+---
+
+### User Story 6 - Draft: assemble without evaluation or balancing (Priority: P3)
+
+A developer wants to inspect the transaction structure before committing to evaluation and balancing — useful for testing, debugging, and ScriptContext derivation.
+
+**Why this priority**: Nice to have for development workflow. Not blocking any current functionality.
+
+**Independent Test**: Call `draft`, inspect the resulting transaction, verify all steps are reflected without script evaluation or fee calculation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a builder with steps, **When** `draft` is called, **Then** a transaction is returned with all inputs, outputs, mints, and witnesses set, but with zero fees and placeholder execution units.
+
+---
+
+### Edge Cases
+
+- What happens when no script inputs exist but `attachScript` was called? Builder should still work — script is included but no redeemers needed.
+- What happens when script evaluation fails? `build` should return the evaluation error with script logs, not a generic failure.
+- What happens when balancing fails due to insufficient funds? Clear error with shortfall amount.
+- What happens when the same input is added twice? Should be idempotent — sets deduplicate.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Builder MUST compute spending redeemer indices automatically from the sorted input set.
+- **FR-002**: Builder MUST compute minting redeemer indices automatically from the sorted policy set.
+- **FR-003**: Builder MUST compute the script integrity hash from protocol parameters and all redeemers.
+- **FR-004**: Builder MUST evaluate scripts via the Provider and patch placeholder execution units with real values.
+- **FR-005**: Builder MUST balance the transaction via the existing balance function after evaluation.
+- **FR-006**: Builder MUST accept typed redeemers (`ToData` constraint) and convert them internally.
+- **FR-007**: Builder MUST accept typed datums (`ToData` constraint) for inline datum outputs.
+- **FR-008**: Builder MUST support all transaction components used by MPFS: script spends, minting, burning, reference inputs, collateral, validity intervals, required signers, inline datums.
+- **FR-009**: `complete` MUST query UTxOs from the provider, perform input selection, and add collateral automatically.
+- **FR-010**: `draft` MUST produce a transaction without evaluation or balancing.
+- **FR-011**: Builder MUST work with ledger types directly — no cardano-api dependency.
+
+### Key Entities
+
+- **TxBuilder**: Immutable accumulator of transaction building steps.
+- **TxStep**: Internal representation of a single building action (spend, send, mint, etc.).
+- **SpendWitness**: How a spent input is authorized — pub-key or script with existential typed redeemer.
+- **MintWitness**: How a minting operation is authorized — script with existential typed redeemer.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All 7 MPFS transaction builders can be rewritten using the DSL with no change in on-chain behavior (identical transaction structure).
+- **SC-002**: Each rewritten builder is at most 50% of the line count of the original.
+- **SC-003**: The shared internal helpers for index computation, integrity hashing, and execution unit patching are no longer needed after migration.
+- **SC-004**: All existing e2e tests pass without modification after the MPFS builders are migrated.
+- **SC-005**: No new dependency on cardano-api is introduced.
+
+## Conformance
+
+Since this DSL replicates the Scalus TxBuilder architecture, we use Scalus test vectors for conformance:
+
+- Extract transaction test cases from the Scalus test suite (TransactionBuilderTests.scala, TxBuilderTest.scala, TxBuilderCompleteTest.scala)
+- For each test: capture the builder steps and the expected serialized transaction (CBOR bytes or equivalent)
+- Our `build` function, given the same inputs and protocol parameters, must produce identical transaction structure
+- Priority test vectors: script spend with redeemer, mint+spend combo, reference input + validity interval, multi-input with per-input redeemers
+
+## Assumptions
+
+- The existing balance function is sufficient for fee balancing — no changes needed.
+- The existing Provider record (with evaluateTx, queryProtocolParams, queryUTxOs) provides everything `build` and `complete` need.
+- All current transactions use PlutusV3 scripts only. The builder targets PlutusV3 initially (can be generalized later).
+- Governance operations (votes, proposals, certificates) are out of scope — no current transaction uses them.

--- a/specs/003-tx-builder-dsl/survey.md
+++ b/specs/003-tx-builder-dsl/survey.md
@@ -1,0 +1,332 @@
+# Cardano Transaction Builder Survey
+
+A cross-language survey of transaction builder patterns across the Cardano ecosystem. Focused on crucial design cases relevant to the `cardano-node-clients` TxBuild DSL.
+
+## Libraries Surveyed
+
+### Haskell / Scala / Java
+| Library | Repo | Status |
+|---------|------|--------|
+| cardano-api | IntersectMBO/cardano-api | Active, canonical |
+| cardano-ledger-api | IntersectMBO/cardano-ledger | Active, low-level |
+| Atlas (GeniusYield) | GeniusYield/atlas | Active, highest-level Haskell |
+| cooked-validators | Tweag/cooked-validators | Active, testing-focused |
+| Convex / sc-tools | j-mueller/sc-tools | Active, combinator-based |
+| Kuber | dQuadrant/kuber | Active, JSON-API-based |
+| cardano-node-emulator | IntersectMBO/cardano-node-emulator | Maintained, slowing |
+| cardano-balance-tx | cardano-foundation/cardano-balance-tx | New (Feb 2026), ledger-native |
+| hydra-cardano-api | cardano-scaling/hydra | Active, Hydra-specific wrapper |
+| cardano-wallet | cardano-foundation/cardano-wallet | Active, wallet-level balancing |
+| Scalus (Scala/JVM) | nau/scalus | Active, most complete builder |
+| cardano-client-lib (Java) | bloxbean/cardano-client-lib | Active, Java production |
+
+### TypeScript/JavaScript
+| Library | Repo | Status |
+|---------|------|--------|
+| Lucid Evolution | anastasia-labs/lucid-evolution | Active, production |
+| Blaze | butaneprotocol/blaze-cardano | Active |
+| Mesh SDK | MeshJS/mesh | Active, multi-backend |
+| cardano-js-sdk | input-output-hk/cardano-js-sdk | Active, IOG/Lace wallet |
+| Buildooor | HarmonicLabs/buildooor | Active, Plu-ts ecosystem |
+| TyphonJS | StricaHQ/typhonjs | Active, Typhon wallet |
+| Helios tx-utils | HeliosLang/tx-utils | Active, modular |
+| Lucid (original) | spacebudz/lucid | Archived |
+
+### PureScript
+| Library | Repo | Status |
+|---------|------|--------|
+| CTL | Plutonomicon/cardano-transaction-lib | Active, constraint-based |
+
+### Rust
+| Library | Repo | Status |
+|---------|------|--------|
+| cardano-serialization-lib (CSL) | Emurgo/cardano-serialization-lib | Production, battle-tested |
+| cardano-multiplatform-lib (CML) | dcSpark/cardano-multiplatform-lib | Production, deferred redeemers |
+| Pallas txbuilder | txpipe/pallas | Early, minimal |
+| Whisky | sidan-lab/whisky | Active, Mesh-compatible |
+
+### Python
+| Library | Repo | Status |
+|---------|------|--------|
+| PyCardano | Python-Cardano/pycardano | Production, most automated |
+
+### Go
+| Library | Repo | Status |
+|---------|------|--------|
+| cardano-go | echovl/cardano-go | Proof-of-concept, no Plutus |
+| go-cardano-serialization | fivebinaries/go-cardano-serialization | Has golden tests |
+| Rum | sidan-lab/rum | Active, Mesh-compatible |
+
+### C#/.NET
+| Library | Repo | Status |
+|---------|------|--------|
+| CardanoSharp | CardanoSharp/cardanosharp-wallet | Production |
+
+---
+
+## Crucial Cases
+
+### Case 1: Redeemer Index Computation
+
+**The problem:** Cardano requires redeemers to carry the index of their target in the *sorted* input or policy set. The index isn't known until all inputs are collected.
+
+**Approaches:**
+
+| Library | Approach |
+|---------|----------|
+| **Scalus** | Computed at build time from sorted input/policy sets |
+| **Lucid Evolution** | Delegated to CML which handles it internally |
+| **Blaze** | Manual `insertSorted` + bump existing indices at insertion time |
+| **CSL/CML** | Auto-computed from `TxInputsBuilder`'s sorted structure |
+| **PyCardano** | `_set_redeemer_index()` post-hoc before build |
+| **CardanoSharp** | `SetIndex(tx, scriptInput)` sorts and finds position |
+| **Pallas** | Computed at build time from sorted `HashMap` keys |
+| **MPFS (current)** | Manual `spendingIndex` per input |
+| **Our DSL** | Auto-computed by interpreter + returned via `WithFinalTx` fixpoint |
+
+**Crucial insight:** Every library does this automatically except raw ledger APIs. The DSL must absorb this completely — the user should never think about indices.
+
+### Case 2: Fee-Dependent Outputs (Conservation)
+
+**The problem:** Some transactions have outputs whose values depend on the final fee. Example: MPFS refund outputs where `refund = totalInput - fee - tips`. The fee depends on tx size, which depends on outputs, which depend on fee.
+
+**Approaches:**
+
+| Library | Approach |
+|---------|----------|
+| **Scalus** | Iterative balancing loop (max 20 iterations) |
+| **Blaze** | Iterative loop (max 10 iterations) until `lastFee === fee` |
+| **CSL/CML** | Single-pass — no support for fee-dependent outputs |
+| **PyCardano** | Two-pass: estimate fee → compute changes → precise fee |
+| **Lucid Evolution** | Two-pass via CML |
+| **cardano-js-sdk** | Input selection constraints loop |
+| **MPFS onchain#37** | Custom `balanceFeeLoop` with `mkOutputs(fee)` callback |
+| **Our DSL** | `WithFinalTx` reads fee from fixpoint, build loop converges |
+
+**Crucial insight:** This is rare but critical. Most libraries don't support it. Scalus and Blaze iterate. Our `WithFinalTx` is the most general — the user writes `fee <- withFinalTx (^. feeTxBodyL)` and computes outputs from it. The loop handles convergence.
+
+### Case 3: Deferred Redeemer (Value Depends on Final Tx)
+
+**The problem:** A redeemer's Data value depends on the assembled transaction — e.g., "the number of inputs" or "the index of a specific output."
+
+**Approaches:**
+
+| Library | Approach |
+|---------|----------|
+| **Scalus** | `redeemerBuilder: Transaction => Data` — resolved after assembly, before balancing |
+| **Lucid Evolution** | `RedeemerBuilder { makeRedeemer: (inputIndices: bigint[]) => Redeemer }` — resolved after coin selection |
+| **Blaze** | `preCompleteHooks` — callbacks before finalization |
+| **cardano-js-sdk** | `customize(cb)` — modify body before input selection |
+| **CSL/CML** | Not supported |
+| **PyCardano** | Not supported |
+| **CardanoSharp** | Not supported |
+| **Our DSL** | `WithFinalTx :: (Tx ConwayEra -> a) -> TxInstr q a` — general, returns any type, resolved by fixpoint |
+
+**All known deferred patterns across the ecosystem:**
+
+| Library | Mechanism | What it sees | What it produces |
+|---------|-----------|-------------|-----------------|
+| Scalus | `redeemerBuilder: Transaction => Data` | Final Tx | Data only |
+| Scalus | `datumBuilder: Transaction => Data` | Final Tx | Data only |
+| Lucid Evolution | `RedeemerBuilder { makeRedeemer(indices) }` | Input indices after coin selection | Redeemer CBOR |
+| Blaze | `addPreCompleteHook(tx => Promise<void>)` | Mutable builder before finalization | Side effects on builder |
+| cardano-js-sdk | `customize(cb)` | Tx body before input selection | Modified tx body |
+| cardano-js-sdk | Lazy `build()` | Everything deferred | `UnwitnessedTx` |
+| CML | `build_for_evaluation()` + `set_exunits()` | Draft tx | ExUnits patching |
+| Buildooor | `CanResolveToUTxO` | UTxO resolution at build time | Resolved UTxOs |
+| CTL | Constraint-based balancing | Constraints, not concrete steps | Balanced tx |
+| **Our DSL** | `WithFinalTx :: (Tx -> a) -> TxInstr q a` | Final balanced Tx (fixpoint) | **Any type** (bound via >>=) |
+| **Our DSL** | `Ctx :: q a -> TxInstr q a` | Pluggable context | **Any type** (user-defined `q`) |
+
+**Crucial insight:** Every library has invented its own ad-hoc deferred mechanism. None of them are general. Ours is the only one where (a) the deferred value can be any type, (b) it's bound via monadic `>>=`, and (c) the context is pluggable via a type parameter.
+
+### Case 4: Deferred UTxO Queries (Steps Depend on Chain State)
+
+**The problem:** The transaction steps themselves depend on chain state that's only available at submission time — e.g., "find the UTxO with my beacon token, decode its state, decide what to spend."
+
+**Approaches:**
+
+| Library | Approach |
+|---------|----------|
+| **Scalus** | `Deferred(query: UtxoQuery, resolve: Utxos => Seq[Step])` with declarative query DSL |
+| **PyCardano** | `add_input_address(addr)` defers UTxO selection to build time |
+| **cardano-js-sdk** | Lazy `build()` defers everything |
+| **Lucid Evolution** | No — must query before building |
+| **Blaze** | No — must query before building |
+| **CSL/CML** | No |
+| **Our DSL** | `Ctx :: q a -> TxInstr q a` — pluggable context, user defines query GADT |
+
+**Crucial insight:** Only Scalus has a structured deferred query system. Our `Ctx` is more general — the query type `q` is user-defined, and the interpreter is pluggable (`DMap q Identity` for tests, `forall x. q x -> IO x` for production). This enables composable protocol interactions (Scalus's UtxoCell pattern).
+
+### Case 5: Datum Handling (Inline vs Hash)
+
+**The problem:** Outputs can carry data as inline datums (V2+) or datum hashes (V1). Script spends may need the datum provided in the witness set (hash case) or can read it from the UTxO (inline case).
+
+**Approaches:**
+
+| Library | How outputs carry data | How script spends resolve data |
+|---------|----------------------|-------------------------------|
+| **Scalus** | `payTo(addr, value, datum)` — inline. `payTo(addr, value, datumHash)` — hash | Auto from inline; manual `attach()` for hash |
+| **Lucid Evolution** | Three modes: `hash`, `asHash`, `inline` via `OutputDatum` | Auto-detect: inline → `plutus_script_inline_datum`; hash → needs explicit datum |
+| **Blaze** | `lockAssets(addr, value, datum)` — always inline | Auto from inline; pass `unhashDatum` for hash case |
+| **PyCardano** | `TransactionOutput(datum=)` inline, `datum_hash=` for hash | `add_script_input(datum=)` auto-hashes |
+| **CSL/CML** | `OutputDatum` enum: inline or hash | Part of `PlutusWitness` |
+| **CardanoSharp** | `DatumOption` on `AddOutput` | Manual datum witness |
+| **MPFS** | Always inline (`mkInlineDatum`) | Inline only, `TxDats mempty` |
+| **Our DSL** | `payTo'(addr, value, datum)` — typed, inline. `output` for raw | Inline only (MPFS scope). Extensible later. |
+
+**Crucial insight:** MPFS only uses inline datums. Our DSL handles this via `ToData` existential in `payTo'`. Datum hash support can be added later if needed.
+
+### Case 6: Coin Selection Algorithms
+
+**The problem:** Choose UTxOs from a wallet to cover the transaction's required value (outputs + fee + min-UTxO for change).
+
+**Approaches:**
+
+| Library | Algorithms |
+|---------|-----------|
+| **CSL/CML** | LargestFirst, RandomImprove, LargestFirstMultiAsset, RandomImproveMultiAsset (CIP-2) |
+| **PyCardano** | LargestFirst + RandomImproveMultiAsset (dual fallback) |
+| **Atlas** | Adapted from cardano-wallet |
+| **cardano-balance-tx** | From cardano-wallet (standalone) |
+| **Lucid Evolution** | Delegated to CML |
+| **Blaze** | Pluggable `useCoinSelector(selector)` |
+| **CardanoSharp** | LargestFirst + RandomImprove with pluggable strategy |
+| **Scalus** | In `complete()`, largest UTxOs first |
+| **Pallas** | None (manual) |
+| **cardano-go** | None (manual) |
+| **Our DSL** | Delegated to existing `balanceTx` (largest-first ADA-only) |
+
+**Crucial insight:** Coin selection is a solved problem (CIP-2). Our existing `balanceTx` handles it for the ADA-only case. Multi-asset coin selection is out of scope unless MPFS needs it.
+
+### Case 7: Script Evaluation (ExUnits)
+
+**The problem:** Plutus scripts need execution budgets (CPU + memory units) set in their redeemers. These are only known after running the scripts against the assembled transaction.
+
+**Approaches:**
+
+| Library | Approach |
+|---------|----------|
+| **Scalus** | Built-in CEK machine (same as cardano-node) |
+| **CML** | Two-phase: `build_for_evaluation()` → external eval → `set_exunits()` → `build()` |
+| **CSL** | External evaluator |
+| **Lucid Evolution** | Local UPLC evaluation via `@lucid-evolution/uplc` |
+| **Blaze** | Pluggable `useEvaluator(evaluator)` |
+| **PyCardano** | Auto via `ChainContext.evaluate_tx()` (delegates to node/Blockfrost) |
+| **cardano-js-sdk** | Pluggable `TxEvaluator` interface |
+| **MPFS** | Via Provider's `evaluateTx` (node socket) |
+| **Our DSL** | Via evaluator function parameter to `build` |
+
+**Crucial insight:** ExUnit evaluation is always external to the builder. The builder needs: (1) assemble with placeholders, (2) call evaluator, (3) patch results. Our `build` loop does this. CML's two-phase pattern is closest to our `draft` + `build` separation.
+
+### Case 8: Composability (Multiple Protocols in One Tx)
+
+**The problem:** Compose interactions with multiple independent protocols in a single transaction. Each protocol knows its own UTxO patterns but shouldn't know about the others.
+
+**Approaches:**
+
+| Library | Approach |
+|---------|----------|
+| **Scalus** | `UtxoCellDef.apply(action)` → `Deferred` step encapsulates query + resolver per protocol |
+| **Blaze** | `preCompleteHooks` — multiple hooks can modify the tx independently |
+| **Atlas** | `GYTxBuilderMonad` — monadic composition with `buildTxBodyParallel` for independent tx chains |
+| **cardano-js-sdk** | `customize(cb)` — single callback, but composable via function composition |
+| **Most others** | Manual — caller must orchestrate all protocol interactions |
+| **Our DSL** | `Ctx :: q a -> TxInstr q a` — each protocol defines its query GADT, composed via sum type or extensible effects |
+
+**Crucial insight:** Scalus's UtxoCell pattern is the gold standard for composable protocol interactions. Our `Ctx` instruction with pluggable `q` enables the same pattern. The operational monad's bind gives us natural sequencing that Scalus achieves through `Deferred` step resolution.
+
+### Case 9: Pay vs Lock Semantic Safety
+
+**The problem:** Paying to a script address without a datum is almost always a bug (funds locked forever). Some libraries enforce this at the API level.
+
+**Approaches:**
+
+| Library | Approach |
+|---------|----------|
+| **Blaze** | `payAssets` (asserts payment address) vs `lockAssets` (asserts script address + requires datum) |
+| **Lucid Evolution** | `pay.ToAddress` vs `pay.ToContract` (soft distinction) |
+| **Scalus** | No enforcement — `payTo(scriptAddress, value)` without datum is allowed |
+| **PyCardano** | No enforcement |
+| **CSL/CML** | No enforcement |
+| **Our DSL** | No enforcement currently. Could add `lockAt` that requires `ToData d => d` |
+
+**Crucial insight:** Blaze's approach is the cleanest. Worth considering for our DSL as a future addition, but not blocking — MPFS always uses `payTo'` with datums for script outputs.
+
+### Case 10: Fee Estimation Method
+
+**The problem:** Estimate the transaction fee before the final transaction is known (chicken-and-egg: fee affects size, size affects fee).
+
+**Approaches:**
+
+| Method | Used by |
+|--------|---------|
+| **Fake-witness serialization** | CSL, CML — build full tx with fake witnesses of correct size, serialize, compute fee from size |
+| **Iterative convergence** | Scalus (20 iter), Blaze (10 iter), our DSL (20 iter) — loop until fee stabilizes |
+| **Two-pass** | PyCardano, Lucid — estimate → build → precise fee |
+| **estimateMinFeeTx** | cardano-ledger-api — single-pass with witness count |
+| **Manual** | Pallas, CardanoSharp, cardano-go |
+| **Our existing balanceTx** | Uses `estimateMinFeeTx` iteratively (max 10 rounds) |
+
+**Crucial insight:** Our `balanceTx` already handles this. The `build` loop adds another layer of iteration for `WithFinalTx` convergence. Two nested loops — inner (fee convergence in `balanceTx`) and outer (`WithFinalTx` convergence in `build`).
+
+---
+
+## Full Feature Matrix (25 libraries)
+
+| # | Library | Lang | Script | Mint | Datum | Redeemer | Fee | CoinSel | Balance | Deferred |
+|---|---------|------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| 1 | cardano-api | Haskell | Y | Y | Y | Y | Y | - | Y | experimental |
+| 2 | Atlas | Haskell | Y | Y | Y | Y | Y | Y | Y | skeleton |
+| 3 | cooked-validators | Haskell | Y | Y | Y | Y | Y | - | Y | skeleton |
+| 4 | Convex/sc-tools | Haskell | Y | Y | Y | Y | Y | Y | Y | - |
+| 5 | Scalus | Scala | Y | Y | Y | Y | Y | Y | Y | 3 mechanisms |
+| 6 | cardano-client-lib | Java | Y | Y | Y | Y | Y | Y | Y | - |
+| 7 | CSL | Rust/WASM | Y | Y | Y | Y | Y | Y | Y | - |
+| 8 | CML | Rust/WASM | Y | Y | Y | Y | Y | Y | Y | 2-phase eval |
+| 9 | Whisky | Rust/WASM | Y | Y | Y | Y | Y | Y | Y | - |
+| 10 | Lucid Evolution | TS | Y | Y | Y | Y | Y | Y | Y | RedeemerBuilder |
+| 11 | Blaze | TS | Y | Y | Y | Y | Y | Y | Y | preCompleteHooks |
+| 12 | Mesh SDK | TS | Y | Y | Y | Y | Y | Y | Y | - |
+| 13 | cardano-js-sdk | TS | Y | Y | Y | Y | Y | Y | Y | lazy build + customize |
+| 14 | Buildooor | TS | Y | Y | Y | Y | Y | Y | Y | deferred resolve |
+| 15 | CTL | PureScript | Y | Y | Y | Y | Y | Y | Y | constraints |
+| 16 | PyCardano | Python | Y | Y | Y | Y | Y | Y | Y | auto-eval |
+| 17 | CardanoSharp | C# | Y | Y | Y | Y | manual | Y | - | - |
+| 18 | Pallas | Rust | Y | Y | Y | Y | manual | - | - | - |
+| 19 | Rum | Go | Y | Y | Y | Y | - | - | - | - |
+| 20 | cardano-go | Go | Y | Y | - | - | Y | - | basic | - |
+| 21 | Helios tx-utils | JS | Y | Y | Y | Y | Y | Y | Y | - |
+| 22 | TyphonJS | TS | Y | Y | Y | Y | Y | - | - | - |
+| 23 | Kuber | Haskell | Y | Y | Y | Y | Y | Y | Y | - |
+| 24 | hydra-cardano-api | Haskell | Y | Y | Y | Y | Y | - | Y | - |
+| 25 | **Our DSL** | Haskell | Y | Y | Y | Y | Y | Y | Y | **3 unified** |
+
+### Case 11: The Simulation Gap (Derived Application State)
+
+**Problem:** Real applications maintain derived state (databases, indexes, caches) updated asynchronously by a chain follower. Simulators provide raw `LedgerState` / UTxO queries but don't update the application's derived state after each simulated transaction. Every builder that claims "test without a node" hits this: the context queries in simulation don't go through the same code path as production.
+
+**Who is affected:** Every tx builder with simulation support — Scalus Emulator, cardano-node-emulator, PyCardano ChainContext, Blaze, Lucid. None document this gap.
+
+**Scalus UtxoCell** hides it best: the cell's state IS the inline datum on the UTxO, so raw UTxO queries = application state queries. But this only works when all state lives on-chain as inline datums.
+
+**MPFS example:** Production queries a CSMT-UTxO database (RocksDB, updated by chain follower). Simulation queries raw `LedgerState` UTxOs. The filtering logic must exist in both — or be factored out:
+
+```
+classifyTx :: Tx -> [StateUpdate]     -- pure, shared
+applyUpdates :: Storage -> [StateUpdate] -> IO ()     -- production
+applyUpdates :: SimState -> [StateUpdate] -> SimState  -- simulation
+```
+
+**What our DSL does:** Makes the gap explicit via `Ctx q`. Same `q` GADT, different interpreters. The simulation interpreter is knowingly a simplification. Testing the full chain-sync → derived-state → query → build → submit → sync cycle requires a devnet. The builder should not pretend simulation replaces integration testing.
+
+## Summary: What Our DSL Uniquely Provides
+
+| Capability | Closest prior art | Our advantage |
+|-----------|------------------|---------------|
+| Operational monad builder | None (all use fluent/mutable) | Bind for forward values, instructions as data |
+| `WithFinalTx` fixpoint | Scalus `redeemerBuilder`, Lucid `RedeemerBuilder` | Fully general — any type, not just `Data` or indices |
+| Pluggable context `q` | Scalus `Deferred(query, resolve)` | Type-safe queries with `GCompare`, `DMap` for tests |
+| Position-returning instructions | None | `spend` returns `Word32`, resolved by fixpoint |
+| Fee-dependent outputs | Scalus iterative loop, MPFS `balanceFeeLoop` | Natural via `withFinalTx` — no special callback API |
+| Composable protocol interactions | Scalus UtxoCellDef | `Ctx` + query GADT sum types |

--- a/specs/003-tx-builder-dsl/tasks.md
+++ b/specs/003-tx-builder-dsl/tasks.md
@@ -1,191 +1,123 @@
 # Tasks: Transaction Builder DSL
 
 **Branch**: `003-tx-builder-dsl`
-**Generated**: 2026-04-10
-**Spec**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md)
+**Updated**: 2026-04-11
+**Spec**: [spec-design.md](spec-design.md)
 
-Each task is a vertical slice: types + logic + test in one commit.
-
----
-
-## US1: Script-spending transactions with typed redeemers
-
-### Task 1.1: Core types and empty builder
-**Story**: US1 | **Priority**: P1 | **Depends**: none
-
-Define `TxBuilder`, `TxStep`, `SpendWitness`, `MintWitness` types and the `txBuilder` empty constructor in `Cardano.Node.Client.TxBuild`.
-
-**Acceptance**: Module compiles, `txBuilder` returns an empty builder, types are exported.
-
-**Commit scope**: `lib/Cardano/Node/Client/TxBuild.hs` (new file)
+Each slice is one commit: types + logic + interpreter + test.
 
 ---
 
-### Task 1.2: spend and spendScript combinators
-**Story**: US1 | **Priority**: P1 | **Depends**: 1.1
+## Slice 1: Simple pub-key spend + draft
 
-Implement `spend` (pub-key) and `spendScript` (typed redeemer via existential `ToData`) combinators that append `Spend` steps to the builder.
+GADT with `Spend`, `Send`, `Collateral`, `Peek`. Types: `Convergence`, `Check`, `LedgerCheck`, `SpendWitness`, `Interpret`, `InterpretIO`. Smart constructors: `spend` (returns `Word32` via `Peek`), `payTo`, `collateral`. `draft` interpreter (pure, `q = Void, e = Void`).
 
-**Acceptance**: Builder accumulates spend steps. Unit test: add two spends, verify step list contains both with correct witnesses.
+**Test**: simple transfer — verify inputs/outputs in assembled Tx, `spend` returns correct index.
 
-**Commit scope**: `TxBuild.hs` + `test/Cardano/Node/Client/TxBuildSpec.hs` (new file)
-
----
-
-### Task 1.3: draft — assemble without evaluation
-**Story**: US1, US6 | **Priority**: P1 | **Depends**: 1.2
-
-Implement `draft` that converts accumulated steps into a `Tx ConwayEra`:
-- Collect all `Spend` steps into `inputsTxBodyL`
-- Compute spending indices from sorted input set
-- Build `Redeemers` map with `ConwaySpending (AsIx ix)` + placeholder ExUnits
-- Attach scripts from builder's script map
-- Compute script integrity hash
-
-This is the assembly core without evaluation or balancing.
-
-**Acceptance**: `draft` on a builder with `spendScript` produces a `Tx` with correct redeemer indices and integrity hash. Test with known inputs, verify index assignment matches `spendingIndex` from Internal.hs.
-
-**Commit scope**: `lib/Cardano/Node/Client/TxBuild/Build.hs` (new file) + test
+**Depends**: none
 
 ---
 
-### Task 1.4: build — evaluate + patch + balance
-**Story**: US1 | **Priority**: P1 | **Depends**: 1.3
+## Slice 2: Script spend + mint + redeemer indices
 
-Implement `build` that:
-1. Calls `draft` to get the unbalanced tx
-2. Evaluates scripts via Provider's `evaluateTx`
-3. Patches ExUnits in redeemers
-4. Recomputes script integrity hash
-5. Calls existing `balanceTx`
+Add `MintI`, `AttachScript`, `ReqSignature` to GADT. `MintWitness` existential. Smart constructors: `spendScript`, `mint`, `attachScript`, `requireSignature`. `draft` computes spending + minting redeemer indices automatically.
 
-This absorbs the entire `evaluateAndBalance` function from MPFS Internal.hs.
+**Test**: Boot-shaped tx (spend + mint +1), End-shaped tx (spend + mint -1 + dual redeemers). Verify redeemer indices match sorted position.
 
-**Acceptance**: `build` with a mock Provider returning known ExUnits produces a balanced tx with patched redeemers. Integration test: build an End-shaped transaction, compare structure to hand-built version.
-
-**Commit scope**: `Build.hs` + test
+**Depends**: Slice 1
 
 ---
 
-### Task 1.5: attachScript combinator
-**Story**: US1 | **Priority**: P1 | **Depends**: 1.1
+## Slice 3: Peek convergence + build loop
 
-Implement `attachScript` that adds a script to the builder's script map (keyed by ScriptHash).
+`build` interpreter: fixpoint iteration over `Peek` nodes, script evaluation via evaluator function, ExUnits patching, recompute integrity hash, fee balancing via `balanceTx`. Convergence: iterate while any `Peek` returns `Iterate`, stop when all `Ok` and Tx body stable.
 
-**Acceptance**: Attached scripts appear in `witsTxL . scriptTxWitsL` after `draft`.
+**Test**: fee-dependent outputs — refund = totalIn - fee - tips. Verify `Peek` reads fee, outputs converge in 2-3 iterations. (Conservation case from cardano-mpfs-onchain#37.)
 
-**Commit scope**: `TxBuild.hs` + test
-
----
-
-## US2: Minting/burning transactions
-
-### Task 2.1: mint combinator
-**Story**: US2 | **Priority**: P1 | **Depends**: 1.3
-
-Implement `mint` combinator that appends `Mint` steps. `draft` must:
-- Collect all Mint steps into `mintTxBodyL`
-- Compute minting indices from sorted policy set
-- Build `ConwayMinting (AsIx ix)` redeemer entries
-
-Positive quantities mint, negative burn. Unified API following Scalus.
-
-**Acceptance**: Builder with `spendScript` + `mint` produces a `Tx` with both spending and minting redeemers at correct indices. Test with Boot-shaped (mint +1) and End-shaped (mint -1 + spend) transactions.
-
-**Commit scope**: `TxBuild.hs` + `Build.hs` + test
+**Depends**: Slice 2
 
 ---
 
-## US3: Typed inline datums
+## Slice 4: Ctx + pluggable queries
 
-### Task 3.1: payTo and payTo' combinators
-**Story**: US3 | **Priority**: P1 | **Depends**: 1.1
+Add `Ctx` instruction. `ctx` smart constructor. `build` takes `InterpretIO q`. `draftWith` takes `Interpret q` (or `DMap q Identity`).
 
-Implement `payTo` (address + value, no datum) and `payTo'` (address + value + typed datum with `ToData` constraint → inline datum). Also `output` for raw `TxOut` passthrough.
+**Test**: define `data TestQ a where GetValue :: TestQ Int`. Use `ctx GetValue` in a builder, interpret with `Interpret TestQ`. Verify the value flows through bind into a subsequent step.
 
-**Acceptance**: `payTo'` produces output with inline `Datum` constructed via `dataToBinaryData . Data . toPlcData`. Roundtrip test: encode datum, extract from TxOut, decode via `FromData`, compare.
-
-**Commit scope**: `TxBuild.hs` + test
+**Depends**: Slice 3
 
 ---
 
-## US4: Reference inputs, validity, required signers
+## Slice 5: Valid + library checkers
 
-### Task 4.1: references, collaterals, validFrom, validTo, requireSignature
-**Story**: US4 | **Priority**: P2 | **Depends**: 1.3
+Add `Valid` instruction. `valid` smart constructor. `Check e = Pass | LedgerFail LedgerCheck | CustomFail e`. Library checkers: `checkMinUtxo`, `checkTxSize`. Interpreter runs checks after `Peek` convergence. `build` returns `Left (ChecksFailed [Check e])` on failure.
 
-Implement remaining combinators:
-- `references` → `referenceInputsTxBodyL`
-- `collaterals` → `collateralInputsTxBodyL`
-- `validFrom` → `ValidityInterval` lower bound
-- `validTo` → `ValidityInterval` upper bound
-- `requireSignature` / `requireSignatures` → `reqSignerHashesTxBodyL`
+**Test**: output below min UTxO → `LedgerFail (MinUtxoViolation ...)`. Custom check → `CustomFail MyErr`. All-pass → `Right tx`.
 
-**Acceptance**: `draft` on a Retract-shaped builder (reference input + validity + required signer) has all fields set correctly. Unit tests for each combinator.
-
-**Commit scope**: `TxBuild.hs` + `Build.hs` + test
+**Depends**: Slice 3
 
 ---
 
-## US5: Auto-complete
+## Slice 6: Reference inputs + validity intervals
 
-### Task 5.1: complete — query + select + build
-**Story**: US5 | **Priority**: P2 | **Depends**: 1.4
+Add `Reference`, `SetValidFrom`, `SetValidTo`. Smart constructors: `reference`, `validFrom`, `validTo`.
 
-Implement `complete` that:
-1. Queries UTxOs from Provider at sponsor address
-2. Selects inputs covering outputs + estimated fees (largest-first)
-3. Adds collateral if any script steps present
-4. Calls `build`
+**Test**: Retract-shaped tx — reference input (not consumed), validity window (lower + upper), required signer. Verify fields in assembled TxBody.
 
-**Acceptance**: `complete` with a mock Provider returning known UTxOs produces a balanced tx. Error case: insufficient funds returns clear error.
-
-**Commit scope**: `Build.hs` + test
+**Depends**: Slice 1
 
 ---
 
-## Conformance: Scalus test vectors
+## Slice 7: MPFS Boot migration
 
-### Task 6.1: Extract Scalus test vectors
-**Story**: Conformance | **Priority**: P2 | **Depends**: 1.4, 2.1
+In `cardano-mpfs-offchain`: define `CageQ` and `CageErr`. Rewrite `bootTokenImpl` as `TxBuild CageQ CageErr ()`. Production `InterpretIO CageQ` wrapping existing Provider. Test `Interpret CageQ` with fixture data.
 
-Extract test cases from Scalus TransactionBuilderTests.scala:
-- Simple spend + payTo
-- Script spend with redeemer
-- Mint + spend combo
-- Reference input + validity interval
-- Multi-input with per-input redeemers
+**Test**: e2e Boot test passes with the DSL builder.
 
-For each: capture builder steps, protocol params, UTxO set, and expected transaction CBOR or structure.
-
-**Acceptance**: Test vectors documented as Haskell test cases. Our `build`/`draft` produces matching transaction structure.
-
-**Commit scope**: `test/Cardano/Node/Client/TxBuild/ConformanceSpec.hs` (new file)
+**Depends**: Slice 4
 
 ---
 
-## Dependency Graph
+## Slice 8: MPFS Update/Reject (conservation)
+
+Rewrite `updateTokenImpl` and `rejectRequestsImpl` using `peek` for fee-dependent refunds. The `balanceFeeLoop` + `mkOutputs` callback pattern is replaced by `peek` + natural convergence.
+
+**Test**: e2e Update and Reject tests pass. Delete `balanceFeeLoop` from `Balance.hs`.
+
+**Depends**: Slice 7, Slice 3
+
+---
+
+## Slice 9: Remaining MPFS migrations
+
+Rewrite End, Retract, Request builders. Delete `evaluateAndBalance`, `spendingIndex`, `computeScriptIntegrity`, `placeholderExUnits` from Internal.hs. All e2e tests pass.
+
+**Test**: full e2e cage flow (Boot → Request → Update → Retract → Reject → End).
+
+**Depends**: Slice 8, Slice 6
+
+---
+
+## Dependency graph
 
 ```
-1.1 ──→ 1.2 ──→ 1.3 ──→ 1.4 ──→ 5.1
-  │               │        │
-  ├──→ 1.5        ├──→ 2.1 ├──→ 6.1
-  │               │
-  ├──→ 3.1        └──→ 4.1
+Slice 1 → Slice 2 → Slice 3 → Slice 4 → Slice 7 → Slice 8 → Slice 9
+              ↓           ↓                              ↑
+          Slice 6     Slice 5                             |
+              ↓                                           |
+              └───────────────────────────────────────────┘
 ```
 
-## Task Summary
+## Summary
 
-| Task | Description | Priority | Depends |
-|------|------------|----------|---------|
-| 1.1  | Core types + empty builder | P1 | — |
-| 1.2  | spend/spendScript combinators | P1 | 1.1 |
-| 1.3  | draft (assembly without eval) | P1 | 1.2 |
-| 1.4  | build (evaluate + patch + balance) | P1 | 1.3 |
-| 1.5  | attachScript combinator | P1 | 1.1 |
-| 2.1  | mint combinator (mint+burn) | P1 | 1.3 |
-| 3.1  | payTo/payTo' with typed datums | P1 | 1.1 |
-| 4.1  | references/collaterals/validity/signers | P2 | 1.3 |
-| 5.1  | complete (auto-select + build) | P2 | 1.4 |
-| 6.1  | Scalus conformance test vectors | P2 | 1.4, 2.1 |
+| Slice | What | Depends |
+|-------|------|---------|
+| 1 | Pub-key spend + payTo + draft | — |
+| 2 | Script spend + mint + redeemer indices | 1 |
+| 3 | Peek convergence + build loop | 2 |
+| 4 | Ctx + pluggable queries | 3 |
+| 5 | Valid + library checkers | 3 |
+| 6 | Reference inputs + validity intervals | 1 |
+| 7 | MPFS Boot migration | 4 |
+| 8 | MPFS Update/Reject (conservation) | 7, 3 |
+| 9 | Remaining MPFS + cleanup | 8, 6 |

--- a/specs/003-tx-builder-dsl/tasks.md
+++ b/specs/003-tx-builder-dsl/tasks.md
@@ -1,0 +1,191 @@
+# Tasks: Transaction Builder DSL
+
+**Branch**: `003-tx-builder-dsl`
+**Generated**: 2026-04-10
+**Spec**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md)
+
+Each task is a vertical slice: types + logic + test in one commit.
+
+---
+
+## US1: Script-spending transactions with typed redeemers
+
+### Task 1.1: Core types and empty builder
+**Story**: US1 | **Priority**: P1 | **Depends**: none
+
+Define `TxBuilder`, `TxStep`, `SpendWitness`, `MintWitness` types and the `txBuilder` empty constructor in `Cardano.Node.Client.TxBuild`.
+
+**Acceptance**: Module compiles, `txBuilder` returns an empty builder, types are exported.
+
+**Commit scope**: `lib/Cardano/Node/Client/TxBuild.hs` (new file)
+
+---
+
+### Task 1.2: spend and spendScript combinators
+**Story**: US1 | **Priority**: P1 | **Depends**: 1.1
+
+Implement `spend` (pub-key) and `spendScript` (typed redeemer via existential `ToData`) combinators that append `Spend` steps to the builder.
+
+**Acceptance**: Builder accumulates spend steps. Unit test: add two spends, verify step list contains both with correct witnesses.
+
+**Commit scope**: `TxBuild.hs` + `test/Cardano/Node/Client/TxBuildSpec.hs` (new file)
+
+---
+
+### Task 1.3: draft — assemble without evaluation
+**Story**: US1, US6 | **Priority**: P1 | **Depends**: 1.2
+
+Implement `draft` that converts accumulated steps into a `Tx ConwayEra`:
+- Collect all `Spend` steps into `inputsTxBodyL`
+- Compute spending indices from sorted input set
+- Build `Redeemers` map with `ConwaySpending (AsIx ix)` + placeholder ExUnits
+- Attach scripts from builder's script map
+- Compute script integrity hash
+
+This is the assembly core without evaluation or balancing.
+
+**Acceptance**: `draft` on a builder with `spendScript` produces a `Tx` with correct redeemer indices and integrity hash. Test with known inputs, verify index assignment matches `spendingIndex` from Internal.hs.
+
+**Commit scope**: `lib/Cardano/Node/Client/TxBuild/Build.hs` (new file) + test
+
+---
+
+### Task 1.4: build — evaluate + patch + balance
+**Story**: US1 | **Priority**: P1 | **Depends**: 1.3
+
+Implement `build` that:
+1. Calls `draft` to get the unbalanced tx
+2. Evaluates scripts via Provider's `evaluateTx`
+3. Patches ExUnits in redeemers
+4. Recomputes script integrity hash
+5. Calls existing `balanceTx`
+
+This absorbs the entire `evaluateAndBalance` function from MPFS Internal.hs.
+
+**Acceptance**: `build` with a mock Provider returning known ExUnits produces a balanced tx with patched redeemers. Integration test: build an End-shaped transaction, compare structure to hand-built version.
+
+**Commit scope**: `Build.hs` + test
+
+---
+
+### Task 1.5: attachScript combinator
+**Story**: US1 | **Priority**: P1 | **Depends**: 1.1
+
+Implement `attachScript` that adds a script to the builder's script map (keyed by ScriptHash).
+
+**Acceptance**: Attached scripts appear in `witsTxL . scriptTxWitsL` after `draft`.
+
+**Commit scope**: `TxBuild.hs` + test
+
+---
+
+## US2: Minting/burning transactions
+
+### Task 2.1: mint combinator
+**Story**: US2 | **Priority**: P1 | **Depends**: 1.3
+
+Implement `mint` combinator that appends `Mint` steps. `draft` must:
+- Collect all Mint steps into `mintTxBodyL`
+- Compute minting indices from sorted policy set
+- Build `ConwayMinting (AsIx ix)` redeemer entries
+
+Positive quantities mint, negative burn. Unified API following Scalus.
+
+**Acceptance**: Builder with `spendScript` + `mint` produces a `Tx` with both spending and minting redeemers at correct indices. Test with Boot-shaped (mint +1) and End-shaped (mint -1 + spend) transactions.
+
+**Commit scope**: `TxBuild.hs` + `Build.hs` + test
+
+---
+
+## US3: Typed inline datums
+
+### Task 3.1: payTo and payTo' combinators
+**Story**: US3 | **Priority**: P1 | **Depends**: 1.1
+
+Implement `payTo` (address + value, no datum) and `payTo'` (address + value + typed datum with `ToData` constraint → inline datum). Also `output` for raw `TxOut` passthrough.
+
+**Acceptance**: `payTo'` produces output with inline `Datum` constructed via `dataToBinaryData . Data . toPlcData`. Roundtrip test: encode datum, extract from TxOut, decode via `FromData`, compare.
+
+**Commit scope**: `TxBuild.hs` + test
+
+---
+
+## US4: Reference inputs, validity, required signers
+
+### Task 4.1: references, collaterals, validFrom, validTo, requireSignature
+**Story**: US4 | **Priority**: P2 | **Depends**: 1.3
+
+Implement remaining combinators:
+- `references` → `referenceInputsTxBodyL`
+- `collaterals` → `collateralInputsTxBodyL`
+- `validFrom` → `ValidityInterval` lower bound
+- `validTo` → `ValidityInterval` upper bound
+- `requireSignature` / `requireSignatures` → `reqSignerHashesTxBodyL`
+
+**Acceptance**: `draft` on a Retract-shaped builder (reference input + validity + required signer) has all fields set correctly. Unit tests for each combinator.
+
+**Commit scope**: `TxBuild.hs` + `Build.hs` + test
+
+---
+
+## US5: Auto-complete
+
+### Task 5.1: complete — query + select + build
+**Story**: US5 | **Priority**: P2 | **Depends**: 1.4
+
+Implement `complete` that:
+1. Queries UTxOs from Provider at sponsor address
+2. Selects inputs covering outputs + estimated fees (largest-first)
+3. Adds collateral if any script steps present
+4. Calls `build`
+
+**Acceptance**: `complete` with a mock Provider returning known UTxOs produces a balanced tx. Error case: insufficient funds returns clear error.
+
+**Commit scope**: `Build.hs` + test
+
+---
+
+## Conformance: Scalus test vectors
+
+### Task 6.1: Extract Scalus test vectors
+**Story**: Conformance | **Priority**: P2 | **Depends**: 1.4, 2.1
+
+Extract test cases from Scalus TransactionBuilderTests.scala:
+- Simple spend + payTo
+- Script spend with redeemer
+- Mint + spend combo
+- Reference input + validity interval
+- Multi-input with per-input redeemers
+
+For each: capture builder steps, protocol params, UTxO set, and expected transaction CBOR or structure.
+
+**Acceptance**: Test vectors documented as Haskell test cases. Our `build`/`draft` produces matching transaction structure.
+
+**Commit scope**: `test/Cardano/Node/Client/TxBuild/ConformanceSpec.hs` (new file)
+
+---
+
+## Dependency Graph
+
+```
+1.1 ──→ 1.2 ──→ 1.3 ──→ 1.4 ──→ 5.1
+  │               │        │
+  ├──→ 1.5        ├──→ 2.1 ├──→ 6.1
+  │               │
+  ├──→ 3.1        └──→ 4.1
+```
+
+## Task Summary
+
+| Task | Description | Priority | Depends |
+|------|------------|----------|---------|
+| 1.1  | Core types + empty builder | P1 | — |
+| 1.2  | spend/spendScript combinators | P1 | 1.1 |
+| 1.3  | draft (assembly without eval) | P1 | 1.2 |
+| 1.4  | build (evaluate + patch + balance) | P1 | 1.3 |
+| 1.5  | attachScript combinator | P1 | 1.1 |
+| 2.1  | mint combinator (mint+burn) | P1 | 1.3 |
+| 3.1  | payTo/payTo' with typed datums | P1 | 1.1 |
+| 4.1  | references/collaterals/validity/signers | P2 | 1.3 |
+| 5.1  | complete (auto-select + build) | P2 | 1.4 |
+| 6.1  | Scalus conformance test vectors | P2 | 1.4, 2.1 |

--- a/specs/003-tx-builder-dsl/tasks.md
+++ b/specs/003-tx-builder-dsl/tasks.md
@@ -68,44 +68,12 @@ Add `Reference`, `SetValidFrom`, `SetValidTo`. Smart constructors: `reference`, 
 
 ---
 
-## Slice 7: MPFS Boot migration
-
-In `cardano-mpfs-offchain`: define `CageQ` and `CageErr`. Rewrite `bootTokenImpl` as `TxBuild CageQ CageErr ()`. Production `InterpretIO CageQ` wrapping existing Provider. Test `Interpret CageQ` with fixture data.
-
-**Test**: e2e Boot test passes with the DSL builder.
-
-**Depends**: Slice 4
-
----
-
-## Slice 8: MPFS Update/Reject (conservation)
-
-Rewrite `updateTokenImpl` and `rejectRequestsImpl` using `peek` for fee-dependent refunds. The `balanceFeeLoop` + `mkOutputs` callback pattern is replaced by `peek` + natural convergence.
-
-**Test**: e2e Update and Reject tests pass. Delete `balanceFeeLoop` from `Balance.hs`.
-
-**Depends**: Slice 7, Slice 3
-
----
-
-## Slice 9: Remaining MPFS migrations
-
-Rewrite End, Retract, Request builders. Delete `evaluateAndBalance`, `spendingIndex`, `computeScriptIntegrity`, `placeholderExUnits` from Internal.hs. All e2e tests pass.
-
-**Test**: full e2e cage flow (Boot → Request → Update → Retract → Reject → End).
-
-**Depends**: Slice 8, Slice 6
-
----
-
 ## Dependency graph
 
 ```
-Slice 1 → Slice 2 → Slice 3 → Slice 4 → Slice 7 → Slice 8 → Slice 9
-              ↓           ↓                              ↑
-          Slice 6     Slice 5                             |
-              ↓                                           |
-              └───────────────────────────────────────────┘
+Slice 1 → Slice 2 → Slice 3 → Slice 4
+              ↓           ↓
+          Slice 6     Slice 5
 ```
 
 ## Summary
@@ -118,6 +86,3 @@ Slice 1 → Slice 2 → Slice 3 → Slice 4 → Slice 7 → Slice 8 → Slice 9
 | 4 | Ctx + pluggable queries | 3 |
 | 5 | Valid + library checkers | 3 |
 | 6 | Reference inputs + validity intervals | 1 |
-| 7 | MPFS Boot migration | 4 |
-| 8 | MPFS Update/Reject (conservation) | 7, 3 |
-| 9 | Remaining MPFS + cleanup | 8, 6 |

--- a/specs/003-tx-builder-dsl/zoo.md
+++ b/specs/003-tx-builder-dsl/zoo.md
@@ -1,0 +1,358 @@
+# Transaction Pattern Zoo
+
+Concrete `TxBuild q` programs for every crucial case identified in the [survey](survey.md). Each pattern shows how the DSL handles a real-world scenario found across the 25 libraries surveyed.
+
+## Case 1: Redeemer Index Computation
+
+**Problem:** Redeemer index depends on sorted position of the input/policy, unknown at call time.
+
+**How other libraries handle it:** CSL/CML auto-compute from sorted structure. Blaze does `insertSorted` + bumps. MPFS does manual `spendingIndex`. PyCardano does `_set_redeemer_index()` post-hoc.
+
+**Our DSL:** Invisible. `spend`/`spendScript` return the index via `Peek`.
+
+```haskell
+-- User never thinks about indices
+multiSpend :: TxBuild q e ()
+multiSpend = do
+    idx0 <- spendScript txIn1 (Modify proofs)
+    idx1 <- spendScript txIn2 (Contribute ref)
+    idx2 <- spendScript txIn3 (Contribute ref)
+    -- idx0, idx1, idx2 are Word32 — correct sorted
+    -- positions, resolved by fixpoint. The user
+    -- can use them (e.g., in a datum) but doesn't
+    -- have to.
+    pure ()
+```
+
+## Case 2: Fee-Dependent Outputs (Conservation)
+
+**Problem:** Output values depend on the final fee. Fee depends on Tx size. Tx size depends on outputs. Circular.
+
+**How other libraries handle it:** Scalus iterates (20 max). Blaze iterates (10 max). MPFS has `balanceFeeLoop` with `mkOutputs(fee)` callback. Most libraries don't support this.
+
+**Our DSL:** `peek` reads the fee. Build loop converges.
+
+```haskell
+-- From cardano-mpfs-onchain#37
+conservationTx :: TxBuild CageQ CageErr ()
+conservationTx = do
+    (stateIn, datum) <- ctx (FindState pid tid)
+    reqs <- ctx (FindReqs tid)
+    let numReqs = length reqs
+        totalIn = sumLovelace reqs
+    spendScript stateIn (Modify proofs)
+    forM_ reqs $ \(reqIn, _) ->
+        spendScript reqIn (Contribute stateRef)
+    -- Fee is circular — peek breaks the cycle
+    Coin feeVal <- peek $ \tx ->
+        let fee = tx ^. bodyTxL . feeTxBodyL
+        in if fee > Coin 0
+            then Ok fee
+            else Iterate (Coin 0)
+    let totalRefund = totalIn - feeVal - numReqs * tip
+        perReq = totalRefund `div` numReqs
+        leftover = totalRefund `mod` numReqs
+    -- State output: locked value + tips
+    payTo' scriptAddr
+        (MaryValue (Coin (2_000_000 + numReqs * tip)) tokenMA)
+        newStateDatum
+    -- Refund outputs: depend on fee
+    forM_ (zip [0 :: Int ..] reqs) $ \(i, _) ->
+        payTo ownerAddr
+            (inject (Coin (perReq + if i == 0 then leftover else 0)))
+    collateral feeIn
+    requireSignature ownerKh
+    attachScript script
+```
+
+## Case 3: Deferred Redeemer (Value Depends on Final Tx)
+
+**Problem:** A redeemer's Data depends on the final transaction — e.g., number of inputs, index of a specific output.
+
+**How other libraries handle it:** Scalus: `redeemerBuilder: Transaction => Data`. Lucid Evolution: `RedeemerBuilder { makeRedeemer(inputIndices) }`. Most libraries don't support this.
+
+**Our DSL:** `peek` returns any type, used via bind.
+
+```haskell
+-- Scalus pattern: redeemer counts inputs
+selfReferentialSpend :: TxBuild q e ()
+selfReferentialSpend = do
+    spend pubKeyIn
+    inputCount <- peek $ \tx ->
+        Ok $ Set.size (tx ^. bodyTxL . inputsTxBodyL)
+    spendScript scriptIn (CountRedeemer inputCount)
+    payTo recipientAddr value
+```
+
+```haskell
+-- Lucid Evolution pattern: redeemer references
+-- the index where a specific input lands
+indexAwareSpend :: TxBuild q e ()
+indexAwareSpend = do
+    myIdx <- spendScript oracleIn OracleRedeemer
+    -- myIdx is the sorted index of oracleIn
+    -- in the final input set. Downstream code
+    -- can use it in a datum:
+    payTo' outputAddr value (ProofOfIndex myIdx)
+```
+
+## Case 4: Deferred Datum (Value Depends on Final Tx)
+
+**Problem:** An inline datum depends on the final transaction structure — e.g., "which output index am I?"
+
+**How other libraries handle it:** Scalus: `datumBuilder: Transaction => Data`. Others: not supported.
+
+**Our DSL:** Same mechanism as deferred redeemers — `peek`.
+
+```haskell
+-- Scalus pattern: datum contains its own output index
+selfAwareDatum :: TxBuild q e ()
+selfAwareDatum = do
+    myOutIdx <- payTo' bobAddr value (PlaceholderDatum 0)
+    -- Wait — payTo' already committed the datum.
+    -- For a truly deferred datum, use output + peek:
+    selfIdx <- peek $ \tx ->
+        let outs = tx ^. bodyTxL . outputsTxBodyL
+            idx = findIndex (\o -> getAddr o == bobAddr) outs
+        in maybe (Iterate 0) Ok idx
+    output $ mkBasicTxOut bobAddr value
+        & datumTxOutL .~ mkInlineDatum (toPlcData (SelfDatum selfIdx))
+```
+
+Note: this is more verbose than Scalus's `payTo(addr, value, tx => datum)` because our `payTo'` commits the datum eagerly. For a deferred datum, use `output` + `peek` separately. Could add a `payToDeferred` combinator later.
+
+## Case 5: Deferred UTxO Query (Steps Depend on Chain State)
+
+**Problem:** Transaction steps depend on chain state only available at runtime — find a UTxO, decode its state, decide what to spend.
+
+**How other libraries handle it:** Scalus: `Deferred(UtxoQuery, Utxos => Seq[Step])`. PyCardano: `add_input_address(addr)` defers to build. Others: must query upfront.
+
+**Our DSL:** `ctx` with user-defined query GADT.
+
+```haskell
+-- Scalus UtxoCell pattern: find beacon, decode, transition
+data CounterQ a where
+    FindCell :: PolicyID -> AssetName
+             -> CounterQ (TxIn, CounterState)
+    FindFee  :: Addr -> CounterQ (TxIn, TxOut ConwayEra)
+
+incrementCounter :: TxBuild CounterQ CounterErr ()
+incrementCounter = do
+    (cellIn, state) <- ctx (FindCell pid tokenName)
+    let newState = state { count = count state + 1 }
+    spendScript cellIn (Increment)
+    payTo' scriptAddr cellValue newState
+    (feeIn, _) <- ctx (FindFee walletAddr)
+    collateral feeIn
+    attachScript counterScript
+```
+
+## Case 6: Coin Selection
+
+**Problem:** Select UTxOs from a wallet to cover outputs + fees.
+
+**How other libraries handle it:** CSL/CML: 4 CIP-2 strategies. PyCardano: LargestFirst + RandomImproveMultiAsset. Atlas: from cardano-wallet.
+
+**Our DSL:** Delegated to `balanceTx` (inside `build`). The user doesn't see it.
+
+```haskell
+-- User just declares what they want
+simplePay :: TxBuild Void Void ()
+simplePay = do
+    payTo bobAddr (inject (Coin 5_000_000))
+    payTo charlieAddr (inject (Coin 3_000_000))
+
+-- build handles input selection + fee + change
+result <- build pp evaluator utxos changeAddr simplePay
+```
+
+## Case 7: Script Evaluation (ExUnits)
+
+**Problem:** Plutus scripts need execution budgets. Only known after running scripts against the assembled Tx.
+
+**How other libraries handle it:** CML: two-phase `build_for_evaluation` + `set_exunits`. PyCardano: auto via ChainContext. Blaze: pluggable `useEvaluator`.
+
+**Our DSL:** `build` takes an evaluator function. `draft` skips evaluation (placeholders).
+
+```haskell
+-- draft: for testing, no evaluation
+let tx = draft pp myProgram
+-- tx has ExUnits 0 0 in all redeemers
+
+-- build: real evaluation
+result <- build pp
+    (evaluateTx provider)     -- evaluator
+    inputUtxos changeAddr
+    myProgram
+-- tx has real ExUnits, balanced fee
+```
+
+## Case 8: Composability (Multiple Protocols in One Tx)
+
+**Problem:** Compose independent protocol interactions. Each protocol knows its own patterns but not the others.
+
+**How other libraries handle it:** Scalus: `UtxoCellDef.apply(action)` with `Deferred`. Blaze: `preCompleteHooks`. Atlas: `buildTxBodyParallel`.
+
+**Our DSL:** Each protocol defines its query constructors. Composed via sum type.
+
+```haskell
+-- Protocol A: MPFS cage
+data CageQ a where
+    FindState :: PolicyID -> TokenId -> CageQ (TxIn, CageDatum)
+
+-- Protocol B: DEX swap
+data DexQ a where
+    FindPool :: AssetPair -> DexQ (TxIn, PoolDatum)
+
+-- Composed
+data AppQ a where
+    Cage :: CageQ a -> AppQ a
+    Dex  :: DexQ a -> AppQ a
+
+-- One transaction, two protocols
+composedTx :: TxBuild AppQ AppErr ()
+composedTx = do
+    -- MPFS update
+    (stateIn, datum) <- ctx (Cage (FindState pid tid))
+    spendScript stateIn (Modify proofs)
+    payTo' cageAddr stateValue newDatum
+
+    -- DEX swap in same tx
+    (poolIn, poolDatum) <- ctx (Dex (FindPool pair))
+    spendScript poolIn (Swap amount)
+    payTo' dexAddr poolValue newPoolDatum
+
+    -- Shared: fee, collateral
+    collateral feeIn
+    attachScript cageScript
+    attachScript dexScript
+
+-- Each protocol's interpreter is independent
+appInterpreter :: Provider IO -> AppQ a -> IO a
+appInterpreter prov (Cage q) = cageInterpreter prov q
+appInterpreter prov (Dex q)  = dexInterpreter prov q
+```
+
+## Case 9: Pay vs Lock Safety
+
+**Problem:** Paying to a script address without a datum locks funds forever.
+
+**How other libraries handle it:** Blaze: `lockAssets` (asserts script + datum) vs `payAssets`. Lucid: `pay.ToContract`. Others: no enforcement.
+
+**Our DSL:** Not enforced in the core. Could add as a smart constructor:
+
+```haskell
+-- Future addition: enforced script output
+lockAt
+    :: ToData d
+    => ScriptHash -> MaryValue -> d
+    -> TxBuild q Word32
+lockAt sh val datum = do
+    let addr = Addr net (ScriptHashObj sh) StakeRefNull
+    payTo' addr val datum
+
+-- Using it makes the intent clear
+lockAt cageScriptHash stateValue stateDatum
+-- vs
+payTo someAddr value  -- might be script, might not
+```
+
+## Case 10: Nested Fee Convergence
+
+**Problem:** Two levels of iteration: `balanceTx` converges the fee, `peek` converges deferred values. They interact.
+
+**How other libraries handle it:** Scalus: single loop (delayed redeemers resolved inside balancing). Blaze: single loop. CML: explicit two-phase. MPFS: `balanceFeeLoop` is a custom single loop.
+
+**Our DSL:** Explicit two nested loops. The interaction is safe because:
+
+```
+Outer loop (Peek convergence):
+  1. Interpret program with current Tx
+     → Peek nodes see current Tx
+     → Iterate/Ok determine satisfaction
+  2. Assemble Tx from steps
+  3. Inner loop (balanceTx fee convergence):
+     a. Evaluate scripts → ExUnits
+     b. Estimate fee from Tx size
+     c. Adjust change output
+     d. If fee changed → goto a
+  4. If outer Tx changed OR any Iterate → goto 1
+  5. All Ok AND Tx stable → return
+```
+
+```haskell
+-- The user doesn't see the loops. They write:
+myTx :: TxBuild CageQ CageErr ()
+myTx = do
+    fee <- peek $ \tx ->
+        Ok (tx ^. bodyTxL . feeTxBodyL)
+    let refund = totalIn - unCoin fee - tips
+    payTo refundAddr (inject (Coin refund))
+    ...
+
+-- build handles everything
+result <- build pp evaluator utxos changeAddr myTx
+```
+
+## Bonus: Transaction Chaining (Helios pattern)
+
+**Problem:** Use outputs from tx1 as inputs in tx2 without submitting tx1 first.
+
+```haskell
+chainTxs :: TxBuild q e ()
+chainTxs = do
+    -- tx1: create a state UTxO
+    outIdx <- payTo' scriptAddr value initialDatum
+    -- outIdx is the output index of this output
+    -- in the final tx1. A subsequent builder could
+    -- reference it as TxIn(tx1Hash, outIdx).
+    -- But tx1Hash isn't known until tx1 is built.
+    -- This needs peek:
+    tx1Id <- peek $ \tx ->
+        Ok (txIdFromTx tx)
+    -- Now we have (tx1Id, outIdx) — a valid TxIn
+    -- for a chained tx2. But that's a different
+    -- TxBuild program, not this one.
+    pure ()
+```
+
+Note: true chaining (multiple txs in one program) would need `TxBuild` to support multiple transaction boundaries. Out of scope for now — each `TxBuild q a` is one transaction.
+
+## Bonus: Metadata (TyphonJS / Mesh pattern)
+
+**Problem:** Attach transaction metadata (auxiliary data).
+
+```haskell
+-- Not yet in our GADT. Would be:
+-- SetMetadata :: Word64 -> PLC.Data -> TxInstr q ()
+
+-- For now, use output with raw TxOut construction
+-- or add to the GADT when needed.
+```
+
+## Bonus: Collateral Return (Blaze / CML pattern)
+
+**Problem:** When collateral contains native tokens, a collateral return output is needed to get the tokens back if a script fails.
+
+```haskell
+-- Not yet in our GADT. Would be:
+-- SetCollateralReturn :: TxOut ConwayEra -> TxInstr q ()
+
+-- For now, the balancer could handle this
+-- automatically when collateral has tokens.
+```
+
+## Summary
+
+| Pattern | Mechanism | Lines of user code |
+|---------|-----------|-------------------|
+| Redeemer indices | `spend`/`spendScript` return `Word32` | 0 (automatic) |
+| Fee-dependent outputs | `peek` reads fee | 3-4 |
+| Deferred redeemer | `peek` + bind | 2-3 |
+| Deferred datum | `peek` + `output` | 3-4 |
+| UTxO queries | `ctx` | 1 per query |
+| Coin selection | `build` internally | 0 (automatic) |
+| Script evaluation | `build` internally | 0 (automatic) |
+| Composability | Sum-type `q` | natural |
+| Pay vs Lock | `lockAt` (future) | 1 |
+| Fee convergence | `build` loop | 0 (automatic) |

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -1,0 +1,222 @@
+{- |
+Module      : Cardano.Node.Client.TxBuildSpec
+Description : TxBuild DSL tests — Slice 1
+License     : Apache-2.0
+
+Tests for simple pub-key spend, payTo, collateral,
+and draft assembly. Verifies inputs/outputs in
+assembled Tx and that spend returns correct index.
+-}
+module Cardano.Node.Client.TxBuildSpec (spec) where
+
+import Data.Set qualified as Set
+import Test.Hspec
+
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Api.PParams (emptyPParams)
+import Cardano.Ledger.Api.Tx (Tx)
+import Cardano.Ledger.Api.Tx.Body (
+    collateralInputsTxBodyL,
+    inputsTxBodyL,
+    outputsTxBodyL,
+ )
+import Cardano.Ledger.BaseTypes (
+    Inject (..),
+    Network (..),
+    TxIx (..),
+ )
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core (bodyTxL)
+import Cardano.Ledger.Credential (
+    Credential (..),
+    StakeReference (..),
+ )
+import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
+import Cardano.Ledger.Keys (KeyHash (..))
+import Cardano.Ledger.TxIn (
+    TxId (..),
+    TxIn (..),
+ )
+import Cardano.Node.Client.TxBuild
+import Lens.Micro ((^.))
+
+import Cardano.Crypto.Hash (
+    Hash,
+    HashAlgorithm,
+    hashFromBytes,
+ )
+import Data.ByteString qualified as BS
+import Data.Maybe (fromJust)
+import Data.Word (Word8)
+
+-- --------------------------------------------------
+-- Test helpers
+-- --------------------------------------------------
+
+-- | Deterministic 32-byte hash.
+mkHash32 ::
+    (HashAlgorithm h) => Word8 -> Hash h a
+mkHash32 n =
+    fromJust $
+        hashFromBytes $
+            BS.pack $
+                replicate 31 0 ++ [n]
+
+-- | Deterministic 28-byte hash.
+mkHash28 ::
+    (HashAlgorithm h) => Word8 -> Hash h a
+mkHash28 n =
+    fromJust $
+        hashFromBytes $
+            BS.pack $
+                replicate 27 0 ++ [n]
+
+-- | Fake TxIn from a byte.
+mkTxIn :: Word8 -> TxIn
+mkTxIn n =
+    TxIn
+        (TxId $ unsafeMakeSafeHash $ mkHash32 n)
+        (TxIx (fromIntegral n))
+
+-- | Fake address from a byte.
+mkAddr :: Word8 -> Addr
+mkAddr n =
+    Addr
+        Testnet
+        (KeyHashObj (KeyHash (mkHash28 n)))
+        StakeRefNull
+
+-- --------------------------------------------------
+-- Spec
+-- --------------------------------------------------
+
+spec :: Spec
+spec = describe "TxBuild" $ do
+    spendSpec
+    payToSpec
+    collateralSpec
+    spendIndexSpec
+
+spendSpec :: Spec
+spendSpec =
+    describe "spend" $ do
+        it "adds TxIn to inputsTxBodyL" $ do
+            let tx =
+                    draft emptyPParams $ do
+                        _ <- spend (mkTxIn 1)
+                        pure ()
+                ins =
+                    tx ^. bodyTxL . inputsTxBodyL
+            Set.member (mkTxIn 1) ins
+                `shouldBe` True
+
+        it "multiple spends all appear" $ do
+            let tx =
+                    draft emptyPParams $ do
+                        _ <- spend (mkTxIn 1)
+                        _ <- spend (mkTxIn 2)
+                        _ <- spend (mkTxIn 3)
+                        pure ()
+                ins =
+                    tx ^. bodyTxL . inputsTxBodyL
+            Set.size ins `shouldBe` 3
+
+payToSpec :: Spec
+payToSpec =
+    describe "payTo" $ do
+        it "adds output to outputsTxBodyL" $ do
+            let tx =
+                    draft emptyPParams $ do
+                        _ <-
+                            payTo
+                                (mkAddr 1)
+                                (inject (Coin 2_000_000))
+                        pure ()
+                outs =
+                    tx ^. bodyTxL . outputsTxBodyL
+            length outs `shouldBe` 1
+
+        it "multiple payTo all appear in order" $
+            do
+                let tx =
+                        draft emptyPParams $ do
+                            _ <-
+                                payTo
+                                    (mkAddr 1)
+                                    (inject (Coin 1_000_000))
+                            _ <-
+                                payTo
+                                    (mkAddr 2)
+                                    (inject (Coin 2_000_000))
+                            pure ()
+                    outs =
+                        tx ^. bodyTxL . outputsTxBodyL
+                length outs `shouldBe` 2
+
+collateralSpec :: Spec
+collateralSpec =
+    describe "collateral" $ do
+        it "adds to collateralInputsTxBodyL" $ do
+            let tx =
+                    draft emptyPParams $ do
+                        collateral (mkTxIn 5)
+                ins =
+                    tx
+                        ^. bodyTxL
+                            . collateralInputsTxBodyL
+            Set.member (mkTxIn 5) ins
+                `shouldBe` True
+
+        it "not in inputsTxBodyL" $ do
+            let tx =
+                    draft emptyPParams $ do
+                        collateral (mkTxIn 5)
+                ins =
+                    tx ^. bodyTxL . inputsTxBodyL
+            Set.member (mkTxIn 5) ins
+                `shouldBe` False
+
+spendIndexSpec :: Spec
+spendIndexSpec =
+    describe "spend index" $ do
+        it "returns 0 for single input" $ do
+            let (tx, idx) =
+                    runDraft $
+                        spend (mkTxIn 1)
+            idx `shouldBe` 0
+            Set.size
+                (tx ^. bodyTxL . inputsTxBodyL)
+                `shouldBe` 1
+
+        it "returns correct sorted indices" $ do
+            -- mkTxIn 1 sorts before mkTxIn 2
+            let (_, (i1, i2)) = runDraft $ do
+                    a <- spend (mkTxIn 2)
+                    b <- spend (mkTxIn 1)
+                    pure (a, b)
+            -- mkTxIn 1 is at index 0 (sorts first)
+            -- mkTxIn 2 is at index 1
+            i2 `shouldBe` 0
+            i1 `shouldBe` 1
+
+        it "interleaves pure computation" $ do
+            let (_, result) = runDraft $ do
+                    i <- spend (mkTxIn 1)
+                    let doubled = i * 2
+                    _ <- spend (mkTxIn 2)
+                    pure doubled
+            -- mkTxIn 1 is at index 0, doubled = 0
+            result `shouldBe` 0
+
+{- | Run draft and return both the Tx and the
+program's result.
+-}
+runDraft ::
+    TxBuild q e a -> (Tx ConwayEra, a)
+runDraft prog =
+    let initialTx = draft emptyPParams (pure ())
+        (st1, _, _) = interpretWith initialTx prog
+        tx1 = assembleTx st1
+        (st2, a, _) = interpretWith tx1 prog
+     in (assembleTx st2, a)

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GADTs #-}
+
 {- |
 Module      : Cardano.Node.Client.TxBuildSpec
 Description : TxBuild DSL tests — Slice 1
@@ -24,7 +26,10 @@ import Cardano.Ledger.Api.Tx.Body (
     mintTxBodyL,
     outputsTxBodyL,
  )
-import Cardano.Ledger.Api.Tx.Out (mkBasicTxOut)
+import Cardano.Ledger.Api.Tx.Out (
+    TxOut,
+    mkBasicTxOut,
+ )
 import Cardano.Ledger.Api.Tx.Wits (rdmrsTxWitsL)
 import Cardano.Ledger.BaseTypes (
     Inject (..),
@@ -65,6 +70,7 @@ import Cardano.Crypto.Hash (
  )
 import Data.ByteString qualified as BS
 import Data.ByteString.Short qualified as SBS
+import Data.Foldable (toList)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromJust)
 import Data.Word (Word8)
@@ -125,7 +131,11 @@ spec = describe "TxBuild" $ do
     spendIndexSpec
     scriptSpendSpec
     mintSpec
+    ctxSpec
     buildSpec
+
+data TestQ a where
+    GetValue :: TestQ Int
 
 spendSpec :: Spec
 spendSpec =
@@ -361,6 +371,29 @@ mintSpec =
             hasMint `shouldBe` True
             Map.size rdmrs `shouldBe` 2
 
+ctxSpec :: Spec
+ctxSpec =
+    describe "ctx" $ do
+        it "flows interpreted values through subsequent binds" $ do
+            let interpret =
+                    Interpret $ \GetValue -> 7
+                expected :: TxOut ConwayEra
+                expected =
+                    mkBasicTxOut
+                        (mkAddr 3)
+                        (inject (Coin 7))
+                tx =
+                    draftWith emptyPParams interpret $ do
+                        n <- ctx GetValue
+                        _ <-
+                            payTo
+                                (mkAddr 3)
+                                (inject (Coin (fromIntegral n)))
+                        pure ()
+                outs = tx ^. bodyTxL . outputsTxBodyL
+            toList outs
+                `shouldBe` [expected]
+
 buildSpec :: Spec
 buildSpec =
     describe "build" $ do
@@ -385,6 +418,7 @@ buildSpec =
                 result <-
                     build
                         emptyPParams
+                        noCtxInterpretIO
                         mockEval
                         [feeUtxo]
                         (mkAddr 1)
@@ -421,6 +455,7 @@ buildSpec =
             result <-
                 build
                     emptyPParams
+                    noCtxInterpretIO
                     mockEval
                     [feeUtxo]
                     (mkAddr 1)
@@ -439,6 +474,48 @@ buildSpec =
                     -- value
                     fee `shouldSatisfy` (>= 0)
 
+        it "resolves ctx queries through InterpretIO" $ do
+            let prog = do
+                    _ <- spend (mkTxIn 1)
+                    n <- ctx GetValue
+                    _ <-
+                        payTo
+                            (mkAddr 4)
+                            (inject (Coin (fromIntegral n)))
+                    pure ()
+                feeUtxo =
+                    ( mkTxIn 1
+                    , mkBasicTxOut
+                        (mkAddr 1)
+                        (inject (Coin 10_000_000))
+                    )
+                interpret =
+                    InterpretIO $ \GetValue -> pure 7
+                mockEval _ = pure Map.empty
+            result <-
+                build
+                    emptyPParams
+                    interpret
+                    mockEval
+                    [feeUtxo]
+                    (mkAddr 1)
+                    prog
+            case result of
+                Left err ->
+                    expectationFailure $ show err
+                Right tx -> do
+                    let outs =
+                            toList $
+                                tx
+                                    ^. bodyTxL
+                                        . outputsTxBodyL
+                        expected :: TxOut ConwayEra
+                        expected =
+                            mkBasicTxOut
+                                (mkAddr 4)
+                                (inject (Coin 7))
+                    expected `shouldSatisfy` (`elem` outs)
+
 isSpend ::
     ConwayPlutusPurpose AsIx ConwayEra -> Bool
 isSpend (ConwaySpending _) = True
@@ -454,9 +531,31 @@ program's result.
 -}
 runDraft ::
     TxBuild q e a -> (Tx ConwayEra, a)
-runDraft prog =
+runDraft = runDraftWith noCtxInterpret
+
+runDraftWith ::
+    Interpret q ->
+    TxBuild q e a ->
+    (Tx ConwayEra, a)
+runDraftWith interpret prog =
     let initialTx = draft emptyPParams (pure ())
-        (st1, _, _) = interpretWith initialTx prog
+        (st1, _, _) =
+            interpretWith interpret initialTx prog
         tx1 = assembleTx emptyPParams st1
-        (st2, a, _) = interpretWith tx1 prog
+        (st2, a, _) =
+            interpretWith interpret tx1 prog
      in (assembleTx emptyPParams st2, a)
+
+noCtxInterpret :: Interpret q
+noCtxInterpret =
+    Interpret $
+        const $
+            error
+                "test: encountered ctx without interpreter"
+
+noCtxInterpretIO :: InterpretIO q
+noCtxInterpretIO =
+    InterpretIO $
+        const $
+            error
+                "test: encountered ctx without interpreter"

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -17,7 +17,12 @@ import Test.Hspec
 import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
-import Cardano.Ledger.Api.PParams (emptyPParams)
+import Cardano.Ledger.Api.PParams (
+    CoinPerByte (..),
+    emptyPParams,
+    ppCoinsPerUTxOByteL,
+    ppMaxTxSizeL,
+ )
 import Cardano.Ledger.Api.Tx (Tx, witsTxL)
 import Cardano.Ledger.Api.Tx.Body (
     collateralInputsTxBodyL,
@@ -61,7 +66,7 @@ import Cardano.Ledger.TxIn (
     TxIn (..),
  )
 import Cardano.Node.Client.TxBuild
-import Lens.Micro ((^.))
+import Lens.Micro ((&), (.~), (^.))
 
 import Cardano.Crypto.Hash (
     Hash,
@@ -132,10 +137,15 @@ spec = describe "TxBuild" $ do
     scriptSpendSpec
     mintSpec
     ctxSpec
+    validSpec
     buildSpec
 
 data TestQ a where
     GetValue :: TestQ Int
+
+data TestErr
+    = BrokenInvariant
+    deriving (Show, Eq)
 
 spendSpec :: Spec
 spendSpec =
@@ -394,12 +404,175 @@ ctxSpec =
             toList outs
                 `shouldBe` [expected]
 
+validSpec :: Spec
+validSpec =
+    describe "valid" $ do
+        it "returns custom failures after convergence" $ do
+            let prog :: TxBuild TestQ TestErr ()
+                prog = do
+                    _ <- spend (mkTxIn 1)
+                    valid $
+                        const $
+                            CustomFail BrokenInvariant
+                    pure ()
+                feeUtxo =
+                    ( mkTxIn 1
+                    , mkBasicTxOut
+                        (mkAddr 1)
+                        (inject (Coin 10_000_000))
+                    )
+                mockEval _ = pure Map.empty
+            result <-
+                build
+                    emptyPParams
+                    noCtxInterpretIO
+                    mockEval
+                    [feeUtxo]
+                    (mkAddr 1)
+                    prog
+            case result of
+                Left (ChecksFailed [CustomFail err]) ->
+                    err `shouldBe` BrokenInvariant
+                Left err ->
+                    expectationFailure $ show err
+                Right _ ->
+                    expectationFailure
+                        "expected custom validation failure"
+
+        it "fails checkMinUtxo when an output is below the threshold" $
+            do
+                let pp =
+                        emptyPParams
+                            & ppCoinsPerUTxOByteL
+                                .~ CoinPerByte
+                                    (Coin 1)
+                    prog :: TxBuild TestQ TestErr ()
+                    prog = do
+                        _ <- spend (mkTxIn 1)
+                        outIx <-
+                            payTo
+                                (mkAddr 2)
+                                (inject (Coin 1))
+                        checkMinUtxo pp outIx
+                    feeUtxo =
+                        ( mkTxIn 1
+                        , mkBasicTxOut
+                            (mkAddr 1)
+                            (inject (Coin 10_000_000))
+                        )
+                    mockEval _ = pure Map.empty
+                result <-
+                    build
+                        pp
+                        noCtxInterpretIO
+                        mockEval
+                        [feeUtxo]
+                        (mkAddr 1)
+                        prog
+                case result of
+                    Left
+                        ( ChecksFailed
+                                [ LedgerFail
+                                        (MinUtxoViolation ix actual required)
+                                    ]
+                            ) -> do
+                            ix `shouldBe` 0
+                            actual `shouldBe` Coin 1
+                            actual `shouldSatisfy` (< required)
+                    Left err ->
+                        expectationFailure $ show err
+                    Right _ ->
+                        expectationFailure
+                            "expected min-UTxO failure"
+
+        it "fails checkTxSize when the encoded tx exceeds ppMaxTxSizeL" $
+            do
+                let pp =
+                        emptyPParams
+                            & ppMaxTxSizeL .~ 1
+                    prog :: TxBuild TestQ TestErr ()
+                    prog = do
+                        _ <- spend (mkTxIn 1)
+                        _ <-
+                            payTo
+                                (mkAddr 2)
+                                (inject (Coin 3_000_000))
+                        checkTxSize pp
+                    feeUtxo =
+                        ( mkTxIn 1
+                        , mkBasicTxOut
+                            (mkAddr 1)
+                            (inject (Coin 10_000_000))
+                        )
+                    mockEval _ = pure Map.empty
+                result <-
+                    build
+                        pp
+                        noCtxInterpretIO
+                        mockEval
+                        [feeUtxo]
+                        (mkAddr 1)
+                        prog
+                case result of
+                    Left
+                        ( ChecksFailed
+                                [ LedgerFail
+                                        (TxSizeExceeded actual limit)
+                                    ]
+                            ) -> do
+                            limit `shouldBe` 1
+                            actual `shouldSatisfy` (> limit)
+                    Left err ->
+                        expectationFailure $ show err
+                    Right _ ->
+                        expectationFailure
+                            "expected tx-size failure"
+
+        it "returns Right when all checks pass" $ do
+            let pp =
+                    emptyPParams
+                        & ppCoinsPerUTxOByteL
+                            .~ CoinPerByte (Coin 1)
+                prog :: TxBuild TestQ TestErr ()
+                prog = do
+                    _ <- spend (mkTxIn 1)
+                    outIx <-
+                        payTo
+                            (mkAddr 2)
+                            (inject (Coin 5_000_000))
+                    checkMinUtxo pp outIx
+                    valid $ const Pass
+                feeUtxo =
+                    ( mkTxIn 1
+                    , mkBasicTxOut
+                        (mkAddr 1)
+                        (inject (Coin 10_000_000))
+                    )
+                mockEval _ = pure Map.empty
+            result <-
+                build
+                    pp
+                    noCtxInterpretIO
+                    mockEval
+                    [feeUtxo]
+                    (mkAddr 1)
+                    prog
+            case result of
+                Left err ->
+                    expectationFailure $ show err
+                Right tx -> do
+                    let outs =
+                            tx ^. bodyTxL . outputsTxBodyL
+                    length outs
+                        `shouldSatisfy` (> 0)
+
 buildSpec :: Spec
 buildSpec =
     describe "build" $ do
         it "produces a balanced Tx with no scripts" $
             do
-                let prog = do
+                let prog :: TxBuild TestQ TestErr ()
+                    prog = do
                         _ <- spend (mkTxIn 1)
                         _ <-
                             payTo
@@ -436,7 +609,8 @@ buildSpec =
                             `shouldSatisfy` (> 0)
 
         it "peek reads fee from balanced Tx" $ do
-            let prog = do
+            let prog :: TxBuild TestQ TestErr ()
+                prog = do
                     _ <- spend (mkTxIn 1)
                     fee <- peek $ \tx ->
                         Ok (tx ^. bodyTxL . feeTxBodyL)
@@ -475,7 +649,8 @@ buildSpec =
                     fee `shouldSatisfy` (>= 0)
 
         it "resolves ctx queries through InterpretIO" $ do
-            let prog = do
+            let prog :: TxBuild TestQ TestErr ()
+                prog = do
                     _ <- spend (mkTxIn 1)
                     n <- ctx GetValue
                     _ <-

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -15,6 +15,7 @@ import Data.Set qualified as Set
 import Test.Hspec
 
 import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
 import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
 import Cardano.Ledger.Api.PParams (
@@ -30,6 +31,9 @@ import Cardano.Ledger.Api.Tx.Body (
     inputsTxBodyL,
     mintTxBodyL,
     outputsTxBodyL,
+    referenceInputsTxBodyL,
+    reqSignerHashesTxBodyL,
+    vldtTxBodyL,
  )
 import Cardano.Ledger.Api.Tx.Out (
     TxOut,
@@ -39,6 +43,7 @@ import Cardano.Ledger.Api.Tx.Wits (rdmrsTxWitsL)
 import Cardano.Ledger.BaseTypes (
     Inject (..),
     Network (..),
+    StrictMaybe (SJust),
     TxIx (..),
  )
 import Cardano.Ledger.Coin (Coin (..))
@@ -55,7 +60,10 @@ import Cardano.Ledger.Hashes (
     ScriptHash (..),
     unsafeMakeSafeHash,
  )
-import Cardano.Ledger.Keys (KeyHash (..))
+import Cardano.Ledger.Keys (
+    KeyHash (..),
+    KeyRole (Witness),
+ )
 import Cardano.Ledger.Mary.Value (
     AssetName (..),
     MultiAsset (..),
@@ -66,6 +74,7 @@ import Cardano.Ledger.TxIn (
     TxIn (..),
  )
 import Cardano.Node.Client.TxBuild
+import Cardano.Slotting.Slot (SlotNo (..))
 import Lens.Micro ((&), (.~), (^.))
 
 import Cardano.Crypto.Hash (
@@ -124,6 +133,10 @@ mkPolicyId n =
         Cardano.Ledger.Hashes.ScriptHash $
             mkHash28 n
 
+mkWitnessKeyHash :: Word8 -> KeyHash 'Witness
+mkWitnessKeyHash n =
+    KeyHash (mkHash28 n)
+
 -- --------------------------------------------------
 -- Spec
 -- --------------------------------------------------
@@ -138,6 +151,7 @@ spec = describe "TxBuild" $ do
     mintSpec
     ctxSpec
     validSpec
+    referenceValiditySpec
     buildSpec
 
 data TestQ a where
@@ -565,6 +579,34 @@ validSpec =
                             tx ^. bodyTxL . outputsTxBodyL
                     length outs
                         `shouldSatisfy` (> 0)
+
+referenceValiditySpec :: Spec
+referenceValiditySpec =
+    describe "reference inputs and validity interval" $ do
+        it "assembles retract-shaped body fields" $ do
+            let signer = mkWitnessKeyHash 9
+                lower = SlotNo 10
+                upper = SlotNo 20
+                tx =
+                    draft emptyPParams $ do
+                        _ <- spend (mkTxIn 1)
+                        reference (mkTxIn 2)
+                        requireSignature signer
+                        validFrom lower
+                        validTo upper
+                        pure ()
+                body = tx ^. bodyTxL
+            body ^. referenceInputsTxBodyL
+                `shouldBe` Set.singleton (mkTxIn 2)
+            body ^. inputsTxBodyL
+                `shouldBe` Set.singleton (mkTxIn 1)
+            body ^. reqSignerHashesTxBodyL
+                `shouldBe` Set.singleton signer
+            body ^. vldtTxBodyL
+                `shouldBe` ValidityInterval
+                    { invalidBefore = SJust lower
+                    , invalidHereafter = SJust upper
+                    }
 
 buildSpec :: Spec
 buildSpec =

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -19,10 +19,12 @@ import Cardano.Ledger.Api.PParams (emptyPParams)
 import Cardano.Ledger.Api.Tx (Tx, witsTxL)
 import Cardano.Ledger.Api.Tx.Body (
     collateralInputsTxBodyL,
+    feeTxBodyL,
     inputsTxBodyL,
     mintTxBodyL,
     outputsTxBodyL,
  )
+import Cardano.Ledger.Api.Tx.Out (mkBasicTxOut)
 import Cardano.Ledger.Api.Tx.Wits (rdmrsTxWitsL)
 import Cardano.Ledger.BaseTypes (
     Inject (..),
@@ -123,6 +125,7 @@ spec = describe "TxBuild" $ do
     spendIndexSpec
     scriptSpendSpec
     mintSpec
+    buildSpec
 
 spendSpec :: Spec
 spendSpec =
@@ -357,6 +360,84 @@ mintSpec =
             hasSpend `shouldBe` True
             hasMint `shouldBe` True
             Map.size rdmrs `shouldBe` 2
+
+buildSpec :: Spec
+buildSpec =
+    describe "build" $ do
+        it "produces a balanced Tx with no scripts" $
+            do
+                let prog = do
+                        _ <- spend (mkTxIn 1)
+                        _ <-
+                            payTo
+                                (mkAddr 2)
+                                (inject (Coin 3_000_000))
+                        pure ()
+                    feeUtxo =
+                        ( mkTxIn 1
+                        , mkBasicTxOut
+                            (mkAddr 1)
+                            ( inject
+                                (Coin 10_000_000)
+                            )
+                        )
+                    mockEval _ = pure Map.empty
+                result <-
+                    build
+                        emptyPParams
+                        mockEval
+                        [feeUtxo]
+                        (mkAddr 1)
+                        prog
+                case result of
+                    Left err ->
+                        expectationFailure $
+                            show err
+                    Right tx -> do
+                        let ins =
+                                tx
+                                    ^. bodyTxL
+                                        . inputsTxBodyL
+                        Set.size ins
+                            `shouldSatisfy` (> 0)
+
+        it "peek reads fee from balanced Tx" $ do
+            let prog = do
+                    _ <- spend (mkTxIn 1)
+                    fee <- peek $ \tx ->
+                        Ok (tx ^. bodyTxL . feeTxBodyL)
+                    _ <-
+                        payTo
+                            (mkAddr 2)
+                            (inject fee)
+                    pure ()
+                feeUtxo =
+                    ( mkTxIn 1
+                    , mkBasicTxOut
+                        (mkAddr 1)
+                        (inject (Coin 10_000_000))
+                    )
+                mockEval _ = pure Map.empty
+            result <-
+                build
+                    emptyPParams
+                    mockEval
+                    [feeUtxo]
+                    (mkAddr 1)
+                    prog
+            case result of
+                Left err ->
+                    expectationFailure $ show err
+                Right tx -> do
+                    let Coin fee =
+                            tx
+                                ^. bodyTxL
+                                    . feeTxBodyL
+                    -- Fee is 0 with emptyPParams
+                    -- (zero fee coefficients) — the
+                    -- point is it converged, not the
+                    -- value
+                    fee `shouldSatisfy` (>= 0)
 
 isSpend ::
     ConwayPlutusPurpose AsIx ConwayEra -> Bool

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -13,13 +13,17 @@ import Data.Set qualified as Set
 import Test.Hspec
 
 import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
+import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
 import Cardano.Ledger.Api.PParams (emptyPParams)
-import Cardano.Ledger.Api.Tx (Tx)
+import Cardano.Ledger.Api.Tx (Tx, witsTxL)
 import Cardano.Ledger.Api.Tx.Body (
     collateralInputsTxBodyL,
     inputsTxBodyL,
+    mintTxBodyL,
     outputsTxBodyL,
  )
+import Cardano.Ledger.Api.Tx.Wits (rdmrsTxWitsL)
 import Cardano.Ledger.BaseTypes (
     Inject (..),
     Network (..),
@@ -27,13 +31,24 @@ import Cardano.Ledger.BaseTypes (
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway.Scripts (
+    ConwayPlutusPurpose (..),
+ )
 import Cardano.Ledger.Core (bodyTxL)
 import Cardano.Ledger.Credential (
     Credential (..),
     StakeReference (..),
  )
-import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
+import Cardano.Ledger.Hashes (
+    ScriptHash (..),
+    unsafeMakeSafeHash,
+ )
 import Cardano.Ledger.Keys (KeyHash (..))
+import Cardano.Ledger.Mary.Value (
+    AssetName (..),
+    MultiAsset (..),
+    PolicyID (..),
+ )
 import Cardano.Ledger.TxIn (
     TxId (..),
     TxIn (..),
@@ -47,6 +62,8 @@ import Cardano.Crypto.Hash (
     hashFromBytes,
  )
 import Data.ByteString qualified as BS
+import Data.ByteString.Short qualified as SBS
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromJust)
 import Data.Word (Word8)
 
@@ -87,6 +104,13 @@ mkAddr n =
         (KeyHashObj (KeyHash (mkHash28 n)))
         StakeRefNull
 
+-- | Fake PolicyID from a byte.
+mkPolicyId :: Word8 -> PolicyID
+mkPolicyId n =
+    PolicyID $
+        Cardano.Ledger.Hashes.ScriptHash $
+            mkHash28 n
+
 -- --------------------------------------------------
 -- Spec
 -- --------------------------------------------------
@@ -97,6 +121,8 @@ spec = describe "TxBuild" $ do
     payToSpec
     collateralSpec
     spendIndexSpec
+    scriptSpendSpec
+    mintSpec
 
 spendSpec :: Spec
 spendSpec =
@@ -209,6 +235,139 @@ spendIndexSpec =
             -- mkTxIn 1 is at index 0, doubled = 0
             result `shouldBe` 0
 
+scriptSpendSpec :: Spec
+scriptSpendSpec =
+    describe "spendScript" $ do
+        it "produces a spending redeemer" $ do
+            let tx =
+                    draft emptyPParams $ do
+                        _ <-
+                            spendScript
+                                (mkTxIn 1)
+                                (42 :: Integer)
+                        pure ()
+                Redeemers rdmrs =
+                    tx ^. witsTxL . rdmrsTxWitsL
+            Map.keys rdmrs
+                `shouldBe` [ ConwaySpending
+                                (AsIx 0)
+                           ]
+
+        it "multiple script spends get correct indices" $
+            do
+                let tx =
+                        draft emptyPParams $ do
+                            _ <-
+                                spendScript
+                                    (mkTxIn 2)
+                                    (2 :: Integer)
+                            _ <-
+                                spendScript
+                                    (mkTxIn 1)
+                                    (1 :: Integer)
+                            pure ()
+                    Redeemers rdmrs =
+                        tx ^. witsTxL . rdmrsTxWitsL
+                Map.size rdmrs `shouldBe` 2
+                Map.member
+                    (ConwaySpending (AsIx 0))
+                    rdmrs
+                    `shouldBe` True
+                Map.member
+                    (ConwaySpending (AsIx 1))
+                    rdmrs
+                    `shouldBe` True
+
+mintSpec :: Spec
+mintSpec =
+    describe "mint" $ do
+        it "produces a minting redeemer" $ do
+            let pid = mkPolicyId 1
+                tx =
+                    draft emptyPParams $ do
+                        mint
+                            pid
+                            ( Map.singleton
+                                ( AssetName
+                                    (SBS.pack [0xDE, 0xAD])
+                                )
+                                100
+                            )
+                            (0 :: Integer)
+                Redeemers rdmrs =
+                    tx ^. witsTxL . rdmrsTxWitsL
+            Map.keys rdmrs
+                `shouldBe` [ConwayMinting (AsIx 0)]
+
+        it "includes mint in TxBody" $ do
+            let pid = mkPolicyId 1
+                assetName =
+                    AssetName (SBS.pack [0xCA, 0xFE])
+                tx =
+                    draft emptyPParams $ do
+                        mint
+                            pid
+                            (Map.singleton assetName 50)
+                            (0 :: Integer)
+                MultiAsset ma =
+                    tx ^. bodyTxL . mintTxBodyL
+            Map.lookup pid ma
+                `shouldBe` Just
+                    (Map.singleton assetName 50)
+
+        it "negative amounts produce burn" $ do
+            let pid = mkPolicyId 1
+                assetName = AssetName "tok"
+                tx =
+                    draft emptyPParams $ do
+                        mint
+                            pid
+                            ( Map.singleton
+                                assetName
+                                (-1)
+                            )
+                            (0 :: Integer)
+                MultiAsset ma =
+                    tx ^. bodyTxL . mintTxBodyL
+            Map.lookup pid ma
+                `shouldBe` Just
+                    (Map.singleton assetName (-1))
+
+        it "combined spend + mint redeemers" $ do
+            let pid = mkPolicyId 1
+                tx =
+                    draft emptyPParams $ do
+                        _ <-
+                            spendScript
+                                (mkTxIn 1)
+                                (42 :: Integer)
+                        mint
+                            pid
+                            ( Map.singleton
+                                (AssetName "t")
+                                1
+                            )
+                            (0 :: Integer)
+                Redeemers rdmrs =
+                    tx ^. witsTxL . rdmrsTxWitsL
+                hasSpend =
+                    any isSpend (Map.keys rdmrs)
+                hasMint =
+                    any isMint (Map.keys rdmrs)
+            hasSpend `shouldBe` True
+            hasMint `shouldBe` True
+            Map.size rdmrs `shouldBe` 2
+
+isSpend ::
+    ConwayPlutusPurpose AsIx ConwayEra -> Bool
+isSpend (ConwaySpending _) = True
+isSpend _ = False
+
+isMint ::
+    ConwayPlutusPurpose AsIx ConwayEra -> Bool
+isMint (ConwayMinting _) = True
+isMint _ = False
+
 {- | Run draft and return both the Tx and the
 program's result.
 -}
@@ -217,6 +376,6 @@ runDraft ::
 runDraft prog =
     let initialTx = draft emptyPParams (pure ())
         (st1, _, _) = interpretWith initialTx prog
-        tx1 = assembleTx st1
+        tx1 = assembleTx emptyPParams st1
         (st2, a, _) = interpretWith tx1 prog
-     in (assembleTx st2, a)
+     in (assembleTx emptyPParams st2, a)

--- a/test/unit-main.hs
+++ b/test/unit-main.hs
@@ -3,9 +3,11 @@ module Main (main) where
 import Test.Hspec (hspec)
 
 import Cardano.Node.Client.BalanceSpec qualified as BalanceSpec
+import Cardano.Node.Client.TxBuildSpec qualified as TxBuildSpec
 import Data.List.SampleFibonacciSpec qualified as SampleFibonacciSpec
 
 main :: IO ()
 main = hspec $ do
     SampleFibonacciSpec.spec
     BalanceSpec.spec
+    TxBuildSpec.spec


### PR DESCRIPTION
## Summary

This PR delivers the transaction builder DSL branch scope in `cardano-node-clients`: Slices 1-6 plus the matching MkDocs updates.

### Slice 1
- Introduced `TxInstr q e a` with `Spend`, `Send`, `Collateral`, and `Peek`
- Added `Convergence a = Iterate a | Ok a`
- Added `spend`, `payTo`, and `collateral`
- Added the pure two-pass `draft` interpreter
- Introduced `Interpret` and `InterpretIO`

### Slice 2
- Added script and minting witnesses
- Added `spendScript`, `mint`, `payTo'`, `attachScript`, and `requireSignature`
- Assembled redeemers automatically for spending and minting
- Computed script integrity hash and carried script witnesses into the transaction

### Slice 3
- Added the `build` interpreter with `Peek` fixpoint iteration
- Evaluated scripts, patched `ExUnits`, recomputed integrity hash, and balanced the transaction
- Stopped when all `Peek`s converged and the tx body stabilized

### Slice 4
- Added `Ctx :: q a -> TxInstr q e a`
- Added the `ctx` smart constructor
- Added `draftWith :: PParams ConwayEra -> Interpret q -> TxBuild q e a -> Tx ConwayEra`
- Updated `build` to take `InterpretIO q` and resolve effectful context queries in the interpreter loop
- Added coverage for both pure `draftWith` and effectful `build` context resolution paths

### Slice 5
- Added `Valid :: (Tx ConwayEra -> Check e) -> TxInstr q e ()`
- Added `Check e = Pass | LedgerFail LedgerCheck | CustomFail e`
- Added `LedgerCheck` constructors for min-UTxO and tx-size failures
- Added `valid`, `checkMinUtxo`, and `checkTxSize`
- Updated `build` to run validations only after `Peek` convergence and balancing, returning `Left (ChecksFailed [...])` on failure
- Added `cardano-binary` to the library dependencies for encoded tx-size measurement

### Slice 6
- Added `Reference :: TxIn -> TxInstr q e ()`
- Added `SetValidFrom :: SlotNo -> TxInstr q e ()` and `SetValidTo :: SlotNo -> TxInstr q e ()`
- Added `reference`, `validFrom`, and `validTo`
- Extended `TxState` and `assembleTx` to populate `referenceInputsTxBodyL` and `vldtTxBodyL`
- Added retract-shaped assembly coverage for reference inputs, validity bounds, and required signers
- Added `cardano-ledger-allegra` and unit-test `cardano-slotting` dependencies needed for the new types and tests

## Documentation

MkDocs now reflects the final branch scope rather than downstream follow-on work:
- added a dedicated `docs/modules/txbuild.md` page
- added `TxBuild` to the MkDocs navigation
- updated the home page, architecture page, and WIP/spec artifacts to stop advertising downstream MPFS migrations as part of this branch
- added concrete usage examples for:
  - pure `draft`
  - pure `draftWith`
  - effectful `build`
  - `Peek` + `Valid`
  - reference inputs and validity windows
- ignored generated `site/` output so `mkdocs build --strict` does not dirty the worktree

Verified with:
- `nix develop --quiet -c mkdocs build --strict`

## Tests

`TxBuildSpec` covers:
- spend / payTo / collateral assembly
- spend index resolution
- script-spend redeemer indexing
- mint / burn redeemer assembly
- `Peek` through `build`
- `Ctx` through `draftWith`
- `Ctx` through `build` with `InterpretIO`
- custom `Valid` failures
- `checkMinUtxo` failures
- `checkTxSize` failures
- all-pass validation
- reference-input and validity-interval assembly

Verified with:
- `nix develop --quiet -c just build`
- `nix develop --quiet -c cabal test unit-tests -O0 --test-options='--match "TxBuild"'`
- `nix develop --quiet -c mkdocs build --strict`

## Reviewer Notes

The key interpreter behavior is split across three layers:
- `interpretWith` is the pure wrapper over `interpretWithM`
- `draft` remains the no-context entry point and fails fast if `ctx` is used without `draftWith`
- `build` resolves `Ctx`, converges all `Peek`s, balances the transaction, and only then runs `Valid`

The assembly state now also tracks reference inputs and validity bounds, but these changes remain local to the Tx DSL and do not affect the existing N2C/provider code paths.

Ref: #36
