### PR TITLE
feat: re-export Ed25519 verify primitives from E2E.Setup

### DIFF
--- a/e2e-test/Cardano/Node/Client/E2E/Setup.hs
+++ b/e2e-test/Cardano/Node/Client/E2E/Setup.hs
@@ -24,6 +24,25 @@ module Cardano.Node.Client.E2E.Setup (
     -- * Signing
     addKeyWitness,
 
+    -- * Ed25519 primitives (re-exports for downstream test harnesses)
+
+    --
+    -- Downstream projects exercising customer-supplied Ed25519 signatures
+    -- (for example, a ZK-proof validator that consumes a customer signature
+    -- as part of its redeemer) need to verify those bytes with an Ed25519
+    -- library that is byte-compatible with the Plutus @VerifyEd25519Signature@
+    -- builtin. Exposing the underlying @cardano-crypto-class@ primitives here
+    -- keeps the public surface consistent and prevents downstream projects
+    -- from depending on @cardano-crypto-class@ directly.
+    Ed25519DSIGN,
+    SignKeyDSIGN,
+    VerKeyDSIGN,
+    SigDSIGN,
+    verifyDSIGN,
+    deriveVerKeyDSIGN,
+    rawDeserialiseVerKeyDSIGN,
+    rawDeserialiseSigDSIGN,
+
     -- * Devnet bracket
     withDevnet,
 ) where
@@ -37,9 +56,14 @@ import System.Environment (lookupEnv)
 
 import Cardano.Crypto.DSIGN (
     Ed25519DSIGN,
+    SigDSIGN,
     SignKeyDSIGN,
+    VerKeyDSIGN,
     deriveVerKeyDSIGN,
     genKeyDSIGN,
+    rawDeserialiseSigDSIGN,
+    rawDeserialiseVerKeyDSIGN,
+    verifyDSIGN,
  )
 import Cardano.Crypto.Seed (mkSeedFromBytes)
 import Cardano.Ledger.Address (Addr (..))


### PR DESCRIPTION
## Summary

Adds eight Ed25519 primitives to the public export list of `Cardano.Node.Client.E2E.Setup`:

- `Ed25519DSIGN`, `SignKeyDSIGN`, `VerKeyDSIGN`, `SigDSIGN`
- `verifyDSIGN`, `deriveVerKeyDSIGN`
- `rawDeserialiseVerKeyDSIGN`, `rawDeserialiseSigDSIGN`

All of them come from `cardano-crypto-class` (already a transitive dependency of the `:devnet` sub-library).

## Why

Downstream test harnesses need to verify customer-supplied Ed25519 signatures with an implementation byte-compatible with Plutus's `VerifyEd25519Signature` builtin. Without this re-export, downstreams have to depend on `cardano-crypto-class` directly, which splits the Ed25519 surface across two dependencies and creates two sources of truth for the same operation.

Concrete driver: harvest is adding end-to-end tests for its voucher-spend validator ([lambdasistemi/harvest#15](https://github.com/lambdasistemi/harvest/issues/15)) and needs an independent Ed25519 verifier on the Haskell side. The project's standing rule is to consume cryptographic primitives through `cardano-node-clients` and to patch upstream when they're not covered — this PR is that patch.

## Diff

One file, export list + import extension. No logic change.

```
e2e-test/Cardano/Node/Client/E2E/Setup.hs | 24 ++++++++++++++++++++++++
```

## Test plan

- `nix build .#checks.x86_64-linux.build --no-link` — green.
- `nix build .#checks.x86_64-linux.lint --no-link` — green.
- No behavioural tests changed; this is purely an exposure surface.
