### PR TITLE
fix: skip Peek convergence check at zero fee

### DIFF
--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -1096,6 +1096,8 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
                                                     bumped
                                     else
                                         if not peekConverged
+                                            && finalFee
+                                                > Coin 0
                                             then
                                                 -- Fee converged
                                                 -- but Peek has


### PR DESCRIPTION
## Summary

When fee is 0 (mock evaluator, no scripts), a `Peek` callback that checks `tx.fee > 0` always returns `Iterate`, causing the build loop to re-iterate forever. Only check Peek convergence when the fee is positive.

Found via downstream MPFS `updateToken` unit tests hanging after the [#59](https://github.com/lambdasistemi/cardano-node-clients/pull/59) merge.

## Test plan

- [x] 69 unit + 10 E2E pass (local CI)
- [x] MPFS 360 unit tests pass via `cabal-debug.project` local override