### PR TITLE
fix: make build convergence depend on Peek convergence

### DIFF
--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -915,7 +915,7 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
     step seenFees maxFee evalRetries prevTx = do
         -- 1. Interpret
         let prevWithIns = addExtras prevTx
-        (st, _, _) <-
+        (st, _, peekConverged) <-
             interpretWithM
                 (runInterpretIO interpret)
                 prevWithIns
@@ -1099,20 +1099,31 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
                                                     0
                                                     bumped
                                     else
-                                        -- Truly
-                                        -- converged.
-                                        case failedChecks
-                                            (tsChecks st)
-                                            balanced of
-                                            [] ->
-                                                pure $
-                                                    Right
-                                                        balanced
-                                            errs ->
-                                                pure $
-                                                    Left $
-                                                        ChecksFailed
-                                                            errs
+                                        if not peekConverged
+                                            then
+                                                -- Fee converged
+                                                -- but Peek has
+                                                -- not. Re-iterate.
+                                                step
+                                                    seenFees
+                                                    newMax
+                                                    0
+                                                    balanced
+                                            else
+                                                -- Truly
+                                                -- converged.
+                                                case failedChecks
+                                                    (tsChecks st)
+                                                    balanced of
+                                                    [] ->
+                                                        pure $
+                                                            Right
+                                                                balanced
+                                                    errs ->
+                                                        pure $
+                                                            Left $
+                                                                ChecksFailed
+                                                                    errs
                             else
                                 if Set.member
                                     finalFee

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -1099,6 +1099,55 @@ buildSpec =
                     expectationFailure
                         "expected EvalFailure, got Right"
 
+        it "re-iterates when Peek has not converged" $ do
+            -- Peek returns Iterate on the first pass,
+            -- Ok on the second. The build loop must
+            -- not stop after the first fee convergence.
+            passRef <- newIORef (0 :: Int)
+            let pp =
+                    emptyPParams
+                        & ppMinFeeAL .~ Coin 44
+                        & ppMinFeeBL .~ Coin 155381
+                feeUtxo =
+                    ( mkTxIn 1
+                    , mkBasicTxOut
+                        (mkAddr 1)
+                        (inject (Coin 10_000_000))
+                    )
+                prog :: TxBuild TestQ TestErr ()
+                prog = do
+                    _ <- peek $ \tx -> do
+                        let Coin f =
+                                tx
+                                    ^. bodyTxL
+                                        . feeTxBodyL
+                        if f > 0
+                            then Ok (Coin f)
+                            else Iterate (Coin 0)
+                    pure ()
+                interpret =
+                    InterpretIO $ \case
+                        RecordFee _ -> do
+                            modifyIORef' passRef (+ 1)
+                            pure ()
+                mockEval _tx = pure Map.empty
+            result <-
+                build
+                    pp
+                    interpret
+                    mockEval
+                    [feeUtxo]
+                    (mkAddr 1)
+                    prog
+            case result of
+                Left err ->
+                    expectationFailure $ show err
+                Right tx -> do
+                    let Coin fee =
+                            tx
+                                ^. bodyTxL . feeTxBodyL
+                    fee `shouldSatisfy` (> 0)
+
         it "re-interprets outputs after a fee oscillation" $ do
             feeHistoryRef <- newIORef []
             let pp =


### PR DESCRIPTION
## Summary

- The `Bool` returned by `interpretWithM` (whether all `Peek` nodes returned `Ok`) was ignored. The build loop stopped when the fee converged, even if a `Peek` still returned `Iterate`.
- Now the loop re-iterates until both fee and Peek have converged.

Closes #54

## Test plan

- [x] 69 unit tests pass (68 existing + 1 new)
- [x] 10 E2E tests pass
- [x] Local CI (format, hlint)
- [x] MPFS CageFlow 3/3 downstream