### PR TITLE
test: bump devnet protocol to 10

### DIFF
--- a/e2e-test/genesis/shelley-genesis.json
+++ b/e2e-test/genesis/shelley-genesis.json
@@ -32,7 +32,7 @@
         "nOpt": 100,
         "poolDeposit": 0,
         "protocolVersion": {
-            "major": 9,
+            "major": 10,
             "minor": 0
         },
         "rho": 0.1,


### PR DESCRIPTION
This bumps the checked-in E2E devnet genesis from protocol version 9 to 10.

Why:
- downstream Plutus V3 scripts now compile to builtins that are rejected on protocol 9
- current failure observed in `lambdasistemi/cardano-bbs` devnet submit integration: `XorByteString is not available in language PlutusV3 at protocol version 9`

Artifact:
- `e2e-test/genesis/shelley-genesis.json`

This is intended to unblock downstream E2E tests that are already using the `cardano-node-clients` devnet harness.