### PR TITLE
feat: add TxBuild withdrawals and metadata

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -1,7 +1,7 @@
 # WIP: Transaction Builder DSL
 
 ## Status
-Slices 1-6 done, unit tests green. Branch scope complete.
+Slices 1-7 done. Issue #40 adds withdrawals and metadata.
 
 ## Links
 - PR: lambdasistemi/cardano-node-clients#38
@@ -52,8 +52,15 @@ Slices 1-6 done, unit tests green. Branch scope complete.
 - `assembleTx` now fills `referenceInputsTxBodyL` and `vldtTxBodyL`
 - Retract-shaped assembly coverage in `TxBuildSpec`
 
+### Slice 7: Withdrawals + metadata
+- `Withdraw :: RewardAccount -> Coin -> WithdrawWitness -> TxInstr q e ()`
+- `SetMetadata :: Word64 -> Metadatum -> TxInstr q e ()`
+- `withdraw`, `withdrawScript`, `setMetadata`
+- `assembleTx` now fills `withdrawalsTxBodyL`, `auxDataTxL`, and `auxDataHashTxBodyL`
+- Rewarding redeemer coverage in `TxBuildSpec`
+
 ## Tests
-24 `TxBuild` examples passing
+28 `TxBuild` examples targeted
 
 ## Key files
 - `lib/Cardano/Node/Client/TxBuild.hs`

--- a/docs/modules/txbuild.md
+++ b/docs/modules/txbuild.md
@@ -17,6 +17,8 @@ The current implementation covers the first six slices of the DSL:
 - `Ctx` for pluggable domain queries
 - `Valid` for post-convergence transaction checks
 - reference inputs and validity interval instructions
+- withdrawals with optional rewarding redeemers
+- metadata attachment via transaction auxiliary data
 - pure interpreters with `draft` and `draftWith`
 - effectful building with `build`, including script evaluation,
   `ExUnits` patching, eval retry, oscillation handling, bisection,
@@ -81,6 +83,9 @@ payTo            :: Addr -> MaryValue -> TxBuild q e Word32
 payTo'           :: ToData d => Addr -> MaryValue -> d -> TxBuild q e Word32
 output           :: TxOut ConwayEra -> TxBuild q e Word32
 mint             :: ToData r => PolicyID -> Map AssetName Integer -> r -> TxBuild q e ()
+withdraw         :: RewardAccount -> Coin -> TxBuild q e ()
+withdrawScript   :: ToData r => RewardAccount -> Coin -> r -> TxBuild q e ()
+setMetadata      :: Word64 -> Metadatum -> TxBuild q e ()
 requireSignature :: KeyHash 'Witness -> TxBuild q e ()
 attachScript     :: Script ConwayEra -> TxBuild q e ()
 reference        :: TxIn -> TxBuild q e ()
@@ -201,6 +206,19 @@ windowedTx = do
 This covers the common "read but do not spend" pattern for reference
 inputs together with explicit validity bounds and signer requirements.
 
+### Withdrawal and metadata
+
+```haskell
+annotatedWithdrawal :: TxBuild q e ()
+annotatedWithdrawal = do
+    withdraw rewardsAccount (Coin 1_000_000)
+    setMetadata 674 (S "batched withdrawal")
+```
+
+`withdraw` fills `withdrawalsTxBodyL`. `withdrawScript` also adds a
+`ConwayRewarding` redeemer for the reward account. `setMetadata`
+attaches auxiliary data and keeps `auxDataHashTxBodyL` in sync.
+
 ## Testing status
 
 `TxBuildSpec` currently covers:
@@ -217,6 +235,8 @@ inputs together with explicit validity bounds and signer requirements.
 - `checkTxSize` failures
 - all-pass validation
 - reference-input and validity-interval assembly
+- pub-key and script withdrawals
+- metadata aux-data assembly and hashing
 - eval retry after script-evaluation failure
 - fee oscillation with output re-interpretation
 - `bumpFee` in isolation

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -34,6 +34,7 @@ module Cardano.Node.Client.TxBuild (
     -- * Witnesses
     SpendWitness (..),
     MintWitness (..),
+    WithdrawWitness (..),
 
     -- * Input combinators
     spend,
@@ -48,6 +49,11 @@ module Cardano.Node.Client.TxBuild (
 
     -- * Minting
     mint,
+
+    -- * Withdrawals and metadata
+    withdraw,
+    withdrawScript,
+    setMetadata,
 
     -- * Constraints
     validFrom,
@@ -96,10 +102,14 @@ import Data.Map.Strict qualified as Map
 import Data.Sequence.Strict qualified as StrictSeq
 import Data.Set (Set)
 import Data.Set qualified as Set
-import Data.Word (Word32)
+import Data.Word (Word32, Word64)
 import Numeric.Natural (Natural)
 
-import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Address (
+    Addr,
+    RewardAccount,
+    Withdrawals (..),
+ )
 import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
 import Cardano.Ledger.Alonzo.PParams (getLanguageView)
 import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
@@ -119,6 +129,7 @@ import Cardano.Ledger.Api.Scripts.Data (
  )
 import Cardano.Ledger.Api.Tx (
     Tx,
+    auxDataTxL,
     bodyTxL,
     estimateMinFeeTx,
     mkBasicTx,
@@ -134,6 +145,7 @@ import Cardano.Ledger.Api.Tx.Body (
     referenceInputsTxBodyL,
     reqSignerHashesTxBodyL,
     vldtTxBodyL,
+    withdrawalsTxBodyL,
  )
 import Cardano.Ledger.Api.Tx.Out (
     TxOut,
@@ -157,7 +169,11 @@ import Cardano.Ledger.Conway.Scripts (
 import Cardano.Ledger.Core (
     PParams,
     Script,
+    auxDataHashTxBodyL,
     hashScript,
+    hashTxAuxData,
+    metadataTxAuxDataL,
+    mkBasicTxAuxData,
  )
 import Cardano.Ledger.Hashes (ScriptHash)
 import Cardano.Ledger.Keys (
@@ -170,6 +186,7 @@ import Cardano.Ledger.Mary.Value (
     MultiAsset (..),
     PolicyID,
  )
+import Cardano.Ledger.Metadata (Metadatum)
 import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
 import Cardano.Ledger.Plutus.Language (
     Language (PlutusV3),
@@ -231,6 +248,13 @@ data MintWitness
     = -- | Plutus script with a typed redeemer.
       forall r. (ToData r) => PlutusScriptWitness r
 
+-- | How a withdrawal is witnessed.
+data WithdrawWitness
+    = -- | Pub-key withdrawal, no redeemer needed.
+      PubKeyWithdraw
+    | -- | Script withdrawal with a typed redeemer.
+      forall r. (ToData r) => ScriptWithdraw r
+
 -- | Pure query interpreter.
 newtype Interpret q = Interpret
     { runInterpret :: forall x. q x -> x
@@ -263,6 +287,17 @@ data TxInstr q e a where
         AssetName ->
         Integer ->
         MintWitness ->
+        TxInstr q e ()
+    -- | Withdraw stake rewards.
+    Withdraw ::
+        RewardAccount ->
+        Coin ->
+        WithdrawWitness ->
+        TxInstr q e ()
+    -- | Set transaction metadata for a label.
+    SetMetadata ::
+        Word64 ->
+        Metadatum ->
         TxInstr q e ()
     -- | Require a key signature.
     ReqSignature ::
@@ -404,6 +439,29 @@ mint pid assets r =
         , q /= 0
         ]
 
+-- | Withdraw stake rewards from a pub-key account.
+withdraw :: RewardAccount -> Coin -> TxBuild q e ()
+withdraw rewardAccount amount =
+    singleton $ Withdraw rewardAccount amount PubKeyWithdraw
+
+-- | Withdraw stake rewards from a script-backed account.
+withdrawScript ::
+    (ToData r) =>
+    RewardAccount ->
+    Coin ->
+    r ->
+    TxBuild q e ()
+withdrawScript rewardAccount amount redeemer =
+    singleton $
+        Withdraw
+            rewardAccount
+            amount
+            (ScriptWithdraw redeemer)
+
+-- | Set transaction metadata for a label.
+setMetadata :: Word64 -> Metadatum -> TxBuild q e ()
+setMetadata label = singleton . SetMetadata label
+
 -- | Set the lower validity bound.
 validFrom :: SlotNo -> TxBuild q e ()
 validFrom = singleton . SetValidFrom
@@ -492,6 +550,9 @@ data TxState e = TxState
           , MintWitness
           )
         ]
+    , tsWithdrawals ::
+        [(RewardAccount, Coin, WithdrawWitness)]
+    , tsMetadata :: Map Word64 Metadatum
     , tsSigners :: Set (KeyHash 'Witness)
     , tsScripts ::
         Map ScriptHash (Script ConwayEra)
@@ -508,6 +569,8 @@ emptyState =
         , tsCollIns = []
         , tsOuts = []
         , tsMints = []
+        , tsWithdrawals = []
+        , tsMetadata = Map.empty
         , tsSigners = Set.empty
         , tsScripts = Map.empty
         , tsValidFrom = SNothing
@@ -582,6 +645,26 @@ interpretWithM runCtx currentTx = go emptyState True
                     }
                 conv
                 (k ())
+        Withdraw rewardAccount amount w :>>= k ->
+            go
+                st
+                    { tsWithdrawals =
+                        tsWithdrawals st
+                            ++ [(rewardAccount, amount, w)]
+                    }
+                conv
+                (k ())
+        SetMetadata label metadatum :>>= k ->
+            go
+                st
+                    { tsMetadata =
+                        Map.insert
+                            label
+                            metadatum
+                            (tsMetadata st)
+                    }
+                conv
+                (k ())
         ReqSignature kh :>>= k ->
             go
                 st
@@ -652,14 +735,35 @@ assembleTxWith extraIns pp st =
         collIns = Set.fromList (tsCollIns st)
         outs = StrictSeq.fromList (tsOuts st)
         mintMA = foldl' addMint mempty (tsMints st)
+        withdrawalEntries =
+            collectWithdrawalEntries
+                (tsWithdrawals st)
+        withdrawals =
+            Withdrawals
+                (Map.map fst withdrawalEntries)
         -- Build redeemers
         spendRdmrs =
             collectSpendRedeemers
                 allSpendIns
                 (tsSpends st)
         mintRdmrs = collectMintRedeemers (tsMints st)
-        rdmrList = spendRdmrs ++ mintRdmrs
+        withdrawalRdmrs =
+            collectWithdrawalRedeemers
+                withdrawals
+                withdrawalEntries
+        rdmrList =
+            spendRdmrs
+                ++ mintRdmrs
+                ++ withdrawalRdmrs
         allRdmrs = Redeemers $ Map.fromList rdmrList
+        auxData =
+            if Map.null (tsMetadata st)
+                then SNothing
+                else
+                    SJust $
+                        mkBasicTxAuxData
+                            & metadataTxAuxDataL
+                                .~ tsMetadata st
         -- Integrity hash (skip if no scripts)
         integrity =
             if null rdmrList
@@ -678,6 +782,7 @@ assembleTxWith extraIns pp st =
                 & referenceInputsTxBodyL .~ refIns
                 & collateralInputsTxBodyL .~ collIns
                 & mintTxBodyL .~ mintMA
+                & withdrawalsTxBodyL .~ withdrawals
                 & reqSignerHashesTxBodyL
                     .~ tsSigners st
                 & vldtTxBodyL
@@ -685,6 +790,8 @@ assembleTxWith extraIns pp st =
                         { invalidBefore = tsValidFrom st
                         , invalidHereafter = tsValidTo st
                         }
+                & auxDataHashTxBodyL
+                    .~ fmap hashTxAuxData auxData
                 & scriptIntegrityHashTxBodyL
                     .~ integrity
      in
@@ -693,6 +800,8 @@ assembleTxWith extraIns pp st =
                 .~ tsScripts st
             & witsTxL . rdmrsTxWitsL
                 .~ allRdmrs
+            & auxDataTxL
+                .~ auxData
 
 -- ----------------------------------------------------
 -- Assembly
@@ -1133,6 +1242,20 @@ spendingIndex needle inputs =
         | x == needle = n
         | otherwise = go (n + 1) xs
 
+withdrawalIndex ::
+    RewardAccount ->
+    Withdrawals ->
+    Word32
+withdrawalIndex needle (Withdrawals withdrawals) =
+    go 0 (Map.keys withdrawals)
+  where
+    go _ [] =
+        error
+            "withdrawalIndex: RewardAccount not in map"
+    go n (x : xs)
+        | x == needle = n
+        | otherwise = go (n + 1) xs
+
 -- | Collect spending redeemers from steps.
 collectSpendRedeemers ::
     Set TxIn ->
@@ -1181,6 +1304,33 @@ collectMintRedeemers mints =
         | (pid, d) <- Map.toList seenData
         ]
 
+collectWithdrawalEntries ::
+    [(RewardAccount, Coin, WithdrawWitness)] ->
+    Map RewardAccount (Coin, Maybe (Data ConwayEra))
+collectWithdrawalEntries =
+    Map.fromList . fmap toEntry
+  where
+    toEntry (rewardAccount, amount, witness) =
+        ( rewardAccount
+        , (amount, withdrawWitnessData witness)
+        )
+
+collectWithdrawalRedeemers ::
+    Withdrawals ->
+    Map RewardAccount (Coin, Maybe (Data ConwayEra)) ->
+    [ ( ConwayPlutusPurpose AsIx ConwayEra
+      , (Data ConwayEra, ExUnits)
+      )
+    ]
+collectWithdrawalRedeemers withdrawals entries =
+    [ ( ConwayRewarding
+            (AsIx (withdrawalIndex rewardAccount withdrawals))
+      , (redeemer, ExUnits 0 0)
+      )
+    | (rewardAccount, (_, Just redeemer)) <-
+        Map.toList entries
+    ]
+
 -- | Accumulate 'MultiAsset' from mint entries.
 addMint ::
     MultiAsset ->
@@ -1193,6 +1343,13 @@ addMint acc (pid, name, qty, _) =
                 pid
                 (Map.singleton name qty)
             )
+
+withdrawWitnessData ::
+    WithdrawWitness ->
+    Maybe (Data ConwayEra)
+withdrawWitnessData PubKeyWithdraw = Nothing
+withdrawWitnessData (ScriptWithdraw redeemer) =
+    Just (toLedgerData redeemer)
 
 -- | Convert a 'ToData' value to ledger 'Data'.
 toLedgerData :: (ToData a) => a -> Data ConwayEra

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -21,7 +21,11 @@ import Data.IORef (
 import Data.Set qualified as Set
 import Test.Hspec
 
-import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Address (
+    Addr (..),
+    RewardAccount (..),
+    Withdrawals (..),
+ )
 import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
 import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
@@ -33,8 +37,13 @@ import Cardano.Ledger.Api.PParams (
     ppMinFeeAL,
     ppMinFeeBL,
  )
-import Cardano.Ledger.Api.Tx (Tx, witsTxL)
+import Cardano.Ledger.Api.Tx (
+    Tx,
+    auxDataTxL,
+    witsTxL,
+ )
 import Cardano.Ledger.Api.Tx.Body (
+    auxDataHashTxBodyL,
     collateralInputsTxBodyL,
     feeTxBodyL,
     inputsTxBodyL,
@@ -43,6 +52,7 @@ import Cardano.Ledger.Api.Tx.Body (
     referenceInputsTxBodyL,
     reqSignerHashesTxBodyL,
     vldtTxBodyL,
+    withdrawalsTxBodyL,
  )
 import Cardano.Ledger.Api.Tx.Out (
     TxOut,
@@ -61,7 +71,12 @@ import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Scripts (
     ConwayPlutusPurpose (..),
  )
-import Cardano.Ledger.Core (bodyTxL)
+import Cardano.Ledger.Core (
+    bodyTxL,
+    hashTxAuxData,
+    metadataTxAuxDataL,
+    mkBasicTxAuxData,
+ )
 import Cardano.Ledger.Credential (
     Credential (..),
     StakeReference (..),
@@ -79,6 +94,7 @@ import Cardano.Ledger.Mary.Value (
     MultiAsset (..),
     PolicyID (..),
  )
+import Cardano.Ledger.Metadata (Metadatum (..))
 import Cardano.Ledger.Plutus (ExUnits (..))
 import Cardano.Ledger.TxIn (
     TxId (..),
@@ -149,6 +165,18 @@ mkWitnessKeyHash :: Word8 -> KeyHash 'Witness
 mkWitnessKeyHash n =
     KeyHash (mkHash28 n)
 
+mkRewardAccount :: Word8 -> RewardAccount
+mkRewardAccount n =
+    RewardAccount
+        Testnet
+        (KeyHashObj (KeyHash (mkHash28 n)))
+
+mkScriptRewardAccount :: Word8 -> RewardAccount
+mkScriptRewardAccount n =
+    RewardAccount
+        Testnet
+        (ScriptHashObj (ScriptHash (mkHash28 n)))
+
 -- --------------------------------------------------
 -- Spec
 -- --------------------------------------------------
@@ -161,6 +189,8 @@ spec = describe "TxBuild" $ do
     spendIndexSpec
     scriptSpendSpec
     mintSpec
+    withdrawSpec
+    metadataSpec
     ctxSpec
     validSpec
     referenceValiditySpec
@@ -407,6 +437,73 @@ mintSpec =
             hasSpend `shouldBe` True
             hasMint `shouldBe` True
             Map.size rdmrs `shouldBe` 2
+
+withdrawSpec :: Spec
+withdrawSpec =
+    describe "withdraw" $ do
+        it "adds pub-key withdrawals to the tx body" $ do
+            let rewardAccount = mkRewardAccount 7
+                tx =
+                    draft emptyPParams $
+                        withdraw rewardAccount (Coin 3_000_000)
+                Redeemers rdmrs =
+                    tx ^. witsTxL . rdmrsTxWitsL
+            tx ^. bodyTxL . withdrawalsTxBodyL
+                `shouldBe` Withdrawals
+                    (Map.singleton rewardAccount (Coin 3_000_000))
+            Map.null rdmrs `shouldBe` True
+
+        it "produces rewarding redeemers for script withdrawals" $ do
+            let rewardAccount = mkScriptRewardAccount 8
+                tx =
+                    draft emptyPParams $
+                        withdrawScript
+                            rewardAccount
+                            (Coin 2_000_000)
+                            (99 :: Integer)
+                Redeemers rdmrs =
+                    tx ^. witsTxL . rdmrsTxWitsL
+            tx ^. bodyTxL . withdrawalsTxBodyL
+                `shouldBe` Withdrawals
+                    (Map.singleton rewardAccount (Coin 2_000_000))
+            Map.keys rdmrs
+                `shouldBe` [ConwayRewarding (AsIx 0)]
+
+metadataSpec :: Spec
+metadataSpec =
+    describe "setMetadata" $ do
+        it "attaches auxiliary data and hashes it in the tx body" $ do
+            let tx =
+                    draft emptyPParams $
+                        setMetadata 674 (S "gm")
+                expectedAux =
+                    mkBasicTxAuxData
+                        & metadataTxAuxDataL
+                            .~ Map.singleton 674 (S "gm")
+            case tx ^. auxDataTxL of
+                SJust aux -> do
+                    aux `shouldBe` expectedAux
+                    tx ^. bodyTxL . auxDataHashTxBodyL
+                        `shouldBe` SJust (hashTxAuxData aux)
+                _ ->
+                    expectationFailure
+                        "expected auxiliary data"
+
+        it "keeps the last value written for a metadata label" $ do
+            let tx =
+                    draft emptyPParams $ do
+                        setMetadata 674 (S "first")
+                        setMetadata 674 (S "second")
+                expectedAux =
+                    mkBasicTxAuxData
+                        & metadataTxAuxDataL
+                            .~ Map.singleton 674 (S "second")
+            case tx ^. auxDataTxL of
+                SJust aux ->
+                    aux `shouldBe` expectedAux
+                _ ->
+                    expectationFailure
+                        "expected auxiliary data"
 
 ctxSpec :: Spec
 ctxSpec =


### PR DESCRIPTION
Closes #40

## Summary

Extend `Cardano.Node.Client.TxBuild` with the two missing transaction-builder instructions from the protocol survey:

- reward-account withdrawals with explicit witness selection
- transaction metadata attachment through auxiliary data

## What changed

- added `WithdrawWitness` with `PubKeyWithdraw` and `ScriptWithdraw`
- added `Withdraw` and `SetMetadata` instructions to the `TxInstr` GADT
- added smart constructors:
  - `withdraw`
  - `withdrawScript`
  - `setMetadata`
- threaded withdrawals and metadata through interpreter state and assembly
- populated ledger body/tx fields during assembly:
  - `withdrawalsTxBodyL`
  - `auxDataHashTxBodyL`
  - `auxDataTxL`
- generated `ConwayRewarding` redeemers for script-backed withdrawals
- documented the new surface in the TxBuild module docs and WIP notes

## Tests

- added unit coverage for pub-key withdrawals
- added unit coverage for script withdrawals and rewarding redeemer emission
- added unit coverage for metadata auxiliary data attachment and aux-data hash population
- verified repeated metadata labels keep the last value written
- ran `cabal test unit-tests -O0 --test-show-details=direct`
- ran `hlint lib/Cardano/Node/Client/TxBuild.hs test/Cardano/Node/Client/TxBuildSpec.hs`

## Reviewer notes

The implementation keeps the existing TxBuild assembly model intact:

- withdrawals are accumulated in interpreter state and assembled into the tx body
- script withdrawals only contribute redeemers when the final withdrawal entry is script-backed
- metadata is only attached when at least one label is set, and the body hash is derived from the actual assembled auxiliary data

This keeps the issue scoped to the missing DSL surface without changing the balancing or evaluation loop.
