### PR TITLE
fix: replace partial failures with typed errors

### DIFF
--- a/lib/Cardano/Node/Client/Balance.hs
+++ b/lib/Cardano/Node/Client/Balance.hs
@@ -78,10 +78,12 @@ import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
 import Cardano.Ledger.Plutus.Language (Language)
 import Cardano.Ledger.TxIn (TxIn)
 
--- | Fee-paying UTxO has insufficient ada.
+-- | Errors from 'balanceTx'.
 data BalanceError
     = -- | @InsufficientFee required available@
       InsufficientFee !Coin !Coin
+    | -- | Fee did not converge within 10 iterations.
+      FeeNotConverged
     deriving (Eq, Show)
 
 {- | Balance a transaction by adding input UTxOs
@@ -160,9 +162,7 @@ balanceTx pp inputUtxos changeAddr tx =
         -- Iterate until the fee stabilises.
         go !n currentFee
             | n > (10 :: Int) =
-                error
-                    "balanceTx: fee did not \
-                    \converge in 10 iterations"
+                Left FeeNotConverged
             | otherwise =
                 let candidate =
                         buildTx currentFee
@@ -174,18 +174,24 @@ balanceTx pp inputUtxos changeAddr tx =
                             0 -- Byron witnesses
                             0 -- ref scripts bytes
                  in if newFee <= currentFee
-                        then currentFee
+                        then Right currentFee
                         else go (n + 1) newFee
         initFee = Coin 0
-        fee = go 0 initFee
-        Coin available = inputCoin
-        Coin required = fee
-        changeAmount =
-            available - required - origAda
-     in if changeAmount < 0
-            then
-                Left (InsufficientFee fee inputCoin)
-            else Right (buildTx fee)
+     in case go 0 initFee of
+            Left err -> Left err
+            Right fee ->
+                let Coin available = inputCoin
+                    Coin required = fee
+                    changeAmount =
+                        available - required - origAda
+                 in if changeAmount < 0
+                        then
+                            Left
+                                ( InsufficientFee
+                                    fee
+                                    inputCoin
+                                )
+                        else Right (buildTx fee)
 
 {- | Output function rejected the fee, or the
 iteration did not converge.

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -858,6 +858,8 @@ data BuildError e
       BalanceFailed BalanceError
     | -- | Validation failures on the final Tx.
       ChecksFailed [Check e]
+    | -- | Internal error adjusting the fee.
+      BumpFeeFailed String
     deriving (Show)
 
 {- | Assemble, evaluate scripts, and balance.
@@ -1082,14 +1084,20 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
                                         -- once with max
                                         -- so Peek sees
                                         -- the right fee.
-                                        step
-                                            seenFees
-                                            newMax
-                                            0
-                                            ( bumpFee
-                                                balanced
-                                                newMax
-                                            )
+                                        case bumpFee
+                                            balanced
+                                            newMax of
+                                            Left msg ->
+                                                pure $
+                                                    Left $
+                                                        BumpFeeFailed
+                                                            msg
+                                            Right bumped ->
+                                                step
+                                                    seenFees
+                                                    newMax
+                                                    0
+                                                    bumped
                                     else
                                         -- Truly
                                         -- converged.
@@ -1149,60 +1157,71 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
                             + (unCoin hi - unCoin lo)
                                 `div` 2
             -- Re-interpret with mid fee
-            let midTx =
-                    bumpFee templateTx mid
-                midWithIns = addExtras midTx
-            (st', _, _) <-
-                interpretWithM
-                    (runInterpretIO interpret)
-                    midWithIns
-                    prog
-            let tx' =
-                    assembleTxWith extraIns pp st'
-                        & bodyTxL . feeTxBodyL .~ mid
-            -- Balance to get change output
-            case balanceTx
-                pp
-                inputUtxos
-                changeAddr
-                tx' of
-                Left _ ->
-                    -- Can't balance at mid, go hi
-                    bisect
-                        st
-                        evalResult
-                        templateTx
-                        mid
-                        hi
-                Right balanced -> do
-                    let midBal =
-                            bumpFee balanced mid
-                    -- Evaluate with change output
-                    evalResult' <-
-                        evaluateTx midBal
-                    let failures' =
-                            [ e
-                            | (_, Left e) <-
-                                Map.toList
-                                    evalResult'
-                            ]
-                    if null failures'
-                        then
-                            -- mid works, try lower
-                            bisect
+            case bumpFee templateTx mid of
+                Left msg ->
+                    pure $ Left $ BumpFeeFailed msg
+                Right midTx -> do
+                    let midWithIns = addExtras midTx
+                    (st', _, _) <-
+                        interpretWithM
+                            (runInterpretIO interpret)
+                            midWithIns
+                            prog
+                    let tx' =
+                            assembleTxWith
+                                extraIns
+                                pp
                                 st'
-                                evalResult'
-                                midBal
-                                lo
-                                mid
-                        else
-                            -- mid fails, try higher
+                                & bodyTxL . feeTxBodyL
+                                    .~ mid
+                    -- Balance to get change output
+                    case balanceTx
+                        pp
+                        inputUtxos
+                        changeAddr
+                        tx' of
+                        Left _ ->
+                            -- Can't balance at mid
                             bisect
                                 st
                                 evalResult
                                 templateTx
                                 mid
                                 hi
+                        Right balanced ->
+                            case bumpFee balanced mid of
+                                Left msg ->
+                                    pure $
+                                        Left $
+                                            BumpFeeFailed
+                                                msg
+                                Right midBal -> do
+                                    evalResult' <-
+                                        evaluateTx
+                                            midBal
+                                    let failures' =
+                                            [ e
+                                            | ( _
+                                                , Left e
+                                                ) <-
+                                                Map.toList
+                                                    evalResult'
+                                            ]
+                                    if null failures'
+                                        then
+                                            bisect
+                                                st'
+                                                evalResult'
+                                                midBal
+                                                lo
+                                                mid
+                                        else
+                                            bisect
+                                                st
+                                                evalResult
+                                                templateTx
+                                                mid
+                                                hi
 
     -- \| Finalize with a specific fee.
     --
@@ -1238,18 +1257,26 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
                 let balFee =
                         balanced
                             ^. bodyTxL . feeTxBodyL
-                    final =
+                    eFinal =
                         if balFee == fee
-                            then balanced
+                            then Right balanced
                             else bumpFee balanced fee
-                case failedChecks
-                    (tsChecks st')
-                    final of
-                    [] -> pure $ Right final
-                    errs ->
+                case eFinal of
+                    Left msg ->
                         pure $
                             Left $
-                                ChecksFailed errs
+                                BumpFeeFailed msg
+                    Right final ->
+                        case failedChecks
+                            (tsChecks st')
+                            final of
+                            [] ->
+                                pure $ Right final
+                            errs ->
+                                pure $
+                                    Left $
+                                        ChecksFailed
+                                            errs
 
     -- \| Patch ExUnits from eval result.
     patchExUnits tx evalResult =
@@ -1301,7 +1328,10 @@ Pre-condition: outputs must be non-empty (the
 last one is the change output added by
 balanceTx).
 -}
-bumpFee :: Tx ConwayEra -> Coin -> Tx ConwayEra
+bumpFee ::
+    Tx ConwayEra ->
+    Coin ->
+    Either String (Tx ConwayEra)
 bumpFee tx targetFee =
     let currentFee = tx ^. bodyTxL . feeTxBodyL
         diff = unCoin targetFee - unCoin currentFee
@@ -1312,9 +1342,7 @@ bumpFee tx targetFee =
                 (tx ^. bodyTxL . outputsTxBodyL)
      in case reverse outs of
             [] ->
-                error
-                    "bumpFee: no outputs to \
-                    \adjust"
+                Left "bumpFee: no outputs"
             (changeOut : rest) ->
                 let Coin changeVal =
                         changeOut ^. coinTxOutL
@@ -1326,11 +1354,12 @@ bumpFee tx targetFee =
                     newOuts =
                         StrictSeq.fromList
                             (reverse (adjusted : rest))
-                 in tx
-                        & bodyTxL . feeTxBodyL
-                            .~ targetFee
-                        & bodyTxL . outputsTxBodyL
-                            .~ newOuts
+                 in Right $
+                        tx
+                            & bodyTxL . feeTxBodyL
+                                .~ targetFee
+                            & bodyTxL . outputsTxBodyL
+                                .~ newOuts
 
 -- ----------------------------------------------------
 -- Internal helpers


### PR DESCRIPTION
## Summary

- `balanceTx`: replace `error` on fee non-convergence with `Left FeeNotConverged` (new `BalanceError` constructor)
- `bumpFee`: return `Either String` instead of calling `error` on empty outputs. Callers surface `BumpFeeFailed` (new `BuildError` constructor)

Closes #55

## Test plan

- [x] 68 unit + 10 E2E pass
- [x] Local CI (format, hlint)
- [x] MPFS CageFlow 3/3 downstream