### PR TITLE
feat: re-export Ed25519 raw-serialise primitives from E2E.Setup

### DIFF
--- a/e2e-test/Cardano/Node/Client/E2E/Setup.hs
+++ b/e2e-test/Cardano/Node/Client/E2E/Setup.hs
@@ -44,6 +44,9 @@ module Cardano.Node.Client.E2E.Setup (
     rawDeserialiseVerKeyDSIGN,
     rawDeserialiseSignKeyDSIGN,
     rawDeserialiseSigDSIGN,
+    rawSerialiseVerKeyDSIGN,
+    rawSerialiseSignKeyDSIGN,
+    rawSerialiseSigDSIGN,
 
     -- * Devnet bracket
     withDevnet,
@@ -66,6 +69,9 @@ import Cardano.Crypto.DSIGN (
     rawDeserialiseSigDSIGN,
     rawDeserialiseSignKeyDSIGN,
     rawDeserialiseVerKeyDSIGN,
+    rawSerialiseSigDSIGN,
+    rawSerialiseSignKeyDSIGN,
+    rawSerialiseVerKeyDSIGN,
     signDSIGN,
     verifyDSIGN,
  )


### PR DESCRIPTION
## Summary

Adds the three Ed25519 raw-serialise primitives to the public export list of `Cardano.Node.Client.E2E.Setup`:

- `rawSerialiseVerKeyDSIGN`
- `rawSerialiseSignKeyDSIGN`
- `rawSerialiseSigDSIGN`

These are the inverses of the three `rawDeserialise*` re-exports that already landed in PRs #65 and #66. Completes the Ed25519 public surface.

## Why

Downstream test harnesses that produce an Ed25519 signature at runtime (for example, [harvest](https://github.com/lambdasistemi/harvest/issues/15)'s `SpendHarness.resignedData`, which re-signs a canonical payload against a live TxOutRef chosen by a devnet) need to turn the resulting `SigDSIGN` back into canonical 64 bytes to put into a Plutus redeemer. Without these re-exports they'd have to depend on `cardano-crypto-class` directly, splitting the Ed25519 surface across two deps.

## Diff

One file, three symbol additions to the export list and the import list. No logic change.

## Test plan

- `nix build .#checks.x86_64-linux.build --no-link` — green locally.
- Downstream consumer pins this branch in [harvest PR #18](https://github.com/lambdasistemi/harvest/pull/18) and its `SpendHarnessSpec` exercises the round-trip: parse pk_c with `rawDeserialiseVerKeyDSIGN`, sign with `signDSIGN`, serialise with `rawSerialiseSigDSIGN`, verify with `verifyDSIGN`. 38 examples, 0 failures.
