### PR TITLE
feat: re-export Ed25519 signing primitives from E2E.Setup

### DIFF
--- a/e2e-test/Cardano/Node/Client/E2E/Setup.hs
+++ b/e2e-test/Cardano/Node/Client/E2E/Setup.hs
@@ -39,8 +39,10 @@ module Cardano.Node.Client.E2E.Setup (
     VerKeyDSIGN,
     SigDSIGN,
     verifyDSIGN,
+    signDSIGN,
     deriveVerKeyDSIGN,
     rawDeserialiseVerKeyDSIGN,
+    rawDeserialiseSignKeyDSIGN,
     rawDeserialiseSigDSIGN,
 
     -- * Devnet bracket
@@ -62,7 +64,9 @@ import Cardano.Crypto.DSIGN (
     deriveVerKeyDSIGN,
     genKeyDSIGN,
     rawDeserialiseSigDSIGN,
+    rawDeserialiseSignKeyDSIGN,
     rawDeserialiseVerKeyDSIGN,
+    signDSIGN,
     verifyDSIGN,
  )
 import Cardano.Crypto.Seed (mkSeedFromBytes)


### PR DESCRIPTION
## Summary

Adds two more Ed25519 primitives to the public export list of `Cardano.Node.Client.E2E.Setup`, following PR #65:

- `signDSIGN`
- `rawDeserialiseSignKeyDSIGN`

## Why

Harvest's [upcoming devnet-backed E2E tests](https://github.com/lambdasistemi/harvest/issues/15) need to re-sign a canonical payload at runtime, because the fixture's `signed_data` is bound to a zero-txid placeholder and a real devnet-submitted tx consumes a real TxOutRef chosen at test time. That re-signing requires `rawDeserialiseSignKeyDSIGN` to reconstruct the customer's Ed25519 signing key from the fixture's hex bytes and `signDSIGN` to produce a signature byte-compatible with Plutus's `VerifyEd25519Signature` builtin.

PR #65 handled the verify side. This is the symmetric sign-side export. Together they let downstream test harnesses do Ed25519 on both sides through `cardano-node-clients:devnet`'s public surface, without depending on `cardano-crypto-class` directly.

## Diff

One file, two symbol additions to the export list and the import list. No logic change.

## Test plan

- `nix build .#checks.x86_64-linux.build --no-link` — green.
- `nix build .#checks.x86_64-linux.lint --no-link` — green.
- Downstream consumer ([harvest PR #18](https://github.com/lambdasistemi/harvest/pull/18)) will exercise the new exports once this lands and the pin bumps in harvest's `cabal.project`.
