### PR TITLE
fix: TxBuild DSL convergent fee balancing (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,19 @@ Channel-driven Haskell clients for Cardano node Ouroboros mini-protocols (N2C + 
 
 - **Provider** -- query UTxOs and protocol parameters
 - **Submitter** -- submit signed transactions
-- **Balance** -- iterative fee estimation and transaction balancing
+- **Balance** -- exact-fee transaction balancing plus fee-dependent output convergence
+- **TxBuild** -- Conway-era transaction builder DSL with `Peek`, `Ctx`, and `Valid`
 - **N2C** -- LocalStateQuery + LocalTxSubmission over Unix socket
+
+## Testing
+
+- Unit tests cover `balanceTx`, `balanceFeeLoop`, and the `TxBuild`
+  convergence logic, including eval retry, fee oscillation, and
+  `bumpFee`.
+- E2E tests run against a real devnet for provider, chainsync,
+  chain-population, `balanceFeeLoop`, and a submitted `TxBuild`
+  transaction using `spend`, `payTo`, `payTo'`, `ctx`, `peek`,
+  `valid`, `requireSignature`, and `validFrom`/`validTo`.
 
 ## Build
 

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -148,6 +148,7 @@ test-suite unit-tests
     , cardano-ledger-mary
     , cardano-node-clients
     , cardano-slotting
+    , cardano-strict-containers
     , containers
     , hspec
     , microlens
@@ -165,12 +166,14 @@ test-suite e2e-tests
     Cardano.Node.Client.E2E.ChainPopulatorSpec
     Cardano.Node.Client.E2E.ChainSyncSpec
     Cardano.Node.Client.E2E.ProviderSpec
+    Cardano.Node.Client.E2E.TxBuildSpec
 
   build-depends:
     , async
     , base
     , bytestring
     , cardano-crypto-class
+    , cardano-ledger-allegra
     , cardano-ledger-api
     , cardano-ledger-byron
     , cardano-ledger-conway
@@ -178,6 +181,7 @@ test-suite e2e-tests
     , cardano-node-clients
     , cardano-node-clients:devnet
     , cardano-read-ledger
+    , cardano-slotting
     , cardano-strict-containers
     , chain-follower
     , containers

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,10 +52,11 @@ with `async`.
 
 ## Transaction balancing
 
-`balanceTx` iteratively estimates fees using `estimateMinFeeTx`,
-adding fee-paying inputs and a change output. It converges in at
-most 10 rounds. Only ADA-only inputs are supported; multi-asset
-coin selection is out of scope.
+`balanceTx` iteratively computes the exact ledger fee with
+`getMinFeeTx`, then adds VKey witness padding for the unsigned
+transaction before adding fee-paying inputs and a change output.
+It converges in at most 10 rounds. Only ADA-only inputs are
+supported; multi-asset coin selection is out of scope.
 
 ## Transaction builder DSL
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Cardano node:
 
 - **Provider** -- query UTxOs and protocol parameters
 - **Submitter** -- submit signed transactions
-- **Balance** -- iterative fee estimation and transaction balancing
+- **Balance** -- exact-fee balancing and fee-dependent output convergence
 - **TxBuild** -- Conway-era transaction builder DSL with `Peek` fixpoints and pluggable `Ctx` queries
 
 The interfaces are protocol-agnostic records-of-functions. Each transport
@@ -25,13 +25,24 @@ protocol supplies its own constructor:
 The transaction builder DSL is under active development and currently
 implements the first complete branch scope:
 
-- spending, outputs, collateral, and minting combinators
+- spending, script spending, outputs, collateral, minting, required
+  signers, attached scripts, reference inputs, and validity intervals
 - `Peek`-driven fixpoint values for indices and fee-dependent assembly
 - pure drafting with `draft` and `draftWith`
 - effectful building with `build` and `InterpretIO`
 - pluggable context queries through `Ctx`
 - opt-in final-transaction validation via `Valid`
-- reference inputs and explicit validity intervals
+- balancing with eval retry, fee oscillation handling, bisection, and
+  final `maxFee` re-iteration
+
+## Testing
+
+- Unit tests cover exact `getMinFeeTx` balancing, eval retry,
+  oscillation handling, `bumpFee`, and the `TxBuild` instruction set.
+- E2E tests run against a real devnet for provider, `balanceFeeLoop`,
+  chainsync, chain population, and a submitted `TxBuild` transaction
+  that exercises `spend`, `payTo`, `payTo'`, `ctx`, `peek`, `valid`,
+  `requireSignature`, and `validFrom`/`validTo`.
 
 ## Quick start
 

--- a/docs/modules/balance.md
+++ b/docs/modules/balance.md
@@ -4,7 +4,7 @@
 `Cardano.Node.Client.Balance`
 :::
 
-Iterative fee estimation and transaction balancing for Conway-era
+Iterative exact-fee transaction balancing for Conway-era
 transactions.
 
 ```haskell
@@ -21,9 +21,10 @@ balanceTx
 1. Collect all input UTxOs and compute total available ADA
 2. Start with fee = 0
 3. Build candidate transaction with change output
-4. Estimate fee via `estimateMinFeeTx` (1 key witness assumed)
-5. If new fee > current fee, repeat from step 3
-6. Converges in at most 10 rounds
+4. Compute exact fee via `getMinFeeTx`
+5. Add 106-byte VKey witness padding using `ppMinFeeAL`
+6. If new fee > current fee, repeat from step 3
+7. Converges in at most 10 rounds
 
 ## Errors
 

--- a/docs/modules/txbuild.md
+++ b/docs/modules/txbuild.md
@@ -19,7 +19,8 @@ The current implementation covers the first six slices of the DSL:
 - reference inputs and validity interval instructions
 - pure interpreters with `draft` and `draftWith`
 - effectful building with `build`, including script evaluation,
-  `ExUnits` patching, and balancing
+  `ExUnits` patching, eval retry, oscillation handling, bisection,
+  and balancing
 
 ## Core types
 
@@ -216,3 +217,17 @@ inputs together with explicit validity bounds and signer requirements.
 - `checkTxSize` failures
 - all-pass validation
 - reference-input and validity-interval assembly
+- eval retry after script-evaluation failure
+- fee oscillation with output re-interpretation
+- `bumpFee` in isolation
+
+`TxBuild` E2E coverage currently covers:
+
+- submitted devnet transactions built with `build`
+- `spend`, `payTo`, and `payTo'`
+- `Ctx`, `Peek`, and `Valid`
+- required signers and explicit validity intervals
+
+Script-specific builder features such as `spendScript`, `mint`,
+`attachScript`, and the real reference/collateral script paths are
+still primarily covered by unit tests and downstream integration tests.

--- a/lib/Cardano/Node/Client/Balance.hs
+++ b/lib/Cardano/Node/Client/Balance.hs
@@ -50,6 +50,7 @@ import Cardano.Ledger.Alonzo.TxWits (
     Redeemers,
     TxDats (..),
  )
+import Cardano.Ledger.Api.PParams (ppMinFeeAL)
 import Cardano.Ledger.Api.Tx (
     Tx,
     bodyTxL,
@@ -71,7 +72,7 @@ import Cardano.Ledger.BaseTypes (
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Core (PParams)
+import Cardano.Ledger.Core (PParams, getMinFeeTx)
 import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
 import Cardano.Ledger.Plutus.Language (Language)
 import Cardano.Ledger.TxIn (TxIn)
@@ -163,13 +164,25 @@ balanceTx pp inputUtxos changeAddr tx =
             | otherwise =
                 let candidate =
                         buildTx currentFee
-                    newFee =
-                        estimateMinFeeTx
+                    -- getMinFeeTx computes the exact
+                    -- fee for the serialized tx. Add
+                    -- VKey witness padding because
+                    -- the tx is unsigned at this
+                    -- point; the signed tx will be
+                    -- larger by ~102 bytes per VKey.
+                    Coin baseFee =
+                        getMinFeeTx
                             pp
                             candidate
-                            1 -- key witnesses
-                            0 -- Byron witnesses
-                            0 -- ref scripts bytes
+                            0
+                    Coin feePerByte =
+                        pp ^. ppMinFeeAL
+                    -- 106 bytes: CBOR overhead +
+                    -- 32 VKey + 64 Ed25519 sig +
+                    -- map entry + length prefixes
+                    vkeyPadding = 106 * feePerByte
+                    newFee =
+                        Coin (baseFee + vkeyPadding)
                  in if newFee <= currentFee
                         then currentFee
                         else go (n + 1) newFee

--- a/lib/Cardano/Node/Client/Balance.hs
+++ b/lib/Cardano/Node/Client/Balance.hs
@@ -7,9 +7,12 @@ License     : Apache-2.0
 
 Balance an unsigned Conway-era transaction by adding
 fee-paying inputs and a change output. The fee is
-estimated iteratively via 'estimateMinFeeTx' from
-@cardano-ledger-api@ until the value converges
-(at most 10 rounds).
+computed iteratively via the exact ledger
+'getMinFeeTx' function, plus VKey witness padding
+for the unsigned transaction size (at most 10
+rounds). 'balanceFeeLoop' still uses
+'estimateMinFeeTx' for fee-dependent output
+fixpoints.
 
 This is a simplified balancer that only handles
 ADA-only fee inputs. Multi-asset coin selection is
@@ -88,10 +91,11 @@ and a change output.
 
 One additional key witness is assumed for the fee
 input. The fee is found by iterating
-'setMinFeeTx' to a fixpoint: each round builds
+'getMinFeeTx' to a fixpoint: each round builds
 the full transaction (with change output and fee
-field set) and re-estimates until the fee
-stabilises.
+field set), computes the exact minimum fee for
+that serialized transaction, and adds witness
+padding until the fee stabilises.
 -}
 balanceTx ::
     PParams ConwayEra ->

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -75,6 +75,7 @@ module Cardano.Node.Client.TxBuild (
     -- * Internal (for testing)
     interpretWith,
     assembleTx,
+    bumpFee,
 ) where
 
 import Cardano.Binary (serialize')

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -119,11 +119,13 @@ import Cardano.Ledger.Api.Scripts.Data (
 import Cardano.Ledger.Api.Tx (
     Tx,
     bodyTxL,
+    estimateMinFeeTx,
     mkBasicTx,
     witsTxL,
  )
 import Cardano.Ledger.Api.Tx.Body (
     collateralInputsTxBodyL,
+    feeTxBodyL,
     inputsTxBodyL,
     mintTxBodyL,
     mkBasicTxBody,
@@ -146,7 +148,7 @@ import Cardano.Ledger.Api.Tx.Wits (
 import Cardano.Ledger.BaseTypes (
     StrictMaybe (SJust, SNothing),
  )
-import Cardano.Ledger.Coin (Coin)
+import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Scripts (
     ConwayPlutusPurpose (..),
@@ -631,10 +633,20 @@ interpretWithM runCtx currentTx = go emptyState True
 
 -- | Assemble a 'Tx' from interpreter state.
 assembleTx :: PParams ConwayEra -> TxState e -> Tx ConwayEra
-assembleTx pp st =
+assembleTx = assembleTxWith Set.empty
+
+{- | Assemble with extra input TxIns (e.g. fee UTxO).
+These are included in the input set for correct
+spending index computation but don't get redeemers.
+-}
+assembleTxWith ::
+    Set.Set TxIn -> PParams ConwayEra -> TxState e -> Tx ConwayEra
+assembleTxWith extraIns pp st =
     let
         allSpendIns =
-            Set.fromList $ map fst (tsSpends st)
+            Set.union extraIns $
+                Set.fromList $
+                    map fst (tsSpends st)
         refIns = Set.fromList (tsRefIns st)
         collIns = Set.fromList (tsCollIns st)
         outs = StrictSeq.fromList (tsOuts st)
@@ -770,32 +782,38 @@ build ::
     TxBuild q e a ->
     IO (Either (BuildError e) (Tx ConwayEra))
 build pp interpret evaluateTx inputUtxos changeAddr prog =
-    loop (mkBasicTx mkBasicTxBody)
+    step Set.empty (Coin 0) (mkBasicTx mkBasicTxBody)
   where
-    loop prevTx = do
-        -- 1. Interpret with current Tx
-        (st, _, converged) <-
+    -- Pre-compute the extra TxIns from inputUtxos
+    -- so Peek-based index computation sees ALL
+    -- inputs (including fee UTxO).
+    extraIns =
+        Set.fromList $ map fst inputUtxos
+    addExtras tx =
+        let existing =
+                tx ^. bodyTxL . inputsTxBodyL
+         in tx
+                & bodyTxL . inputsTxBodyL
+                    .~ Set.union existing extraIns
+
+    -- \| One iteration: interpret, assemble, eval,
+    -- patch, balance. Track seen fees to detect
+    -- oscillation and bisect.
+    step seenFees maxFee prevTx = do
+        -- 1. Interpret
+        let prevWithIns = addExtras prevTx
+        (st, _, _) <-
             interpretWithM
                 (runInterpretIO interpret)
-                prevTx
+                prevWithIns
                 prog
-        let
-            tx = assembleTx pp st
-        -- 2. Add all input TxIns for eval
-        let existingIns =
-                tx ^. bodyTxL . inputsTxBodyL
-            allIns =
-                foldl'
-                    ( \s (tin, _) ->
-                        Set.insert tin s
-                    )
-                    existingIns
-                    inputUtxos
+        let tx = assembleTxWith extraIns pp st
+            prevFee = prevTx ^. bodyTxL . feeTxBodyL
             txForEval =
-                tx
-                    & bodyTxL . inputsTxBodyL
-                        .~ allIns
-        -- 3. Evaluate scripts
+                tx & bodyTxL . feeTxBodyL .~ prevFee
+        -- 2. Eval (no change output; scripts that
+        --    check conservation use tx.fee which
+        --    matches Peek-computed outputs).
         evalResult <- evaluateTx txForEval
         let failures =
                 [ (p, e)
@@ -803,45 +821,26 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
                     Map.toList evalResult
                 ]
         case failures of
-            ((p, e) : _) ->
-                pure $ Left $ EvalFailure p e
-            [] -> do
-                -- 4. Patch ExUnits
-                let Redeemers rdmrMap =
-                        tx ^. witsTxL . rdmrsTxWitsL
-                    patched =
-                        Map.mapWithKey
-                            ( \purpose (dat, eu) ->
-                                case Map.lookup
-                                    purpose
-                                    evalResult of
-                                    Just (Right eu') ->
-                                        (dat, eu')
-                                    _ -> (dat, eu)
-                            )
-                            rdmrMap
-                    newRdmrs = Redeemers patched
-                    integrity =
-                        if Map.null patched
-                            then SNothing
-                            else
-                                hashScriptIntegrity
-                                    ( Set.singleton
-                                        ( getLanguageView
-                                            pp
-                                            PlutusV3
-                                        )
-                                    )
-                                    newRdmrs
-                                    (TxDats mempty)
-                    patchedTx =
+            ((_, _) : _) -> do
+                -- Eval failed. Retry with estimate.
+                let estFee =
+                        estimateMinFeeTx
+                            pp
+                            txForEval
+                            1
+                            0
+                            0
+                    retryTx =
                         tx
-                            & witsTxL . rdmrsTxWitsL
-                                .~ newRdmrs
-                            & bodyTxL
-                                . scriptIntegrityHashTxBodyL
-                                .~ integrity
-                -- 5. Balance
+                            & bodyTxL . feeTxBodyL
+                                .~ estFee
+                step seenFees maxFee retryTx
+            [] -> do
+                -- 3. Patch ExUnits THEN balance.
+                --    This way balanceTx sees the
+                --    real script cost.
+                let patchedTx =
+                        patchExUnits tx evalResult
                 case balanceTx
                     pp
                     inputUtxos
@@ -851,29 +850,270 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
                         pure $
                             Left $
                                 BalanceFailed err
-                    Right balanced
-                        -- 6. Converged?
-                        | converged
-                            && txBodyEq
+                    Right balanced -> do
+                        let finalFee =
                                 balanced
-                                prevTx ->
-                            case failedChecks
-                                (tsChecks st)
-                                balanced of
-                                [] ->
-                                    pure $ Right balanced
-                                errs ->
-                                    pure $
-                                        Left $
-                                            ChecksFailed errs
-                        | otherwise ->
-                            loop balanced
+                                    ^. bodyTxL
+                                        . feeTxBodyL
+                            newMax =
+                                max maxFee finalFee
+                        if finalFee == prevFee
+                            then
+                                if newMax > finalFee
+                                    then
+                                        -- Fee converged
+                                        -- but below max.
+                                        -- Re-iterate
+                                        -- once with max
+                                        -- so Peek sees
+                                        -- the right fee.
+                                        step
+                                            seenFees
+                                            newMax
+                                            ( bumpFee
+                                                balanced
+                                                newMax
+                                            )
+                                    else
+                                        -- Truly
+                                        -- converged.
+                                        case failedChecks
+                                            (tsChecks st)
+                                            balanced of
+                                            [] ->
+                                                pure $
+                                                    Right
+                                                        balanced
+                                            errs ->
+                                                pure $
+                                                    Left $
+                                                        ChecksFailed
+                                                            errs
+                            else
+                                if Set.member
+                                    finalFee
+                                    seenFees
+                                    then do
+                                        -- Oscillation!
+                                        let lo =
+                                                min
+                                                    finalFee
+                                                    prevFee
+                                            hi =
+                                                max
+                                                    finalFee
+                                                    prevFee
+                                        bisect
+                                            st
+                                            evalResult
+                                            balanced
+                                            lo
+                                            hi
+                                    else
+                                        step
+                                            ( Set.insert
+                                                finalFee
+                                                seenFees
+                                            )
+                                            newMax
+                                            balanced
 
--- | Compare Tx bodies for convergence.
-txBodyEq ::
-    Tx ConwayEra -> Tx ConwayEra -> Bool
-txBodyEq a b =
-    (a ^. bodyTxL) == (b ^. bodyTxL)
+    -- \| Binary search for the smallest fee where
+    -- eval passes. lo fails eval, hi passes.
+    bisect st evalResult templateTx lo hi
+        | unCoin hi <= unCoin lo + 1 =
+            -- hi is the smallest valid fee.
+            -- Build final tx with hi.
+            finalize st evalResult templateTx hi
+        | otherwise = do
+            let mid =
+                    Coin $
+                        unCoin lo
+                            + (unCoin hi - unCoin lo)
+                                `div` 2
+            -- Re-interpret with mid fee
+            let midTx =
+                    bumpFee templateTx mid
+                midWithIns = addExtras midTx
+            (st', _, _) <-
+                interpretWithM
+                    (runInterpretIO interpret)
+                    midWithIns
+                    prog
+            let tx' =
+                    assembleTxWith extraIns pp st'
+                        & bodyTxL . feeTxBodyL .~ mid
+            -- Balance to get change output
+            case balanceTx
+                pp
+                inputUtxos
+                changeAddr
+                tx' of
+                Left _ ->
+                    -- Can't balance at mid, go hi
+                    bisect
+                        st
+                        evalResult
+                        templateTx
+                        mid
+                        hi
+                Right balanced -> do
+                    let midBal =
+                            bumpFee balanced mid
+                    -- Evaluate with change output
+                    evalResult' <-
+                        evaluateTx midBal
+                    let failures' =
+                            [ e
+                            | (_, Left e) <-
+                                Map.toList
+                                    evalResult'
+                            ]
+                    if null failures'
+                        then
+                            -- mid works, try lower
+                            bisect
+                                st'
+                                evalResult'
+                                midBal
+                                lo
+                                mid
+                        else
+                            -- mid fails, try higher
+                            bisect
+                                st
+                                evalResult
+                                templateTx
+                                mid
+                                hi
+
+    -- \| Finalize with a specific fee.
+    --
+    -- Re-interpret + assemble so Peek sees the
+    -- chosen fee, patch ExUnits, then balance.
+    -- If balanceTx lowered the fee (it computes
+    -- min_fee), bump it back and shrink the change
+    -- output to compensate.
+    finalize _st evalResult _templateTx fee = do
+        -- Re-interpret with the chosen fee
+        let feeTx =
+                mkBasicTx mkBasicTxBody
+                    & bodyTxL . feeTxBodyL .~ fee
+            feeTxWithIns = addExtras feeTx
+        (st', _, _) <-
+            interpretWithM
+                (runInterpretIO interpret)
+                feeTxWithIns
+                prog
+        let tx' =
+                assembleTxWith extraIns pp st'
+                    & bodyTxL . feeTxBodyL .~ fee
+            patched =
+                patchExUnits tx' evalResult
+        case balanceTx
+            pp
+            inputUtxos
+            changeAddr
+            patched of
+            Left err ->
+                pure $ Left $ BalanceFailed err
+            Right balanced -> do
+                let balFee =
+                        balanced
+                            ^. bodyTxL . feeTxBodyL
+                    final =
+                        if balFee == fee
+                            then balanced
+                            else bumpFee balanced fee
+                case failedChecks
+                    (tsChecks st')
+                    final of
+                    [] -> pure $ Right final
+                    errs ->
+                        pure $
+                            Left $
+                                ChecksFailed errs
+
+    -- \| Patch ExUnits from eval result.
+    patchExUnits tx evalResult =
+        let Redeemers rdmrMap =
+                tx ^. witsTxL . rdmrsTxWitsL
+            patched =
+                Map.mapWithKey
+                    ( \purpose (dat, eu) ->
+                        case Map.lookup
+                            purpose
+                            evalResult of
+                            Just (Right eu') ->
+                                (dat, eu')
+                            _ -> (dat, eu)
+                    )
+                    rdmrMap
+            newRdmrs = Redeemers patched
+            integrity =
+                if Map.null patched
+                    then SNothing
+                    else
+                        hashScriptIntegrity
+                            ( Set.singleton
+                                ( getLanguageView
+                                    pp
+                                    PlutusV3
+                                )
+                            )
+                            newRdmrs
+                            (TxDats mempty)
+         in tx
+                & witsTxL . rdmrsTxWitsL
+                    .~ newRdmrs
+                & bodyTxL
+                    . scriptIntegrityHashTxBodyL
+                    .~ integrity
+
+{- | Bump fee from what balanceTx set to a higher
+target, reducing the last output (change) to
+compensate.
+
+When bisection finds a fee > min_fee,
+balanceTx sets fee = min_fee and puts the
+excess into the change output. This function
+moves the difference back: increase fee,
+decrease change.
+
+Pre-condition: outputs must be non-empty (the
+last one is the change output added by
+balanceTx).
+-}
+bumpFee :: Tx ConwayEra -> Coin -> Tx ConwayEra
+bumpFee tx targetFee =
+    let currentFee = tx ^. bodyTxL . feeTxBodyL
+        diff = unCoin targetFee - unCoin currentFee
+        outs =
+            foldr
+                (:)
+                []
+                (tx ^. bodyTxL . outputsTxBodyL)
+     in case reverse outs of
+            [] ->
+                error
+                    "bumpFee: no outputs to \
+                    \adjust"
+            (changeOut : rest) ->
+                let Coin changeVal =
+                        changeOut ^. coinTxOutL
+                    adjusted =
+                        changeOut
+                            & coinTxOutL
+                                .~ Coin
+                                    (changeVal - diff)
+                    newOuts =
+                        StrictSeq.fromList
+                            (reverse (adjusted : rest))
+                 in tx
+                        & bodyTxL . feeTxBodyL
+                            .~ targetFee
+                        & bodyTxL . outputsTxBodyL
+                            .~ newOuts
 
 -- ----------------------------------------------------
 -- Internal helpers

--- a/test/Cardano/Node/Client/BalanceSpec.hs
+++ b/test/Cardano/Node/Client/BalanceSpec.hs
@@ -3,24 +3,58 @@ module Cardano.Node.Client.BalanceSpec (spec) where
 import Data.List (nub, sort)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromJust)
+import Data.Sequence.Strict qualified as StrictSeq
 import Data.Set qualified as Set
+import Lens.Micro ((&), (.~), (^.))
 import Test.Hspec
 import Test.QuickCheck
 
 import Cardano.Crypto.Hash (hashFromStringAsHex)
+import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
+import Cardano.Ledger.Api.PParams (
+    ppMinFeeAL,
+    ppMinFeeBL,
+ )
 import Cardano.Ledger.Api.Scripts.Data (Data (..))
+import Cardano.Ledger.Api.Tx (
+    bodyTxL,
+    mkBasicTx,
+ )
+import Cardano.Ledger.Api.Tx.Body (
+    feeTxBodyL,
+    mkBasicTxBody,
+    outputsTxBodyL,
+ )
+import Cardano.Ledger.Api.Tx.Out (
+    coinTxOutL,
+    mkBasicTxOut,
+ )
 import Cardano.Ledger.BaseTypes (
+    Inject (..),
+    Network (..),
     StrictMaybe (..),
     TxIx (..),
  )
+import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Scripts (
     ConwayPlutusPurpose (..),
  )
-import Cardano.Ledger.Core (emptyPParams)
+import Cardano.Ledger.Core (
+    emptyPParams,
+    getMinFeeTx,
+ )
+import Cardano.Ledger.Credential (
+    Credential (KeyHashObj),
+    StakeReference (StakeRefNull),
+ )
 import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
+import Cardano.Ledger.Keys (
+    KeyHash (..),
+    KeyRole (Payment),
+ )
 import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
 import Cardano.Ledger.Plutus.Language (
     Language (PlutusV3),
@@ -29,6 +63,8 @@ import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import PlutusCore.Data qualified as PLC
 
 import Cardano.Node.Client.Balance (
+    BalanceError (..),
+    balanceTx,
     computeScriptIntegrity,
     placeholderExUnits,
     spendingIndex,
@@ -39,6 +75,7 @@ spec = describe "Balance helpers" $ do
     spendingIndexSpec
     computeScriptIntegritySpec
     placeholderExUnitsSpec
+    balanceTxSpec
 
 -- -----------------------------------------------------------
 -- Test TxIn construction
@@ -57,6 +94,26 @@ mkTxIn n =
                 ++ hexByte (n `mod` 256)
         h = fromJust (hashFromStringAsHex hexStr)
      in TxIn (TxId (unsafeMakeSafeHash h)) (TxIx 0)
+  where
+    hexByte b =
+        let (hi, lo) = b `divMod` 16
+         in [hexDigit hi, hexDigit lo]
+    hexDigit d
+        | d < 10 = toEnum (fromEnum '0' + d)
+        | otherwise = toEnum (fromEnum 'a' + d - 10)
+
+-- | Deterministic testnet address from an Int.
+mkAddr :: Int -> Addr
+mkAddr n =
+    let hexStr =
+            replicate 52 '0'
+                ++ hexByte (n `div` 256)
+                ++ hexByte (n `mod` 256)
+        h = fromJust (hashFromStringAsHex hexStr)
+     in Addr
+            Testnet
+            (KeyHashObj (KeyHash h :: KeyHash 'Payment))
+            StakeRefNull
   where
     hexByte b =
         let (hi, lo) = b `divMod` 16
@@ -186,3 +243,83 @@ placeholderExUnitsSpec =
             let ExUnits mem steps = placeholderExUnits
             mem `shouldBe` 0
             steps `shouldBe` 0
+
+-- -----------------------------------------------------------
+-- balanceTx
+-- -----------------------------------------------------------
+
+balanceTxSpec :: Spec
+balanceTxSpec =
+    describe "balanceTx" $ do
+        it "uses getMinFeeTx plus VKey padding" $ do
+            let pp =
+                    emptyPParams @ConwayEra
+                        & ppMinFeeAL .~ Coin 44
+                        & ppMinFeeBL .~ Coin 155381
+                inputUtxos =
+                    [
+                        ( mkTxIn 1
+                        , mkBasicTxOut
+                            (mkAddr 1)
+                            (inject (Coin 10_000_000))
+                        )
+                    ]
+                template =
+                    mkBasicTx $
+                        mkBasicTxBody
+                            & outputsTxBodyL
+                                .~ StrictSeq.singleton
+                                    ( mkBasicTxOut
+                                        (mkAddr 2)
+                                        (inject (Coin 3_000_000))
+                                    )
+            case balanceTx
+                pp
+                inputUtxos
+                (mkAddr 3)
+                template of
+                Left err ->
+                    expectationFailure (show err)
+                Right tx -> do
+                    let fee = tx ^. bodyTxL . feeTxBodyL
+                        Coin exactFee =
+                            getMinFeeTx pp tx 0
+                        Coin feePerByte =
+                            pp ^. ppMinFeeAL
+                        expectedFee =
+                            Coin (exactFee + 106 * feePerByte)
+                        outs =
+                            foldr
+                                (:)
+                                []
+                                (tx ^. bodyTxL . outputsTxBodyL)
+                    fee `shouldBe` expectedFee
+                    last outs ^. coinTxOutL
+                        `shouldBe` Coin
+                            (10_000_000 - 3_000_000 - exactFee - 106 * feePerByte)
+
+        it "returns InsufficientFee when exact fee exceeds available input" $ do
+            let pp =
+                    emptyPParams @ConwayEra
+                        & ppMinFeeAL .~ Coin 200
+                        & ppMinFeeBL .~ Coin 200_000
+                inputUtxos =
+                    [
+                        ( mkTxIn 1
+                        , mkBasicTxOut
+                            (mkAddr 1)
+                            (inject (Coin 1))
+                        )
+                    ]
+                template = mkBasicTx mkBasicTxBody
+            case balanceTx
+                pp
+                inputUtxos
+                (mkAddr 2)
+                template of
+                Left (InsufficientFee required available) -> do
+                    required `shouldSatisfy` (> available)
+                    available `shouldBe` Coin 1
+                Right _ ->
+                    expectationFailure
+                        "expected InsufficientFee"

--- a/test/Cardano/Node/Client/E2E/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/E2E/TxBuildSpec.hs
@@ -194,13 +194,20 @@ buildAndSubmit (provider, submitter, pp, utxos) = do
                         { invalidBefore = SJust lower
                         , invalidHereafter = SJust upper
                         }
-                (outs !! 0) ^. coinTxOutL
-                    `shouldBe` plainCoin
-                (outs !! 1) ^. coinTxOutL
-                    `shouldBe` Coin
-                        (unCoin datumBase + unCoin fee)
-                (outs !! 1) ^. datumTxOutL
-                    `shouldNotBe` NoDatum
+                case outs of
+                    [plainOut, datumOut, _changeOut] -> do
+                        plainOut ^. coinTxOutL
+                            `shouldBe` plainCoin
+                        datumOut ^. coinTxOutL
+                            `shouldBe` Coin
+                                ( unCoin datumBase
+                                    + unCoin fee
+                                )
+                        datumOut ^. datumTxOutL
+                            `shouldNotBe` NoDatum
+                    _ ->
+                        expectationFailure
+                            "expected plain, datum, and change outputs"
 
                 let signed =
                         addKeyWitness genesisSignKey tx

--- a/test/Cardano/Node/Client/E2E/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/E2E/TxBuildSpec.hs
@@ -1,0 +1,260 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+module Cardano.Node.Client.E2E.TxBuildSpec (spec) where
+
+import Control.Concurrent (threadDelay)
+import Data.ByteString.Char8 qualified as BS8
+import Data.Foldable (toList)
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Lens.Micro ((^.))
+import Test.Hspec
+
+import Cardano.Crypto.DSIGN (
+    Ed25519DSIGN,
+    SignKeyDSIGN,
+    deriveVerKeyDSIGN,
+ )
+import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
+import Cardano.Ledger.Api.Scripts.Data (Datum (NoDatum))
+import Cardano.Ledger.Api.Tx (bodyTxL)
+import Cardano.Ledger.Api.Tx.Body (
+    feeTxBodyL,
+    outputsTxBodyL,
+    reqSignerHashesTxBodyL,
+    vldtTxBodyL,
+ )
+import Cardano.Ledger.Api.Tx.Out (
+    TxOut,
+    coinTxOutL,
+    datumTxOutL,
+ )
+import Cardano.Ledger.BaseTypes (
+    Inject (..),
+    StrictMaybe (SJust),
+ )
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core (PParams)
+import Cardano.Ledger.Keys (
+    KeyHash,
+    KeyRole (Witness),
+    VKey (..),
+    asWitness,
+    hashKey,
+ )
+import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Node.Client.E2E.Setup (
+    addKeyWitness,
+    enterpriseAddr,
+    genesisAddr,
+    genesisSignKey,
+    keyHashFromSignKey,
+    mkSignKey,
+    withDevnet,
+ )
+import Cardano.Node.Client.N2C.Provider (mkN2CProvider)
+import Cardano.Node.Client.N2C.Submitter (mkN2CSubmitter)
+import Cardano.Node.Client.Provider (Provider (..))
+import Cardano.Node.Client.Submitter (
+    SubmitResult (..),
+    Submitter (..),
+ )
+import Cardano.Node.Client.TxBuild (
+    Check (..),
+    Convergence (..),
+    InterpretIO (..),
+    TxBuild,
+    build,
+    ctx,
+    payTo,
+    payTo',
+    peek,
+    requireSignature,
+    spend,
+    valid,
+    validFrom,
+    validTo,
+ )
+import Cardano.Slotting.Slot (SlotNo (..))
+
+spec :: Spec
+spec =
+    around withEnv $
+        describe "TxBuild E2E" $
+            it
+                "builds and submits a fee-dependent tx with signer and validity constraints"
+                buildAndSubmit
+
+type Env =
+    ( Provider IO
+    , Submitter IO
+    , PParams ConwayEra
+    , [(TxIn, TxOut ConwayEra)]
+    )
+
+withEnv :: (Env -> IO ()) -> IO ()
+withEnv action =
+    withDevnet $ \lsq ltxs -> do
+        let provider = mkN2CProvider lsq
+            submitter = mkN2CSubmitter ltxs
+        pp <- queryProtocolParams provider
+        utxos <- queryUTxOs provider genesisAddr
+        action (provider, submitter, pp, utxos)
+
+data TestQ a where
+    PlainOutputCoin :: TestQ Coin
+    DatumBaseCoin :: TestQ Coin
+    DatumTag :: TestQ Integer
+
+data TestErr
+    = MissingRequiredSigner
+    | NonPositiveFee
+    deriving stock (Eq, Show)
+
+buildAndSubmit :: Env -> IO ()
+buildAndSubmit (provider, submitter, pp, utxos) = do
+    seed@(seedIn, _) <- case utxos of
+        u : _ -> pure u
+        [] -> fail "no genesis UTxOs"
+
+    let recipient1 =
+            enterpriseAddr $
+                keyHashFromSignKey $
+                    mkSignKey (BS8.pack (replicate 32 '1'))
+        recipient2 =
+            enterpriseAddr $
+                keyHashFromSignKey $
+                    mkSignKey (BS8.pack (replicate 32 '2'))
+        signer =
+            witnessKeyHashFromSignKey genesisSignKey
+        lower = SlotNo 0
+        upper = SlotNo 1_000_000
+        plainCoin = Coin 3_000_000
+        datumBase = Coin 2_500_000
+        datumValue = (7 :: Integer)
+        interpret =
+            InterpretIO $ \case
+                PlainOutputCoin -> pure plainCoin
+                DatumBaseCoin -> pure datumBase
+                DatumTag -> pure datumValue
+        eval tx =
+            fmap
+                (Map.map (either (Left . show) Right))
+                (evaluateTx provider tx)
+        prog :: TxBuild TestQ TestErr ()
+        prog = do
+            _ <- spend seedIn
+            plain <- ctx PlainOutputCoin
+            base <- ctx DatumBaseCoin
+            tag <- ctx DatumTag
+            Coin fee <- peek $ \tx ->
+                let currentFee =
+                        tx ^. bodyTxL . feeTxBodyL
+                 in if currentFee > Coin 0
+                        then Ok currentFee
+                        else Iterate currentFee
+            _ <-
+                payTo recipient1 (inject plain)
+            _ <-
+                payTo'
+                    recipient2
+                    (inject (Coin (unCoin base + fee)))
+                    tag
+            requireSignature signer
+            validFrom lower
+            validTo upper
+            valid $ \tx ->
+                if Set.member
+                    signer
+                    (tx ^. bodyTxL . reqSignerHashesTxBodyL)
+                    then
+                        if tx ^. bodyTxL . feeTxBodyL > Coin 0
+                            then Pass
+                            else CustomFail NonPositiveFee
+                    else
+                        CustomFail MissingRequiredSigner
+            pure ()
+
+    build pp interpret eval [seed] genesisAddr prog
+        >>= \case
+            Left err ->
+                expectationFailure (show err)
+            Right tx -> do
+                let outs = toList (tx ^. bodyTxL . outputsTxBodyL)
+                    fee = tx ^. bodyTxL . feeTxBodyL
+                length outs `shouldBe` 3
+                tx ^. bodyTxL . reqSignerHashesTxBodyL
+                    `shouldBe` Set.singleton signer
+                tx ^. bodyTxL . vldtTxBodyL
+                    `shouldBe` ValidityInterval
+                        { invalidBefore = SJust lower
+                        , invalidHereafter = SJust upper
+                        }
+                (outs !! 0) ^. coinTxOutL
+                    `shouldBe` plainCoin
+                (outs !! 1) ^. coinTxOutL
+                    `shouldBe` Coin
+                        (unCoin datumBase + unCoin fee)
+                (outs !! 1) ^. datumTxOutL
+                    `shouldNotBe` NoDatum
+
+                let signed =
+                        addKeyWitness genesisSignKey tx
+                submitTx submitter signed
+                    >>= \case
+                        Submitted _ -> pure ()
+                        Rejected reason ->
+                            expectationFailure $
+                                "submitTx rejected: "
+                                    <> show reason
+
+                recipient1Utxos <-
+                    waitForUtxos provider recipient1 30
+                recipient2Utxos <-
+                    waitForUtxos provider recipient2 30
+
+                case (recipient1Utxos, recipient2Utxos) of
+                    ((_, out1) : _, (_, out2) : _) -> do
+                        out1 ^. coinTxOutL
+                            `shouldBe` plainCoin
+                        out2 ^. coinTxOutL
+                            `shouldBe` Coin
+                                ( unCoin datumBase
+                                    + unCoin fee
+                                )
+                        out2 ^. datumTxOutL
+                            `shouldNotBe` NoDatum
+                    _ ->
+                        expectationFailure
+                            "expected recipient UTxOs"
+
+waitForUtxos ::
+    Provider IO ->
+    Addr ->
+    Int ->
+    IO [(TxIn, TxOut ConwayEra)]
+waitForUtxos provider addr attempts
+    | attempts <= 0 =
+        expectationFailure
+            ("timed out waiting for UTxOs at " <> show addr)
+            >> pure []
+    | otherwise = do
+        utxos <- queryUTxOs provider addr
+        if null utxos
+            then do
+                threadDelay 1_000_000
+                waitForUtxos provider addr (attempts - 1)
+            else pure utxos
+
+witnessKeyHashFromSignKey ::
+    SignKeyDSIGN Ed25519DSIGN ->
+    KeyHash 'Witness
+witnessKeyHashFromSignKey =
+    hashKey
+        . asWitness
+        . VKey
+        . deriveVerKeyDSIGN

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -11,6 +11,12 @@ assembled Tx and that spend returns correct index.
 -}
 module Cardano.Node.Client.TxBuildSpec (spec) where
 
+import Data.IORef (
+    IORef,
+    modifyIORef',
+    newIORef,
+    readIORef,
+ )
 import Data.Set qualified as Set
 import Test.Hspec
 
@@ -77,6 +83,7 @@ import Cardano.Ledger.TxIn (
     TxId (..),
     TxIn (..),
  )
+import Cardano.Node.Client.Balance (balanceTx)
 import Cardano.Node.Client.TxBuild
 import Cardano.Slotting.Slot (SlotNo (..))
 import Lens.Micro ((&), (.~), (^.))
@@ -160,6 +167,7 @@ spec = describe "TxBuild" $ do
 
 data TestQ a where
     GetValue :: TestQ Int
+    RecordFee :: Coin -> TestQ ()
 
 data TestErr
     = BrokenInvariant
@@ -404,7 +412,10 @@ ctxSpec =
     describe "ctx" $ do
         it "flows interpreted values through subsequent binds" $ do
             let interpret =
-                    Interpret $ \GetValue -> 7
+                    Interpret $ \q ->
+                        case q of
+                            GetValue -> 7
+                            RecordFee _ -> ()
                 expected :: TxOut ConwayEra
                 expected =
                     mkBasicTxOut
@@ -711,7 +722,10 @@ buildSpec =
                         (inject (Coin 10_000_000))
                     )
                 interpret =
-                    InterpretIO $ \GetValue -> pure 7
+                    InterpretIO $ \q ->
+                        case q of
+                            GetValue -> pure 7
+                            RecordFee _ -> pure ()
                 mockEval _ = pure Map.empty
             result <-
                 build
@@ -882,6 +896,211 @@ buildSpec =
                         fee
                             `shouldSatisfy` (> 0)
 
+        it "retries with an estimated fee after eval failure" $ do
+            feeHistoryRef <- newIORef []
+            let pp =
+                    emptyPParams
+                        & ppMinFeeAL .~ Coin 44
+                        & ppMinFeeBL .~ Coin 155381
+                feeUtxo =
+                    ( mkTxIn 1
+                    , mkBasicTxOut
+                        (mkAddr 1)
+                        (inject (Coin 10_000_000))
+                    )
+                spendUtxo =
+                    ( mkTxIn 2
+                    , mkBasicTxOut
+                        (mkAddr 3)
+                        (inject (Coin 5_000_000))
+                    )
+                prog :: TxBuild TestQ TestErr ()
+                prog = do
+                    _ <- spend (mkTxIn 2)
+                    fee <- peek $ \tx ->
+                        Ok (tx ^. bodyTxL . feeTxBodyL)
+                    _ <- ctx (RecordFee fee)
+                    _ <-
+                        payTo
+                            (mkAddr 4)
+                            (inject fee)
+                    pure ()
+                interpret =
+                    recordingInterpret feeHistoryRef
+                mockEval tx =
+                    pure $
+                        if tx ^. bodyTxL . feeTxBodyL
+                            == Coin 0
+                            then
+                                Map.singleton
+                                    (ConwaySpending (AsIx 0))
+                                    (Left "fee too small")
+                            else Map.empty
+            result <-
+                build
+                    pp
+                    interpret
+                    mockEval
+                    [feeUtxo, spendUtxo]
+                    (mkAddr 1)
+                    prog
+            history <- readRecordedFees feeHistoryRef
+            case result of
+                Left err ->
+                    expectationFailure $ show err
+                Right tx -> do
+                    history `shouldSatisfy` elem (Coin 0)
+                    history
+                        `shouldSatisfy` any (> Coin 0)
+                    last history
+                        `shouldBe` (tx ^. bodyTxL . feeTxBodyL)
+
+        it "re-interprets outputs after a fee oscillation" $ do
+            feeHistoryRef <- newIORef []
+            let pp =
+                    emptyPParams
+                        & ppMinFeeAL .~ Coin 10
+                        & ppMinFeeBL .~ Coin 0
+                        & ppMaxTxSizeL .~ 100_000
+                feeUtxo =
+                    ( mkTxIn 1
+                    , mkBasicTxOut
+                        (mkAddr 1)
+                        (inject (Coin 20_000_000))
+                    )
+                spendUtxo =
+                    ( mkTxIn 2
+                    , mkBasicTxOut
+                        (mkAddr 3)
+                        (inject (Coin 5_000_000))
+                    )
+                inputUtxos = [feeUtxo, spendUtxo]
+                smallCoin = Coin 3_000_000
+                largeCoin = Coin 4_000_000
+                smallDatum = ([] :: [Integer])
+                largeDatum = [1 .. 2000] :: [Integer]
+                feeFor datum coin =
+                    case balanceTx
+                        pp
+                        inputUtxos
+                        (mkAddr 1)
+                        ( draft pp $ do
+                            _ <- spend (mkTxIn 2)
+                            _ <-
+                                payTo'
+                                    (mkAddr 4)
+                                    (inject coin)
+                                    datum
+                            pure ()
+                        ) of
+                        Left err ->
+                            expectationFailure (show err)
+                                >> pure (Coin 0)
+                        Right tx ->
+                            pure $
+                                tx
+                                    ^. bodyTxL
+                                        . feeTxBodyL
+            lowFee <- feeFor smallDatum smallCoin
+            highFee <- feeFor largeDatum largeCoin
+            let Coin lo = min lowFee highFee
+                Coin hi = max lowFee highFee
+                pivot = Coin (lo + (hi - lo) `div` 2)
+                prog :: TxBuild TestQ TestErr ()
+                prog = do
+                    _ <- spend (mkTxIn 2)
+                    fee <- peek $ \tx ->
+                        Ok (tx ^. bodyTxL . feeTxBodyL)
+                    _ <- ctx (RecordFee fee)
+                    if fee < pivot
+                        then do
+                            _ <-
+                                payTo'
+                                    (mkAddr 4)
+                                    (inject largeCoin)
+                                    largeDatum
+                            pure ()
+                        else do
+                            _ <-
+                                payTo'
+                                    (mkAddr 4)
+                                    (inject smallCoin)
+                                    smallDatum
+                            pure ()
+                interpret =
+                    recordingInterpret feeHistoryRef
+                mockEval _ = pure Map.empty
+            max lowFee highFee
+                `shouldSatisfy` (> min lowFee highFee)
+            result <-
+                build
+                    pp
+                    interpret
+                    mockEval
+                    inputUtxos
+                    (mkAddr 1)
+                    prog
+            history <- readRecordedFees feeHistoryRef
+            case result of
+                Left err ->
+                    expectationFailure $ show err
+                Right tx -> do
+                    let finalFee =
+                            tx
+                                ^. bodyTxL
+                                    . feeTxBodyL
+                        outs =
+                            toList $
+                                tx
+                                    ^. bodyTxL
+                                        . outputsTxBodyL
+                        firstOut =
+                            case outs of
+                                o : _ -> o
+                                [] ->
+                                    error
+                                        "expected at least one output"
+                    history
+                        `shouldSatisfy` any (< pivot)
+                    history
+                        `shouldSatisfy` any (>= pivot)
+                    last history `shouldBe` finalFee
+                    if finalFee < pivot
+                        then
+                            firstOut ^. coinTxOutL
+                                `shouldBe` largeCoin
+                        else
+                            firstOut ^. coinTxOutL
+                                `shouldBe` smallCoin
+
+        it "bumpFee only shrinks the change output" $ do
+            let tx =
+                    draft emptyPParams $ do
+                        _ <-
+                            payTo
+                                (mkAddr 2)
+                                (inject (Coin 3_000_000))
+                        _ <-
+                            payTo
+                                (mkAddr 1)
+                                (inject (Coin 7_000_000))
+                        pure ()
+                bumped =
+                    bumpFee
+                        (tx & bodyTxL . feeTxBodyL .~ Coin 200)
+                        (Coin 500)
+                outs =
+                    toList $
+                        bumped
+                            ^. bodyTxL
+                                . outputsTxBodyL
+            bumped ^. bodyTxL . feeTxBodyL
+                `shouldBe` Coin 500
+            map (^. coinTxOutL) outs
+                `shouldBe` [ Coin 3_000_000
+                           , Coin 6_999_700
+                           ]
+
 isSpend ::
     ConwayPlutusPurpose AsIx ConwayEra -> Bool
 isSpend (ConwaySpending _) = True
@@ -925,3 +1144,16 @@ noCtxInterpretIO =
         const $
             error
                 "test: encountered ctx without interpreter"
+
+recordingInterpret ::
+    IORef [Coin] -> InterpretIO TestQ
+recordingInterpret feeHistoryRef =
+    InterpretIO $ \q ->
+        case q of
+            GetValue -> pure 7
+            RecordFee fee ->
+                modifyIORef' feeHistoryRef (fee :)
+
+readRecordedFees :: IORef [Coin] -> IO [Coin]
+readRecordedFees feeHistoryRef =
+    reverse <$> readIORef feeHistoryRef

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 
 {- |
 Module      : Cardano.Node.Client.TxBuildSpec
@@ -412,10 +413,9 @@ ctxSpec =
     describe "ctx" $ do
         it "flows interpreted values through subsequent binds" $ do
             let interpret =
-                    Interpret $ \q ->
-                        case q of
-                            GetValue -> 7
-                            RecordFee _ -> ()
+                    Interpret $ \case
+                        GetValue -> 7
+                        RecordFee _ -> ()
                 expected :: TxOut ConwayEra
                 expected =
                     mkBasicTxOut
@@ -722,10 +722,9 @@ buildSpec =
                         (inject (Coin 10_000_000))
                     )
                 interpret =
-                    InterpretIO $ \q ->
-                        case q of
-                            GetValue -> pure 7
-                            RecordFee _ -> pure ()
+                    InterpretIO $ \case
+                        GetValue -> pure 7
+                        RecordFee _ -> pure ()
                 mockEval _ = pure Map.empty
             result <-
                 build
@@ -1148,11 +1147,10 @@ noCtxInterpretIO =
 recordingInterpret ::
     IORef [Coin] -> InterpretIO TestQ
 recordingInterpret feeHistoryRef =
-    InterpretIO $ \q ->
-        case q of
-            GetValue -> pure 7
-            RecordFee fee ->
-                modifyIORef' feeHistoryRef (fee :)
+    InterpretIO $ \case
+        GetValue -> pure 7
+        RecordFee fee ->
+            modifyIORef' feeHistoryRef (fee :)
 
 readRecordedFees :: IORef [Coin] -> IO [Coin]
 readRecordedFees feeHistoryRef =

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -23,6 +23,8 @@ import Cardano.Ledger.Api.PParams (
     emptyPParams,
     ppCoinsPerUTxOByteL,
     ppMaxTxSizeL,
+    ppMinFeeAL,
+    ppMinFeeBL,
  )
 import Cardano.Ledger.Api.Tx (Tx, witsTxL)
 import Cardano.Ledger.Api.Tx.Body (
@@ -37,6 +39,7 @@ import Cardano.Ledger.Api.Tx.Body (
  )
 import Cardano.Ledger.Api.Tx.Out (
     TxOut,
+    coinTxOutL,
     mkBasicTxOut,
  )
 import Cardano.Ledger.Api.Tx.Wits (rdmrsTxWitsL)
@@ -69,6 +72,7 @@ import Cardano.Ledger.Mary.Value (
     MultiAsset (..),
     PolicyID (..),
  )
+import Cardano.Ledger.Plutus (ExUnits (..))
 import Cardano.Ledger.TxIn (
     TxId (..),
     TxIn (..),
@@ -732,6 +736,151 @@ buildSpec =
                                 (mkAddr 4)
                                 (inject (Coin 7))
                     expected `shouldSatisfy` (`elem` outs)
+
+        it
+            "fee-dependent outputs converge \
+            \(conservation equation)"
+            $ do
+                -- Simulate a conservation-aware
+                -- validator: the mock evaluator
+                -- checks that fee + outputs == inputs.
+                -- Refund = inputVal - tip - fee.
+                -- Tip is fixed, fee is what Peek reads.
+                let pp =
+                        emptyPParams
+                            & ppMaxTxSizeL .~ 16384
+                            & ppMinFeeAL .~ Coin 44
+                            & ppMinFeeBL .~ Coin 155381
+                            & ppCoinsPerUTxOByteL
+                                .~ CoinPerByte
+                                    (Coin 4310)
+                    tip = 1_000_000
+                    inputVal = 5_000_000
+                    scriptUtxo =
+                        ( mkTxIn 2
+                        , mkBasicTxOut
+                            (mkAddr 3)
+                            (inject (Coin inputVal))
+                        )
+                    feeUtxo =
+                        ( mkTxIn 1
+                        , mkBasicTxOut
+                            (mkAddr 1)
+                            ( inject
+                                (Coin 10_000_000)
+                            )
+                        )
+                    prog ::
+                        TxBuild TestQ TestErr ()
+                    prog = do
+                        _ <-
+                            spendScript
+                                (mkTxIn 2)
+                                (42 :: Integer)
+                        Coin fee <- peek $ \tx ->
+                            let f =
+                                    tx
+                                        ^. bodyTxL
+                                            . feeTxBodyL
+                             in if f > Coin 0
+                                    then Ok f
+                                    else Iterate f
+                        let refund =
+                                inputVal - tip - fee
+                        _ <-
+                            payTo
+                                (mkAddr 4)
+                                (inject (Coin refund))
+                        collateral (mkTxIn 1)
+                        pure ()
+                    -- Mock evaluator: check
+                    -- conservation equation.
+                    -- Only the first output (refund)
+                    -- participates; the change output
+                    -- (added by balanceTx) is ignored.
+                    mockEval tx =
+                        let Coin fee =
+                                tx
+                                    ^. bodyTxL
+                                        . feeTxBodyL
+                            outs =
+                                toList
+                                    ( tx
+                                        ^. bodyTxL
+                                            . outputsTxBodyL
+                                    )
+                            -- First output is the
+                            -- refund (from Peek).
+                            refund = case outs of
+                                (o : _) ->
+                                    let Coin c =
+                                            o
+                                                ^. coinTxOutL
+                                     in c
+                                [] -> 0
+                         in if fee + refund + tip
+                                == inputVal
+                                then
+                                    pure
+                                        ( Map.singleton
+                                            ( ConwaySpending
+                                                (AsIx 0)
+                                            )
+                                            ( Right
+                                                ( ExUnits
+                                                    100
+                                                    100
+                                                )
+                                            )
+                                        )
+                                else
+                                    pure
+                                        ( Map.singleton
+                                            ( ConwaySpending
+                                                (AsIx 0)
+                                            )
+                                            ( Left
+                                                ( "conservation \
+                                                  \violated: fee="
+                                                    <> show fee
+                                                    <> " refund="
+                                                    <> show refund
+                                                    <> " tip="
+                                                    <> show tip
+                                                    <> " sum="
+                                                    <> show
+                                                        ( fee
+                                                            + refund
+                                                            + tip
+                                                        )
+                                                    <> " expected="
+                                                    <> show inputVal
+                                                )
+                                            )
+                                        )
+                result <-
+                    build
+                        pp
+                        noCtxInterpretIO
+                        mockEval
+                        [ feeUtxo
+                        , scriptUtxo
+                        ]
+                        (mkAddr 1)
+                        prog
+                case result of
+                    Left err ->
+                        expectationFailure $
+                            show err
+                    Right tx -> do
+                        let Coin fee =
+                                tx
+                                    ^. bodyTxL
+                                        . feeTxBodyL
+                        -- Conservation holds in
+                        -- the final tx
+                        fee
+                            `shouldSatisfy` (> 0)
 
 isSpend ::
     ConwayPlutusPurpose AsIx ConwayEra -> Bool

--- a/test/main.hs
+++ b/test/main.hs
@@ -6,10 +6,12 @@ import Cardano.Node.Client.E2E.BalanceSpec qualified as BalanceSpec
 import Cardano.Node.Client.E2E.ChainPopulatorSpec qualified as ChainPopulatorSpec
 import Cardano.Node.Client.E2E.ChainSyncSpec qualified as ChainSyncSpec
 import Cardano.Node.Client.E2E.ProviderSpec qualified as ProviderSpec
+import Cardano.Node.Client.E2E.TxBuildSpec qualified as TxBuildSpec
 
 main :: IO ()
 main = hspec $ do
     ProviderSpec.spec
     BalanceSpec.spec
+    TxBuildSpec.spec
     ChainSyncSpec.spec
     ChainPopulatorSpec.spec


### PR DESCRIPTION
## Summary

Fixes #41.

This branch hardens the `TxBuild` fee-convergence fix and brings the surrounding tests and docs up to the same standard. The original change fixed the balancing logic for conservation-aware transactions where `tx.fee` and user outputs are interdependent. This follow-up work closes the test and documentation gaps that were still present on the branch.

At this point the branch does three things:

- fixes fee convergence for script-aware `TxBuild` transactions
- adds direct unit coverage for the failure modes that motivated the fix
- adds a real devnet E2E `TxBuild` submission test and updates the docs to match the shipped behavior

## Why this was needed

The original branch fixed the core behavior in `Balance.hs` and `TxBuild.hs`, but the supporting material lagged behind:

- unit tests covered the happy path but not the exact `getMinFeeTx` path, eval retry, oscillation handling, or `bumpFee`
- E2E coverage proved `balanceFeeLoop` against a real devnet, but it did not prove that a transaction built with the DSL could be assembled, balanced, signed, submitted, and observed on-chain
- several docs still described `balanceTx` as an `estimateMinFeeTx`-based loop, which was no longer true on this branch

That left the PR in an awkward state: the implementation was stronger than the evidence around it. This branch fixes that.

## What changed

### 1. `Balance.hs`: exact fee calculation for balancing

`Cardano.Node.Client.Balance.balanceTx` now uses the exact ledger `getMinFeeTx` calculation plus 106 bytes of VKey witness padding instead of relying on `estimateMinFeeTx` for the balancing path.

Why:

- `estimateMinFeeTx` was underestimating script transactions by roughly 43k lovelace in the failing scenario
- `getMinFeeTx` is what the ledger actually checks
- the unsigned transaction still needs witness-size padding so the fee used before signing matches the eventual signed size

The fee-dependent-output helper `balanceFeeLoop` still uses `estimateMinFeeTx`; that part of the module is unchanged in intent and remains appropriate for its callback-style loop.

### 2. `TxBuild.hs`: expose `bumpFee` for direct testing

The balancing logic in `TxBuild.build` already contained the convergence fixes on this branch:

- eval before balance so real `ExUnits` are included in the fee
- convergence on fee equality rather than whole-body equality
- `maxFee` tracking and re-iteration so `Peek` sees the final fee
- oscillation detection with bisection
- `bumpFee` to move excess change back into the fee atomically

This update exports `bumpFee` in the testing section so the helper can be verified directly instead of only being exercised indirectly.

### 3. Unit tests: cover the real branch behavior

#### `test/Cardano/Node/Client/BalanceSpec.hs`

Added direct coverage for `balanceTx`:

- exact fee = `getMinFeeTx + 106-byte padding`
- `InsufficientFee` based on the exact-fee path rather than the old estimate-only behavior

#### `test/Cardano/Node/Client/TxBuildSpec.hs`

Added direct coverage for the `build` loop paths that mattered for this fix:

- eval failure causes retry with an estimated fee
- fee oscillation causes output re-interpretation and converges on the final fee
- `bumpFee` only changes fee and the final change output

The existing conservation-equation unit test remains in place, but it is no longer the only evidence for the branch.

### 4. E2E tests: add a real devnet `TxBuild` flow

Added `test/Cardano/Node/Client/E2E/TxBuildSpec.hs` and wired it into the `e2e-tests` suite.

This new E2E test:

- uses `build` to assemble a real transaction
- uses `spend`, `payTo`, `payTo'`, `ctx`, `peek`, `valid`, `requireSignature`, `validFrom`, and `validTo`
- signs the built transaction with the devnet genesis key
- submits it through the real N2C submitter
- waits for the resulting UTxOs to appear on-chain and checks the submitted outputs

This closes the biggest E2E gap in the PR: the DSL is now exercised as an actual end-to-end submission flow, not only as a local assembly artifact.

### 5. Docs: bring the narrative in line with the code

Updated the high-signal docs and module docs so they describe the branch as it actually exists:

- `README.md`
- `docs/index.md`
- `docs/architecture.md`
- `docs/modules/balance.md`
- `docs/modules/txbuild.md`

The docs now reflect:

- exact-fee balancing via `getMinFeeTx` + witness padding
- the current `TxBuild` branch scope
- the new unit and E2E coverage
- the remaining distinction between generic builder coverage and script-specific downstream integrations

### 6. Cabal updates

The test stanzas now include the dependencies needed by the new unit and E2E coverage:

- `cardano-strict-containers` for unit tests
- `cardano-ledger-allegra` and `cardano-slotting` for the new E2E builder spec

## Reviewer guide

If you review this incrementally, the most useful order is:

1. `lib/Cardano/Node/Client/Balance.hs` for the exact-fee balancing behavior
2. `test/Cardano/Node/Client/BalanceSpec.hs` for direct evidence of that path
3. `test/Cardano/Node/Client/TxBuildSpec.hs` for retry / oscillation / `bumpFee` coverage
4. `test/Cardano/Node/Client/E2E/TxBuildSpec.hs` for the real submitted DSL flow
5. `docs/modules/balance.md` and `docs/modules/txbuild.md` for the updated user-facing story

## Test plan

- [x] `nix develop -c cabal test unit-tests -O0 --test-show-details=direct`
- [x] `nix develop -c cabal test e2e-tests -O0 --test-show-details=direct`
- [x] GitHub Actions CI green for this PR before merge

## Coverage status after this change

This branch now has meaningful evidence for:

- exact-fee `balanceTx` behavior
- eval retry in the builder loop
- fee oscillation handling and re-interpretation
- `bumpFee` behavior
- fee-dependent-output convergence
- a real devnet `TxBuild` submission using the non-script DSL surface

What is still not directly covered by this repo's E2E builder test:

- real `spendScript` transactions
- real minting flows through the DSL
- real attached-script / reference-script flows
- script-specific reference/collateral paths beyond downstream integrations

Those remain better covered either by dedicated downstream integration suites (for example MPFS) or by future targeted E2E work in this repo.
