### PR TITLE
fix: surface terminal eval failures instead of retrying

### DIFF
--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -893,7 +893,7 @@ build ::
     TxBuild q e a ->
     IO (Either (BuildError e) (Tx ConwayEra))
 build pp interpret evaluateTx inputUtxos changeAddr prog =
-    step Set.empty (Coin 0) (mkBasicTx mkBasicTxBody)
+    step Set.empty (Coin 0) 0 (mkBasicTx mkBasicTxBody)
   where
     -- Pre-compute the extra TxIns from inputUtxos
     -- so Peek-based index computation sees ALL
@@ -910,7 +910,7 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
     -- \| One iteration: interpret, assemble, eval,
     -- patch, balance. Track seen fees to detect
     -- oscillation and bisect.
-    step seenFees maxFee prevTx = do
+    step seenFees maxFee evalRetries prevTx = do
         -- 1. Interpret
         let prevWithIns = addExtras prevTx
         (st, _, _) <-
@@ -965,10 +965,10 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
                     Map.toList evalResult
                 ]
         case failures of
-            ((_, _) : _) -> do
-                -- Eval failed. Retry with estimate.
-                -- Use max of estimate and previous
-                -- fee to converge from above.
+            ((purpose, msg) : _) -> do
+                -- Eval failed. Distinguish terminal
+                -- script failures from retryable
+                -- fee-search failures.
                 let estFee =
                         estimateMinFeeTx
                             pp
@@ -976,24 +976,21 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
                             1
                             0
                             0
-                if estFee >= prevFee
-                    then do
-                        -- Fee grew; retry with the
-                        -- higher estimate.
-                        let retryTx =
-                                tx
-                                    & bodyTxL
-                                        . feeTxBodyL
-                                        .~ estFee
-                        step seenFees maxFee retryTx
+                if evalRetries >= (1 :: Int)
+                    then
+                        -- Already retried once with a
+                        -- fee estimate. The failure is
+                        -- stable — surface it.
+                        pure $
+                            Left $
+                                EvalFailure purpose msg
                     else
                         if prevFee > Coin 0
                             then do
-                                -- Not the first iteration
-                                -- and fee can't improve.
-                                -- Reuse ExUnits from the
-                                -- previous successful tx
-                                -- to avoid a retry loop.
+                                -- A prior iteration
+                                -- succeeded. Reuse its
+                                -- ExUnits to avoid a
+                                -- retry loop.
                                 let prevEUs =
                                         Map.map Right $
                                             fmap snd $
@@ -1037,6 +1034,7 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
                                                         maxFee
                                                         finalFee
                                                     )
+                                                    0
                                                     balanced
                             else do
                                 -- First iteration
@@ -1050,6 +1048,7 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
                                 step
                                     seenFees
                                     maxFee
+                                    (evalRetries + 1)
                                     retryTx
             [] -> do
                 -- 3. Patch ExUnits THEN balance.
@@ -1086,6 +1085,7 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
                                         step
                                             seenFees
                                             newMax
+                                            0
                                             ( bumpFee
                                                 balanced
                                                 newMax
@@ -1132,6 +1132,7 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
                                                 seenFees
                                             )
                                             newMax
+                                            0
                                             balanced
 
     -- \| Binary search for the smallest fee where

--- a/specs/006-053-surface-eval-failures/plan.md
+++ b/specs/006-053-surface-eval-failures/plan.md
@@ -1,0 +1,58 @@
+# Implementation Plan: Surface terminal eval failures
+
+## Research
+
+The eval-fail branch in `step` has two paths:
+
+1. `estFee >= prevFee` → retry with higher fee (line 979)
+2. `prevFee > 0` → reuse prevTx ExUnits (line 990)
+
+Path 1 loops forever when eval always fails: estFee stays
+constant, prevFee catches up, and the condition remains
+true on every retry.
+
+Path 2 is only reached when estFee < prevFee, which means
+a successful balance already happened. This path correctly
+handles the "eval fails after a prior success" case.
+
+The gap: there is no exit for "eval always fails, fee can't
+help." The retry counter is implicit in `seenFees` but only
+checked on the success path.
+
+## Design
+
+Add an eval retry counter to `step`. When eval fails and
+we've already retried once at the same or higher fee without
+any successful eval in between, surface `EvalFailure`.
+
+Specifically:
+- Add an `evalRetries :: Int` parameter to `step`
+- On eval failure: if `evalRetries > 0` AND the fee
+  hasn't changed (estFee == prevFee or estFee < prevFee
+  with no prior success), return `EvalFailure`
+- On eval success: reset `evalRetries` to 0
+- Initial call: `evalRetries = 0`
+
+This distinguishes:
+- First failure at fee=0 → retry (evalRetries 0→1)
+- Second failure at similar fee → terminal (evalRetries=1)
+- Failure after a prior success → use prevTx ExUnits
+  (existing path 2, unchanged)
+
+## Slices
+
+### Slice 1: Add evalRetries counter and terminal exit
+
+- Add `evalRetries` parameter to `step`
+- On eval failure path 1 (estFee >= prevFee):
+  if evalRetries >= 1, return `Left (EvalFailure p msg)`
+  using the first failure from the list
+- On eval success: pass evalRetries=0 to recursive calls
+- On eval failure retry: pass evalRetries+1
+
+### Slice 2: Regression test
+
+- Unit test with mock evaluator that always fails
+  → verify `build` returns `EvalFailure`
+- Unit test with mock evaluator that fails at fee=0
+  but succeeds at fee>0 → verify `build` converges

--- a/specs/006-053-surface-eval-failures/spec.md
+++ b/specs/006-053-surface-eval-failures/spec.md
@@ -1,0 +1,103 @@
+# Feature Specification: Surface terminal eval failures
+
+**Feature Branch**: `006-053-surface-eval-failures`
+**Created**: 2026-04-14
+**Status**: Draft
+**Input**: Issue #53
+
+## User Scenarios & Testing
+
+### User Story 1 - Terminal script failure returns error (Priority: P1)
+
+A developer uses the TxBuild DSL with a script that has a
+logic bug (e.g., wrong redeemer, bad datum encoding). The
+`build` function should return `Left (EvalFailure purpose msg)`
+after detecting the failure is stable, not retry indefinitely.
+
+**Why this priority**: Without this, any script bug causes
+a hang instead of an actionable error message.
+
+**Independent Test**: Mock evaluator that always fails for
+a specific purpose → `build` returns `EvalFailure`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a program with a script spend whose evaluator
+   always returns `Left "logic error"` for that purpose,
+   **When** `build` is called,
+   **Then** it returns `Left (EvalFailure purpose "logic error")`.
+
+2. **Given** a program with two script spends where one
+   always fails and one succeeds,
+   **When** `build` is called,
+   **Then** it returns `Left (EvalFailure failingPurpose msg)`.
+
+---
+
+### User Story 2 - Fee-related eval failures still retry (Priority: P1)
+
+A developer uses the TxBuild DSL with a conservation
+validator. On the first iteration (fee=0), the script
+fails because the fee hasn't been estimated yet. The
+`build` function should retry with an estimated fee and
+eventually converge.
+
+**Why this priority**: This is the existing behavior that
+must be preserved — fee-bootstrapping depends on retry.
+
+**Independent Test**: Mock evaluator that fails when fee=0
+but succeeds when fee>0 → `build` converges.
+
+**Acceptance Scenarios**:
+
+1. **Given** a program whose evaluator fails at fee=0 but
+   succeeds at fee>0,
+   **When** `build` is called,
+   **Then** it returns `Right tx` with a valid fee.
+
+---
+
+### Edge Cases
+
+- What if eval fails on iteration 1 (fee=0) but succeeds
+  on iteration 2, then fails again on iteration 3 with a
+  different error? The second failure is stable → return
+  `EvalFailure`.
+- What if all scripts fail? Return the first failure.
+- What if the same script fails with different messages
+  across iterations? The message content may vary — detect
+  stability by purpose, not by message string.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: `build` MUST return `Left (EvalFailure purpose msg)`
+  when a script evaluation failure is detected as stable
+  (not fee-related).
+- **FR-002**: `build` MUST retry on eval failure when
+  `prevFee == 0` (first iteration, fee bootstrapping).
+- **FR-003**: `build` MUST NOT retry indefinitely — if eval
+  fails and the fee has already been established (prevFee > 0),
+  use the previous ExUnits fallback or surface the error.
+- **FR-004**: The existing `BuildError` type's `EvalFailure`
+  constructor MUST be used (no new error types needed).
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A mock evaluator that always fails causes
+  `build` to return in bounded time (not hang).
+- **SC-002**: Existing unit tests (67) and E2E tests (10)
+  continue to pass.
+- **SC-003**: New regression test covers the terminal
+  failure case.
+
+## Assumptions
+
+- The evaluator function provided to `build` is deterministic
+  for the same transaction — same tx in, same result out.
+- Fee-related failures happen on early iterations (fee=0 or
+  fee too low). Once a successful eval has occurred, subsequent
+  failures for the same purpose are terminal.

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -1051,6 +1051,54 @@ buildSpec =
                     last history
                         `shouldBe` (tx ^. bodyTxL . feeTxBodyL)
 
+        it "surfaces terminal eval failure instead of retrying" $ do
+            let pp =
+                    emptyPParams
+                        & ppMinFeeAL .~ Coin 44
+                        & ppMinFeeBL .~ Coin 155381
+                feeUtxo =
+                    ( mkTxIn 1
+                    , mkBasicTxOut
+                        (mkAddr 1)
+                        (inject (Coin 10_000_000))
+                    )
+                spendUtxo =
+                    ( mkTxIn 2
+                    , mkBasicTxOut
+                        (mkAddr 3)
+                        (inject (Coin 5_000_000))
+                    )
+                prog :: TxBuild TestQ TestErr ()
+                prog = do
+                    _ <- spend (mkTxIn 2)
+                    pure ()
+                interpret = InterpretIO (const (pure undefined))
+                -- Evaluator always fails regardless
+                -- of fee — a genuine script bug.
+                mockEval _tx =
+                    pure $
+                        Map.singleton
+                            (ConwaySpending (AsIx 0))
+                            (Left "script logic error")
+            result <-
+                build
+                    pp
+                    interpret
+                    mockEval
+                    [feeUtxo, spendUtxo]
+                    (mkAddr 1)
+                    prog
+            case result of
+                Left (EvalFailure _purpose msg) ->
+                    msg `shouldBe` "script logic error"
+                Left other ->
+                    expectationFailure $
+                        "expected EvalFailure, got: "
+                            <> show other
+                Right _ ->
+                    expectationFailure
+                        "expected EvalFailure, got Right"
+
         it "re-interprets outputs after a fee oscillation" $ do
             feeHistoryRef <- newIORef []
             let pp =


### PR DESCRIPTION
## Summary

- Add `evalRetries` counter to the `build` loop. On the first eval failure, retry with an estimated fee (fee bootstrap). On the second consecutive failure without a prior success, return `Left (EvalFailure purpose msg)` instead of looping forever.
- When a prior iteration succeeded (`prevFee > 0`), reuse its ExUnits to avoid retry loops from conservation check failures at different fees.
- The existing `EvalFailure` constructor in `BuildError` is now actually emitted.

Closes #53

## Test plan

- [x] 68 unit tests pass (67 existing + 1 new regression test)
- [x] 10 E2E tests pass
- [x] Local CI passes (format, hlint, cabal-check)
- [x] MPFS CageFlow E2E (3/3) verified downstream