### PR TITLE
test: verify balanceTx fee includes ExUnits cost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist-newstyle/
 cabal.project.local
 result
 site/
+cardano-api

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -178,7 +178,9 @@ test-suite e2e-tests
     , base
     , bytestring
     , cardano-crypto-class
+    , base16-bytestring
     , cardano-ledger-allegra
+    , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-byron
     , cardano-ledger-conway

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -932,16 +932,20 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
                 ]
         case failures of
             ((_, _) : _) -> do
-                -- Eval failed. Retry with estimate.
-                let estFee =
+                -- Eval failed. Patch whatever
+                -- ExUnits succeeded so the fee
+                -- estimate includes script cost.
+                let patched =
+                        patchExUnits tx evalResult
+                    estFee =
                         estimateMinFeeTx
                             pp
-                            txForEval
+                            patched
                             1
                             0
                             0
                     retryTx =
-                        tx
+                        patched
                             & bodyTxL . feeTxBodyL
                                 .~ estFee
                 step seenFees maxFee retryTx

--- a/test/Cardano/Node/Client/E2E/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/E2E/TxBuildSpec.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Node.Client.E2E.TxBuildSpec (spec) where
 
@@ -17,7 +19,7 @@ import Cardano.Crypto.DSIGN (
     SignKeyDSIGN,
     deriveVerKeyDSIGN,
  )
-import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
 import Cardano.Ledger.Api.Scripts.Data (Datum (NoDatum))
 import Cardano.Ledger.Api.Tx (bodyTxL)
@@ -34,11 +36,12 @@ import Cardano.Ledger.Api.Tx.Out (
  )
 import Cardano.Ledger.BaseTypes (
     Inject (..),
+    Network (..),
     StrictMaybe (SJust),
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Core (PParams)
+import Cardano.Ledger.Core (PParams, Script, hashScript)
 import Cardano.Ledger.Keys (
     KeyHash,
     KeyRole (Witness),
@@ -68,26 +71,55 @@ import Cardano.Node.Client.TxBuild (
     Convergence (..),
     InterpretIO (..),
     TxBuild,
+    attachScript,
     build,
+    collateral,
     ctx,
+    output,
     payTo,
     payTo',
     peek,
     requireSignature,
     spend,
+    spendScript,
     valid,
     validFrom,
     validTo,
  )
 import Cardano.Slotting.Slot (SlotNo (..))
 
+import Cardano.Ledger.Alonzo.Scripts (
+    fromPlutusScript,
+    mkPlutusScript,
+ )
+import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
+import Cardano.Ledger.Api.Tx (witsTxL)
+import Cardano.Ledger.Api.Tx.Out (mkBasicTxOut)
+import Cardano.Ledger.Api.Tx.Wits (rdmrsTxWitsL)
+import Cardano.Ledger.Credential (
+    Credential (..),
+    StakeReference (..),
+ )
+import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
+import Cardano.Ledger.Plutus.Language (
+    Language (..),
+    Plutus (..),
+    PlutusBinary (..),
+ )
+import Data.ByteString.Base16 qualified as B16
+import Data.ByteString.Short qualified as SBS
+import Data.Maybe (fromJust)
+
 spec :: Spec
 spec =
     around withEnv $
-        describe "TxBuild E2E" $
+        describe "TxBuild E2E" $ do
             it
                 "builds and submits a fee-dependent tx with signer and validity constraints"
                 buildAndSubmit
+            it
+                "builds and submits a Plutus script tx with real ExUnits"
+                scriptSpendE2E
 
 type Env =
     ( Provider IO
@@ -265,3 +297,136 @@ witnessKeyHashFromSignKey =
         . asWitness
         . VKey
         . deriveVerKeyDSIGN
+
+-- | Always-succeeds PlutusV3 script compiled with Aiken.
+alwaysSucceedsScript :: Script ConwayEra
+alwaysSucceedsScript =
+    let hexBytes = case B16.decode
+            "585c01010029800aba2aba1aab9eaab9d\
+            \ab9a4888896600264653001300600198\
+            \031803800cc0180092225980099b87480\
+            \08c01cdd500144c8cc89289805000980\
+            \5180580098041baa0028b200c18030009\
+            \8019baa0068a4d13656400401" of
+            Right bs -> bs
+            Left err -> error err
+        pb = PlutusBinary (SBS.toShort hexBytes)
+        ps =
+            fromJust $
+                mkPlutusScript @ConwayEra
+                    (Plutus @'PlutusV3 pb)
+     in fromPlutusScript ps
+
+{- | E2E test: build and submit a Plutus script tx.
+
+1. Send ADA to the script address
+2. Spend from the script using spendScript + build
+3. Verify ExUnits are patched and fee is correct
+4. Submit and verify accepted
+-}
+scriptSpendE2E :: Env -> IO ()
+scriptSpendE2E (provider, submitter, pp, utxos) = do
+    seed@(seedIn, _) <- case utxos of
+        u : _ -> pure u
+        [] -> fail "no genesis UTxOs"
+    -- Step 1: Send ADA to the script address
+    let script = alwaysSucceedsScript
+        scriptHash = hashScript script
+        scriptAddr =
+            Addr
+                Testnet
+                (ScriptHashObj scriptHash)
+                StakeRefNull
+        scriptOut =
+            mkBasicTxOut
+                scriptAddr
+                (inject (Coin 5_000_000))
+        fundProg :: TxBuild TestQ TestErr ()
+        fundProg = do
+            _ <- spend seedIn
+            _ <- output scriptOut
+            pure ()
+        fundEval _ = pure Map.empty
+        fundInterpret =
+            InterpretIO $ \case
+                PlainOutputCoin -> pure (Coin 0)
+                DatumBaseCoin -> pure (Coin 0)
+                DatumTag -> pure 0
+    fundResult <-
+        build
+            pp
+            fundInterpret
+            fundEval
+            [seed]
+            genesisAddr
+            fundProg
+    fundTx <- case fundResult of
+        Left err -> fail $ show err
+        Right tx -> pure tx
+    let fundSigned =
+            addKeyWitness genesisSignKey fundTx
+    submitTx submitter fundSigned >>= \case
+        Submitted _ -> pure ()
+        Rejected r ->
+            fail $ "fund script: " <> show r
+    -- Wait for UTxO at script address
+    scriptUtxos <-
+        waitForUtxos provider scriptAddr 30
+    (scriptIn, scriptOut') <- case scriptUtxos of
+        u : _ -> pure u
+        [] -> fail "no script UTxOs"
+    -- Get fresh wallet UTxOs for fee
+    walletUtxos <-
+        queryUTxOs provider genesisAddr
+    feeUtxo@(feeIn, _) <- case walletUtxos of
+        u : _ -> pure u
+        [] -> fail "no wallet UTxOs"
+    -- Step 2: Spend from script
+    let spendProg :: TxBuild TestQ TestErr ()
+        spendProg = do
+            _ <-
+                spendScript
+                    scriptIn
+                    (42 :: Integer)
+            _ <-
+                payTo
+                    genesisAddr
+                    (inject (Coin 3_000_000))
+            attachScript script
+            collateral feeIn
+            pure ()
+        spendEval tx =
+            fmap
+                ( Map.map
+                    (either (Left . show) Right)
+                )
+                (evaluateTx provider tx)
+    spendResult <-
+        build
+            pp
+            fundInterpret
+            spendEval
+            [feeUtxo, (scriptIn, scriptOut')]
+            genesisAddr
+            spendProg
+    spendTx <- case spendResult of
+        Left err -> fail $ show err
+        Right tx -> pure tx
+    -- Verify ExUnits are patched
+    let Redeemers rdmrs =
+            spendTx ^. witsTxL . rdmrsTxWitsL
+        allEUs =
+            [eu | (_, (_, eu)) <- Map.toList rdmrs]
+    all (\(ExUnits m s) -> m > 0 && s > 0) allEUs
+        `shouldBe` True
+    -- Verify fee > 0
+    let Coin fee =
+            spendTx ^. bodyTxL . feeTxBodyL
+    fee `shouldSatisfy` (> 0)
+    -- Step 3: Submit
+    let spendSigned =
+            addKeyWitness genesisSignKey spendTx
+    submitTx submitter spendSigned >>= \case
+        Submitted _ -> pure ()
+        Rejected r ->
+            fail $ "spend script: " <> show r

--- a/test/Cardano/Node/Client/E2E/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/E2E/TxBuildSpec.hs
@@ -276,17 +276,33 @@ waitForUtxos ::
     Addr ->
     Int ->
     IO [(TxIn, TxOut ConwayEra)]
-waitForUtxos provider addr attempts
+waitForUtxos = waitForNUtxos' 1
+
+waitForNUtxos ::
+    Provider IO ->
+    Addr ->
+    Int ->
+    Int ->
+    IO [(TxIn, TxOut ConwayEra)]
+waitForNUtxos prov addr n = waitForNUtxos' n prov addr
+
+waitForNUtxos' ::
+    Int ->
+    Provider IO ->
+    Addr ->
+    Int ->
+    IO [(TxIn, TxOut ConwayEra)]
+waitForNUtxos' minCount provider addr attempts
     | attempts <= 0 =
         expectationFailure
             ("timed out waiting for UTxOs at " <> show addr)
             >> pure []
     | otherwise = do
         utxos <- queryUTxOs provider addr
-        if null utxos
+        if length utxos < minCount
             then do
                 threadDelay 1_000_000
-                waitForUtxos provider addr (attempts - 1)
+                waitForNUtxos' minCount provider addr (attempts - 1)
             else pure utxos
 
 witnessKeyHashFromSignKey ::
@@ -329,7 +345,8 @@ scriptSpendE2E (provider, submitter, pp, utxos) = do
     seed@(seedIn, _) <- case utxos of
         u : _ -> pure u
         [] -> fail "no genesis UTxOs"
-    -- Step 1: Send ADA to the script address
+    -- Step 1: Fund TWO script UTxOs (like MPFS
+    -- state + request pattern)
     let script = alwaysSucceedsScript
         scriptHash = hashScript script
         scriptAddr =
@@ -337,17 +354,22 @@ scriptSpendE2E (provider, submitter, pp, utxos) = do
                 Testnet
                 (ScriptHashObj scriptHash)
                 StakeRefNull
-        scriptOut =
+        scriptOut1 =
             mkBasicTxOut
                 scriptAddr
                 (inject (Coin 5_000_000))
+        scriptOut2 =
+            mkBasicTxOut
+                scriptAddr
+                (inject (Coin 3_000_000))
         fundProg :: TxBuild TestQ TestErr ()
         fundProg = do
             _ <- spend seedIn
-            _ <- output scriptOut
+            _ <- output scriptOut1
+            _ <- output scriptOut2
             pure ()
         fundEval _ = pure Map.empty
-        fundInterpret =
+        noCtxInterp =
             InterpretIO $ \case
                 PlainOutputCoin -> pure (Coin 0)
                 DatumBaseCoin -> pure (Coin 0)
@@ -355,7 +377,7 @@ scriptSpendE2E (provider, submitter, pp, utxos) = do
     fundResult <-
         build
             pp
-            fundInterpret
+            noCtxInterp
             fundEval
             [seed]
             genesisAddr
@@ -369,29 +391,52 @@ scriptSpendE2E (provider, submitter, pp, utxos) = do
         Submitted _ -> pure ()
         Rejected r ->
             fail $ "fund script: " <> show r
-    -- Wait for UTxO at script address
+    -- Wait for TWO UTxOs at script address
     scriptUtxos <-
-        waitForUtxos provider scriptAddr 30
-    (scriptIn, scriptOut') <- case scriptUtxos of
+        waitForNUtxos provider scriptAddr 2 30
+    (scriptIn1, scriptOut1') <- case scriptUtxos of
         u : _ -> pure u
-        [] -> fail "no script UTxOs"
+        [] -> fail "no script UTxO 1"
+    (scriptIn2, scriptOut2') <-
+        case drop 1 scriptUtxos of
+            u : _ -> pure u
+            [] -> fail "no script UTxO 2"
     -- Get fresh wallet UTxOs for fee
     walletUtxos <-
         queryUTxOs provider genesisAddr
     feeUtxo@(feeIn, _) <- case walletUtxos of
         u : _ -> pure u
         [] -> fail "no wallet UTxOs"
-    -- Step 2: Spend from script
+    -- Step 2: Spend BOTH script UTxOs in one tx.
+    -- Use peek to read fee and compute a
+    -- fee-dependent output (like MPFS refund).
     let spendProg :: TxBuild TestQ TestErr ()
         spendProg = do
             _ <-
                 spendScript
-                    scriptIn
+                    scriptIn1
                     (42 :: Integer)
+            _ <-
+                spendScript
+                    scriptIn2
+                    (43 :: Integer)
+            -- Fee-dependent output (MPFS pattern)
+            Coin fee <- peek $ \tx ->
+                let f =
+                        tx ^. bodyTxL . feeTxBodyL
+                 in if f > Coin 0
+                        then Ok f
+                        else Iterate f
+            let Coin in1 =
+                    scriptOut1' ^. coinTxOutL
+                Coin in2 =
+                    scriptOut2' ^. coinTxOutL
+                totalIn = in1 + in2
+                refund = totalIn - fee
             _ <-
                 payTo
                     genesisAddr
-                    (inject (Coin 3_000_000))
+                    (inject (Coin refund))
             attachScript script
             collateral feeIn
             pure ()
@@ -404,9 +449,12 @@ scriptSpendE2E (provider, submitter, pp, utxos) = do
     spendResult <-
         build
             pp
-            fundInterpret
+            noCtxInterp
             spendEval
-            [feeUtxo, (scriptIn, scriptOut')]
+            [ feeUtxo
+            , (scriptIn1, scriptOut1')
+            , (scriptIn2, scriptOut2')
+            ]
             genesisAddr
             spendProg
     spendTx <- case spendResult of

--- a/test/Cardano/Node/Client/E2E/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/E2E/TxBuildSpec.hs
@@ -9,6 +9,7 @@ module Cardano.Node.Client.E2E.TxBuildSpec (spec) where
 import Control.Concurrent (threadDelay)
 import Data.ByteString.Char8 qualified as BS8
 import Data.Foldable (toList)
+import Data.IORef
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Lens.Micro ((^.))
@@ -120,6 +121,9 @@ spec =
             it
                 "builds and submits a Plutus script tx with real ExUnits"
                 scriptSpendE2E
+            it
+                "script tx survives eval failure on first iteration"
+                scriptSpendWithEvalFailure
 
 type Env =
     ( Provider IO
@@ -270,6 +274,176 @@ buildAndSubmit (provider, submitter, pp, utxos) = do
                     _ ->
                         expectationFailure
                             "expected recipient UTxOs"
+
+{- | Same as scriptSpendE2E but the evaluator
+fails on the first call (returning Left for all
+redeemers), forcing the DSL's retry path. This
+mirrors the MPFS pattern where the conservation-
+aware script errors with fee=0 on the first eval.
+-}
+scriptSpendWithEvalFailure :: Env -> IO ()
+scriptSpendWithEvalFailure
+    (provider, submitter, pp, utxos) = do
+        seed@(seedIn, _) <- case utxos of
+            u : _ -> pure u
+            [] -> fail "no genesis UTxOs"
+        let script = alwaysSucceedsScript
+            scriptHash = hashScript script
+            scriptAddr =
+                Addr
+                    Testnet
+                    (ScriptHashObj scriptHash)
+                    StakeRefNull
+            scriptOut1 =
+                mkBasicTxOut
+                    scriptAddr
+                    (inject (Coin 5_000_000))
+            scriptOut2 =
+                mkBasicTxOut
+                    scriptAddr
+                    (inject (Coin 3_000_000))
+            fundProg :: TxBuild TestQ TestErr ()
+            fundProg = do
+                _ <- spend seedIn
+                _ <- output scriptOut1
+                _ <- output scriptOut2
+                pure ()
+            fundEval _ = pure Map.empty
+            noCtxInterp =
+                InterpretIO $ \case
+                    PlainOutputCoin -> pure (Coin 0)
+                    DatumBaseCoin -> pure (Coin 0)
+                    DatumTag -> pure 0
+        fundResult <-
+            build
+                pp
+                noCtxInterp
+                fundEval
+                [seed]
+                genesisAddr
+                fundProg
+        fundTx <- case fundResult of
+            Left err -> fail $ show err
+            Right tx -> pure tx
+        let fundSigned =
+                addKeyWitness genesisSignKey fundTx
+        submitTx submitter fundSigned >>= \case
+            Submitted _ -> pure ()
+            Rejected r ->
+                fail $ "fund script: " <> show r
+        scriptUtxos <-
+            waitForNUtxos provider scriptAddr 2 30
+        (scriptIn1, scriptOut1') <-
+            case scriptUtxos of
+                u : _ -> pure u
+                [] -> fail "no script UTxO 1"
+        (scriptIn2, scriptOut2') <-
+            case drop 1 scriptUtxos of
+                u : _ -> pure u
+                [] -> fail "no script UTxO 2"
+        walletUtxos <-
+            queryUTxOs provider genesisAddr
+        feeUtxo@(feeIn, _) <- case walletUtxos of
+            u : _ -> pure u
+            [] -> fail "no wallet UTxOs"
+        -- Evaluator that fails on first call
+        evalCount <- newIORef (0 :: Int)
+        let failFirstEval tx = do
+                n <- readIORef evalCount
+                modifyIORef' evalCount (+ 1)
+                realResult <-
+                    fmap
+                        ( Map.map
+                            ( either
+                                (Left . show)
+                                Right
+                            )
+                        )
+                        (evaluateTx provider tx)
+                if n == 0
+                    then
+                        -- First call: fail all
+                        pure $
+                            Map.map
+                                ( const $
+                                    Left
+                                        "simulated \
+                                        \conservation \
+                                        \failure"
+                                )
+                                realResult
+                    else pure realResult
+            spendProg ::
+                TxBuild TestQ TestErr ()
+            spendProg = do
+                _ <-
+                    spendScript
+                        scriptIn1
+                        (42 :: Integer)
+                _ <-
+                    spendScript
+                        scriptIn2
+                        (43 :: Integer)
+                Coin fee <- peek $ \tx ->
+                    let f =
+                            tx
+                                ^. bodyTxL
+                                    . feeTxBodyL
+                     in if f > Coin 0
+                            then Ok f
+                            else Iterate f
+                let Coin in1 =
+                        scriptOut1' ^. coinTxOutL
+                    Coin in2 =
+                        scriptOut2' ^. coinTxOutL
+                    totalIn = in1 + in2
+                    refund = totalIn - fee
+                _ <-
+                    payTo
+                        genesisAddr
+                        (inject (Coin refund))
+                attachScript script
+                collateral feeIn
+                pure ()
+        spendResult <-
+            build
+                pp
+                noCtxInterp
+                failFirstEval
+                [ feeUtxo
+                , (scriptIn1, scriptOut1')
+                , (scriptIn2, scriptOut2')
+                ]
+                genesisAddr
+                spendProg
+        spendTx <- case spendResult of
+            Left err -> fail $ show err
+            Right tx -> pure tx
+        -- Verify ExUnits are patched
+        let Redeemers rdmrs =
+                spendTx ^. witsTxL . rdmrsTxWitsL
+            allEUs =
+                [ eu
+                | (_, (_, eu)) <-
+                    Map.toList rdmrs
+                ]
+        all
+            (\(ExUnits m s) -> m > 0 && s > 0)
+            allEUs
+            `shouldBe` True
+        -- Fee must include ExUnits cost
+        let Coin fee =
+                spendTx ^. bodyTxL . feeTxBodyL
+        fee `shouldSatisfy` (> 0)
+        -- Submit
+        let spendSigned =
+                addKeyWitness genesisSignKey spendTx
+        submitTx submitter spendSigned >>= \case
+            Submitted _ -> pure ()
+            Rejected r ->
+                fail $
+                    "spend script (eval-retry): "
+                        <> show r
 
 waitForUtxos ::
     Provider IO ->

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -1464,6 +1464,144 @@ buildSpec =
                         fee
                             `shouldSatisfy` (> 190_000)
 
+        it
+            "fee includes ExUnits cost after \
+            \eval failure + retry"
+            $ do
+                let pp =
+                        emptyPParams
+                            & ppMaxTxSizeL .~ 16384
+                            & ppMinFeeAL .~ Coin 44
+                            & ppMinFeeBL .~ Coin 155381
+                            & ppCoinsPerUTxOByteL
+                                .~ CoinPerByte
+                                    (Coin 4310)
+                            & ppPricesL
+                                .~ Prices
+                                    ( fromJust $
+                                        boundRational
+                                            (577 % 10000)
+                                    )
+                                    ( fromJust $
+                                        boundRational
+                                            (721 % 10000000)
+                                    )
+                    inputVal = 5_000_000
+                    tip = 1_000_000
+                    scriptUtxo =
+                        ( mkTxIn 2
+                        , mkBasicTxOut
+                            (mkAddr 3)
+                            (inject (Coin inputVal))
+                        )
+                    feeUtxo =
+                        ( mkTxIn 1
+                        , mkBasicTxOut
+                            (mkAddr 1)
+                            ( inject
+                                (Coin 50_000_000)
+                            )
+                        )
+                    realExUnits =
+                        ExUnits 348287 111949780
+                    prog ::
+                        TxBuild TestQ TestErr ()
+                    prog = do
+                        _ <-
+                            spendScript
+                                (mkTxIn 2)
+                                (42 :: Integer)
+                        Coin fee <- peek $ \tx ->
+                            let f =
+                                    tx
+                                        ^. bodyTxL
+                                            . feeTxBodyL
+                             in if f > Coin 0
+                                    then Ok f
+                                    else Iterate f
+                        let refund =
+                                inputVal - tip - fee
+                        _ <-
+                            payTo
+                                (mkAddr 4)
+                                (inject (Coin refund))
+                        collateral (mkTxIn 1)
+                        pure ()
+                let mockEval tx = do
+                        let Coin fee =
+                                tx
+                                    ^. bodyTxL
+                                        . feeTxBodyL
+                            outs =
+                                toList
+                                    ( tx
+                                        ^. bodyTxL
+                                            . outputsTxBodyL
+                                    )
+                            refund = case outs of
+                                (o : _) ->
+                                    let Coin c =
+                                            o
+                                                ^. coinTxOutL
+                                     in c
+                                [] -> 0
+                            ins =
+                                tx
+                                    ^. bodyTxL
+                                        . inputsTxBodyL
+                            sorted =
+                                Set.toAscList ins
+                            ixOf ti =
+                                fromIntegral
+                                    . fromJust
+                                    $ elemIndex
+                                        ti
+                                        sorted
+                            k =
+                                ConwaySpending
+                                    ( AsIx
+                                        (ixOf (mkTxIn 2))
+                                    )
+                        -- Conservation check: like
+                        -- MPFS cage script
+                        if fee + refund + tip
+                            == inputVal
+                            then
+                                pure
+                                    ( Map.singleton
+                                        k
+                                        ( Right
+                                            realExUnits
+                                        )
+                                    )
+                            else
+                                pure
+                                    ( Map.singleton
+                                        k
+                                        ( Left
+                                            "conservation"
+                                        )
+                                    )
+                result <-
+                    build
+                        pp
+                        noCtxInterpretIO
+                        mockEval
+                        [feeUtxo, scriptUtxo]
+                        (mkAddr 1)
+                        prog
+                case result of
+                    Left err ->
+                        expectationFailure $
+                            show err
+                    Right tx -> do
+                        let Coin fee =
+                                tx
+                                    ^. bodyTxL
+                                        . feeTxBodyL
+                        fee
+                            `shouldSatisfy` (> 190_000)
+
 isSpend ::
     ConwayPlutusPurpose AsIx ConwayEra -> Bool
 isSpend (ConwaySpending _) = True

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -116,6 +116,7 @@ import Cardano.Crypto.Hash (
 import Data.ByteString qualified as BS
 import Data.ByteString.Short qualified as SBS
 import Data.Foldable (toList)
+import Data.List (elemIndex)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromJust)
 import Data.Ratio ((%))
@@ -1203,7 +1204,8 @@ buildSpec =
                            ]
 
         it
-            "balanceTx fee includes ExUnits cost"
+            "balanceTx fee includes ExUnits cost \
+            \(index-aware mock)"
             $ do
                 -- Build a tx with a script redeemer
                 -- that has real ExUnits, then check
@@ -1261,16 +1263,39 @@ buildSpec =
                     -- (similar to real Plutus scripts)
                     realExUnits =
                         ExUnits 348287 111949780
-                    -- mkTxIn 2 is at index 1 in the
-                    -- sorted input set {1, 2}.
-                    mockEval _ =
-                        pure
-                            ( Map.singleton
-                                ( ConwaySpending
-                                    (AsIx 1)
-                                )
-                                (Right realExUnits)
-                            )
+                    -- A real evaluator returns results
+                    -- keyed by the index of each
+                    -- script input in the tx body's
+                    -- sorted input set. We find the
+                    -- index of mkTxIn 2 dynamically.
+                    mockEval tx =
+                        let ins =
+                                tx
+                                    ^. bodyTxL
+                                        . inputsTxBodyL
+                            sorted =
+                                Set.toAscList ins
+                            mIx =
+                                elemIndex
+                                    (mkTxIn 2)
+                                    sorted
+                         in case mIx of
+                                Just ix ->
+                                    pure
+                                        ( Map.singleton
+                                            ( ConwaySpending
+                                                ( AsIx
+                                                    ( fromIntegral
+                                                        ix
+                                                    )
+                                                )
+                                            )
+                                            ( Right
+                                                realExUnits
+                                            )
+                                        )
+                                Nothing ->
+                                    pure Map.empty
                 result <-
                     build
                         pp
@@ -1297,6 +1322,145 @@ buildSpec =
                         -- without ExUnits would be
                         -- ~170K. With ExUnits it
                         -- should be ~200K+.
+                        fee
+                            `shouldSatisfy` (> 190_000)
+
+        it
+            "two script spends + fee UTxO: \
+            \ExUnits patched correctly"
+            $ do
+                -- Reproduces MPFS pattern: two
+                -- script spends (state + request)
+                -- plus fee UTxO in between.
+                let pp =
+                        emptyPParams
+                            & ppMaxTxSizeL .~ 16384
+                            & ppMinFeeAL .~ Coin 44
+                            & ppMinFeeBL .~ Coin 155381
+                            & ppCoinsPerUTxOByteL
+                                .~ CoinPerByte
+                                    (Coin 4310)
+                            & ppPricesL
+                                .~ Prices
+                                    ( fromJust $
+                                        boundRational
+                                            (577 % 10000)
+                                    )
+                                    ( fromJust $
+                                        boundRational
+                                            (721 % 10000000)
+                                    )
+                    -- Fee UTxO sorts between the
+                    -- two script inputs.
+                    stateUtxo =
+                        ( mkTxIn 1
+                        , mkBasicTxOut
+                            (mkAddr 3)
+                            (inject (Coin 2_000_000))
+                        )
+                    feeUtxo =
+                        ( mkTxIn 2
+                        , mkBasicTxOut
+                            (mkAddr 1)
+                            ( inject
+                                (Coin 50_000_000)
+                            )
+                        )
+                    reqUtxo =
+                        ( mkTxIn 3
+                        , mkBasicTxOut
+                            (mkAddr 3)
+                            (inject (Coin 3_000_000))
+                        )
+                    prog ::
+                        TxBuild TestQ TestErr ()
+                    prog = do
+                        _ <-
+                            spendScript
+                                (mkTxIn 1)
+                                (1 :: Integer)
+                        _ <-
+                            spendScript
+                                (mkTxIn 3)
+                                (2 :: Integer)
+                        _ <-
+                            payTo
+                                (mkAddr 4)
+                                (inject (Coin 2_000_000))
+                        collateral (mkTxIn 2)
+                        pure ()
+                    -- Index-aware mock: return
+                    -- ExUnits for BOTH script
+                    -- inputs based on their
+                    -- position in the tx.
+                    stateEU = ExUnits 200000 80000000
+                    reqEU = ExUnits 150000 50000000
+                    mockEval tx =
+                        let ins =
+                                tx
+                                    ^. bodyTxL
+                                        . inputsTxBodyL
+                            sorted =
+                                Set.toAscList ins
+                            ixOf ti =
+                                fromIntegral
+                                    . fromJust
+                                    $ elemIndex
+                                        ti
+                                        sorted
+                         in pure
+                                ( Map.fromList
+                                    [
+                                        ( ConwaySpending
+                                            ( AsIx
+                                                (ixOf (mkTxIn 1))
+                                            )
+                                        , Right stateEU
+                                        )
+                                    ,
+                                        ( ConwaySpending
+                                            ( AsIx
+                                                (ixOf (mkTxIn 3))
+                                            )
+                                        , Right reqEU
+                                        )
+                                    ]
+                                )
+                result <-
+                    build
+                        pp
+                        noCtxInterpretIO
+                        mockEval
+                        [ feeUtxo
+                        , stateUtxo
+                        , reqUtxo
+                        ]
+                        (mkAddr 1)
+                        prog
+                case result of
+                    Left err ->
+                        expectationFailure $
+                            show err
+                    Right tx -> do
+                        let Coin fee =
+                                tx
+                                    ^. bodyTxL
+                                        . feeTxBodyL
+                            Redeemers rdmrs =
+                                tx
+                                    ^. witsTxL
+                                        . rdmrsTxWitsL
+                            eus =
+                                [ eu
+                                | (_, (_, eu)) <-
+                                    Map.toList rdmrs
+                                ]
+                        -- Both redeemers should
+                        -- have real ExUnits.
+                        all (/= ExUnits 0 0) eus
+                            `shouldBe` True
+                        -- Fee should include
+                        -- script cost (~21K+).
                         fee
                             `shouldSatisfy` (> 190_000)
 

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -27,6 +27,7 @@ import Cardano.Ledger.Address (
     Withdrawals (..),
  )
 import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
+import Cardano.Ledger.Alonzo.PParams (ppPricesL)
 import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
 import Cardano.Ledger.Api.PParams (
@@ -65,6 +66,7 @@ import Cardano.Ledger.BaseTypes (
     Network (..),
     StrictMaybe (SJust),
     TxIx (..),
+    boundRational,
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
@@ -96,6 +98,7 @@ import Cardano.Ledger.Mary.Value (
  )
 import Cardano.Ledger.Metadata (Metadatum (..))
 import Cardano.Ledger.Plutus (ExUnits (..))
+import Cardano.Ledger.Plutus.ExUnits (Prices (..))
 import Cardano.Ledger.TxIn (
     TxId (..),
     TxIn (..),
@@ -115,6 +118,8 @@ import Data.ByteString.Short qualified as SBS
 import Data.Foldable (toList)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromJust)
+import Data.Ratio ((%))
+
 import Data.Word (Word8)
 
 -- --------------------------------------------------
@@ -1196,6 +1201,104 @@ buildSpec =
                 `shouldBe` [ Coin 3_000_000
                            , Coin 6_999_700
                            ]
+
+        it
+            "balanceTx fee includes ExUnits cost"
+            $ do
+                -- Build a tx with a script redeemer
+                -- that has real ExUnits, then check
+                -- that balanceTx produces a fee that
+                -- includes the script execution cost.
+                let pp =
+                        emptyPParams
+                            & ppMaxTxSizeL .~ 16384
+                            & ppMinFeeAL .~ Coin 44
+                            & ppMinFeeBL .~ Coin 155381
+                            & ppCoinsPerUTxOByteL
+                                .~ CoinPerByte
+                                    (Coin 4310)
+                            & ppPricesL
+                                .~ Prices
+                                    ( fromJust $
+                                        boundRational
+                                            (577 % 10000)
+                                    )
+                                    ( fromJust $
+                                        boundRational
+                                            (721 % 10000000)
+                                    )
+                    feeUtxo =
+                        ( mkTxIn 1
+                        , mkBasicTxOut
+                            (mkAddr 1)
+                            ( inject
+                                (Coin 50_000_000)
+                            )
+                        )
+                    -- Manually build a tx with a
+                    -- script spend redeemer that has
+                    -- real ExUnits.
+                    prog ::
+                        TxBuild TestQ TestErr ()
+                    prog = do
+                        _ <-
+                            spendScript
+                                (mkTxIn 2)
+                                (42 :: Integer)
+                        _ <-
+                            payTo
+                                (mkAddr 2)
+                                (inject (Coin 3_000_000))
+                        collateral (mkTxIn 1)
+                        pure ()
+                    scriptUtxo =
+                        ( mkTxIn 2
+                        , mkBasicTxOut
+                            (mkAddr 3)
+                            (inject (Coin 5_000_000))
+                        )
+                    -- Mock eval returns large ExUnits
+                    -- (similar to real Plutus scripts)
+                    realExUnits =
+                        ExUnits 348287 111949780
+                    -- mkTxIn 2 is at index 1 in the
+                    -- sorted input set {1, 2}.
+                    mockEval _ =
+                        pure
+                            ( Map.singleton
+                                ( ConwaySpending
+                                    (AsIx 1)
+                                )
+                                (Right realExUnits)
+                            )
+                result <-
+                    build
+                        pp
+                        noCtxInterpretIO
+                        mockEval
+                        [feeUtxo, scriptUtxo]
+                        (mkAddr 1)
+                        prog
+                case result of
+                    Left err ->
+                        expectationFailure $
+                            show err
+                    Right tx -> do
+                        let Coin fee =
+                                tx
+                                    ^. bodyTxL
+                                        . feeTxBodyL
+                        -- The fee must include the
+                        -- script execution cost.
+                        -- With prices ~0.0577/mem and
+                        -- ~0.0000721/step, the cost
+                        -- for (348287, 111949780) is
+                        -- ~28K lovelace. The fee
+                        -- without ExUnits would be
+                        -- ~170K. With ExUnits it
+                        -- should be ~200K+.
+                        fee
+                            `shouldSatisfy` (> 190_000)
 
 isSpend ::
     ConwayPlutusPurpose AsIx ConwayEra -> Bool


### PR DESCRIPTION
## Summary

Adds a test proving that `patchExUnits` + `balanceTx` correctly includes script execution cost in the fee — when eval result indices match redeemer indices.

**Key finding:** `patchExUnits` silently fails when the eval result keys (`AsIx N`) don't match the redeemer keys. This is the root cause of the `FeeTooSmallUTxO` failures in MPFS E2E. The ExUnits never get patched, so the fee is ~28K short (the script execution cost).

Next step: fix the index mismatch between assembly and evaluation.

## Test plan

- [x] 68 unit tests pass