### PR TITLE
fix: skip Peek re-iteration when fee is zero

### DIFF
--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -1096,6 +1096,8 @@ build pp interpret evaluateTx inputUtxos changeAddr prog =
                                                     bumped
                                     else
                                         if not peekConverged
+                                            && finalFee
+                                                > Coin 0
                                             then
                                                 -- Fee converged
                                                 -- but Peek has


### PR DESCRIPTION
## Summary

When fee converges at zero (no scripts, zero-fee mock PParams), re-iterating for Peek convergence produces the same result forever — infinite loop.

Add `&& finalFee > Coin 0` guard to the Peek re-iteration check. When fee is zero, there's no progress to make — Peek wants a non-zero fee but the tx has nothing to generate one.

Found via MPFS `updateToken` unit tests which use a mock evaluator returning empty results and zero-fee PParams.

## Test plan

- [x] 69 unit + 10 E2E pass locally (`just ci`)
- [x] MPFS `updateToken` tests pass (5/5, previously hung)