### PR TITLE
fix: split mkCardanoLedgerWasm → 24 min → 11 s per edit

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -17,12 +17,20 @@ Test helpers (devnet, genesis keys, transaction building) are exported as public
 ### V. Demo Infrastructure Carve-Out
 This repository MAY host application-shaped artifacts whose sole purpose is to exercise and showcase this repository's own infrastructure (Nix modules, flake outputs, cross-compilation toolchains, build helpers). Such artifacts MUST live under a clearly-named subtree (e.g. `wasm-apps/`, `demos/`) and MUST be excluded from the library's public API surface. They exist to prove the infrastructure works end-to-end and to give downstream consumers a reference implementation; they are not product. Principle III applies to the library, not to demo subtrees.
 
+### VI. Ledger Functional Layer and Data Boundary
+Ledger-facing browser demos and downstream applications MUST model user-visible work as explicit transaction documents in application/workspace state. The canonical transaction state is CBOR bytes owned by that workspace, not hidden mutable state inside a WASM instance.
+
+Haskell/WASM ledger components MUST behave as a ledger functional layer: each operation receives the current transaction CBOR, explicit operation arguments, and any external ledger context required for reproducibility; each operation returns a JSON result and, for mutating operations, the resulting transaction CBOR. WASM code MAY cache decoded values or handles for performance, but cached state MUST NOT be the source of truth and MUST NOT make operation results depend on unobserved prior calls.
+
+JSON is the control plane for operation names, paths, diagnostics, summaries, and simple arguments. CBOR is the data plane for transactions and fidelity-sensitive ledger values. Structural JSON is a view over ledger data, not a round-trippable ledger serialization. Provider or chain state MAY enter an operation only through explicit request context or an explicitly named provider fetch, so results can be reproduced from captured inputs.
+
 ## Quality Gates
 
 - `just ci` passes (build, e2e, format, hlint)
 - All E2E tests run against a real devnet node
 - No mocks for node communication
 - Demo subtrees build under their target toolchain (e.g. wasm32-wasi) and their fixture-based tests pass in CI
+- Ledger operation interfaces preserve CBOR as the canonical transaction state and expose JSON only as an operation/view contract
 
 ## Development Workflow
 
@@ -30,4 +38,4 @@ This repository MAY host application-shaped artifacts whose sole purpose is to e
 - Fourmolu formatting
 - Linear git history via rebase merge
 
-**Version**: 1.1.0 | **Ratified**: 2026-04-02 | **Amended**: 2026-04-23 (added Principle V to carve out demo infrastructure for the WASM ledger inspector)
+**Version**: 1.2.0 | **Ratified**: 2026-04-02 | **Amended**: 2026-04-25 (added Principle VI for the ledger functional layer, workspace-owned transaction state, and JSON-control/CBOR-data boundary)

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -37,7 +37,13 @@ nix develop .#wasm-dev                                # host-side iteration shel
 
 - **Haskell-only edits to `nix/wasm/tx-inspector/wasm-tx-inspector/src/Conway/Inspector.hs`**: ~11 s rebuild. This is the fast path. The split builder (`prebuiltDeps` + `wasm`) keeps the ledger closure cached; Inspector edits only re-link the exe.
 - **Edits to `wasm-tx-inspector.cabal` (adding build-depends)**: ~24 min, because `prebuiltDeps`'s `srcMetadata` filter picks up the cabal file change → its hash changes → full `wasm32-wasi-cabal build --only-dependencies` from scratch in a fresh sandbox.
-- **Edits to `docs/inspector/src/*.purs` (UI)**: ~30 s via `nix build .#tx-inspector-ui`. Or iterate locally faster: `nix shell 'github:paolino/purescript-overlay/fix/remove-nodePackages#{purs,spago-unstable}' -c 'spago build'`.
+- **Edits to `docs/inspector/src/*.purs` (UI)**: ~30 s via `nix build .#tx-inspector-ui`. Or iterate locally faster:
+  ```bash
+  nix shell \
+    'github:paolino/purescript-overlay?ref=fix/remove-nodePackages#purs' \
+    'github:paolino/purescript-overlay?ref=fix/remove-nodePackages#spago-unstable' \
+    -c spago build
+  ```
 - **FOD deps hashes**: hard-coded in `nix/wasm-targets.nix`. If you change forks or bump cabal deps, set `dependenciesHash = pkgs.lib.fakeHash`, build once, replace with the hash Nix prints.
 - Key gotcha: `srcMetadata` in `nix/wasm/mkCardanoLedgerWasm.nix` must set `name = builtins.baseNameOf (toString src)`. Default `"source"` kills the cache because the sandbox extraction path won't match between `prebuiltDeps` and `wasm`.
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,0 +1,134 @@
+# Handover — Conway tx inspector (Haskell → wasm32-wasi → PureScript/Halogen UI)
+
+You're picking up work on `lambdasistemi/cardano-node-clients`. The project builds a browser-loadable tx inspector using the upstream Haskell ledger code, cross-compiled to `wasm32-wasi`, with a PureScript + Halogen UI.
+
+## Repo and branches
+
+- Main repo: `/code/cardano-node-clients`
+- Worktrees:
+  - `/code/cardano-node-clients-wasm-inspector` → branch `033-wasm-ledger-inspector` (PR [#69](https://github.com/lambdasistemi/cardano-node-clients/pull/69)) — feature umbrella.
+  - `/code/cardano-node-clients-wasm-devx` → branch `fix/wasm-devx` (PR [#71](https://github.com/lambdasistemi/cardano-node-clients/pull/71)) — DevX fix + UI polish. This is where you should work unless the task is explicitly for #69.
+- Base for #71 is `033-wasm-ledger-inspector`. Rebase onto `main` once #69 merges.
+- Open tracker issue: [#70](https://github.com/lambdasistemi/cardano-node-clients/issues/70) — DevX deep-dive.
+
+## What runs today
+
+Live preview: <https://cardano-tx-inspector.surge.sh>
+
+- Browser UI (Halogen) with two input modes: **by tx hash** (fetches CBOR via Blockfrost or Koios) and **by CBOR hex** (paste). Pico.css v2 theming; password-typed credential inputs; opt-in persistence switch (off by default → in-memory only; on → `localStorage` cleartext, warned explicitly).
+- Decoder is pure Haskell (`cardano-ledger-conway` + `cardano-ledger-binary` + `cardano-ledger-mary`, unchanged), cross-compiled to `wasm32-wasi` via `ghc-wasm-meta` GHC 9.12. Loaded in the browser via `@bjorn3/browser_wasi_shim`.
+- Current JSON schema: era, decoder, `fee_lovelace`, `validity_interval`, `input_count` / `reference_input_count` / `output_count` / `cert_count` / `withdrawal_count` / `required_signer_count`, `inputs[]`, `reference_inputs[]`, `outputs[{address_hex, coin_lovelace, assets, datum}]`, `mint{}`.
+- Koios in-browser requires a free bearer token (koios.rest intentionally strips CORS on anonymous requests — see [koios-artifacts#397](https://github.com/cardano-community/koios-artifacts/issues/397)). Blockfrost works with the free-tier `project_id`.
+
+## Nix flake outputs (what to build)
+
+```bash
+# from /code/cardano-node-clients-wasm-devx
+nix build .#packages.x86_64-linux.wasm-smoke          # cborg-only smoke (proves toolchain)
+nix build .#packages.x86_64-linux.wasm-ledger-smoke   # full ledger closure smoke
+nix build .#packages.x86_64-linux.wasm-tx-inspector   # THE decoder; ./result/wasm-tx-inspector.wasm
+nix build .#packages.x86_64-linux.tx-inspector-ui     # PS bundle; ./result/{index.html,index.js}
+nix build .#packages.x86_64-linux.devnet-genesis      # untouched pre-existing output
+
+nix develop .#wasm-dev                                # host-side iteration shell (not fully working; see #70 open item)
+```
+
+## Build-cycle facts you need
+
+- **Haskell-only edits to `nix/wasm/tx-inspector/wasm-tx-inspector/src/Conway/Inspector.hs`**: ~11 s rebuild. This is the fast path. The split builder (`prebuiltDeps` + `wasm`) keeps the ledger closure cached; Inspector edits only re-link the exe.
+- **Edits to `wasm-tx-inspector.cabal` (adding build-depends)**: ~24 min, because `prebuiltDeps`'s `srcMetadata` filter picks up the cabal file change → its hash changes → full `wasm32-wasi-cabal build --only-dependencies` from scratch in a fresh sandbox.
+- **Edits to `docs/inspector/src/*.purs` (UI)**: ~30 s via `nix build .#tx-inspector-ui`. Or iterate locally faster: `nix shell 'github:paolino/purescript-overlay/fix/remove-nodePackages#{purs,spago-unstable}' -c 'spago build'`.
+- **FOD deps hashes**: hard-coded in `nix/wasm-targets.nix`. If you change forks or bump cabal deps, set `dependenciesHash = pkgs.lib.fakeHash`, build once, replace with the hash Nix prints.
+- Key gotcha: `srcMetadata` in `nix/wasm/mkCardanoLedgerWasm.nix` must set `name = builtins.baseNameOf (toString src)`. Default `"source"` kills the cache because the sandbox extraction path won't match between `prebuiltDeps` and `wasm`.
+
+## File layout you care about
+
+```
+nix/
+  wasm/
+    default.nix                       # public lib.wasm surface
+    forks.json                        # vendored source-repository-package pins + nix32 hashes
+    cabal-project-fragment.nix        # renders the `if arch(wasm32)` stanza
+    mkCardanoLedgerWasm.nix           # ★ the builder; split into prebuiltDeps + wasm
+    c-libs/                           # libsodium, secp256k1, blst for wasm32
+    tx-inspector/
+      cabal-wasm.project              # project file with SRP stanzas (rewritten at build time)
+      wasm-tx-inspector/
+        wasm-tx-inspector.cabal
+        src/Conway/Inspector.hs       # ★ decoder → JSON
+        app/Main.hs                   # WASI entry (stdin hex → stdout JSON)
+    ledger-smoke/, smoke/             # sibling smoke targets
+  wasm-targets.nix                    # wasm-smoke / wasm-ledger-smoke / wasm-tx-inspector wiring
+  wasm-ui.nix                         # mkSpagoDerivation wrapper for tx-inspector-ui
+  project.nix, fix-libs.nix           # native (non-wasm) cardano-node-clients lib
+  checks.nix, apps.nix                # existing
+
+docs/
+  inspector/
+    spago.yaml, spago.lock, package.json, package-lock.json
+    dist/index.html                   # Pico.css v2 shell
+    src/
+      bootstrap.js                    # loads inspector.wasm via @bjorn3/browser_wasi_shim, exposes globalThis.runInspector
+      Main.purs                       # ★ Halogen root
+      Provider.purs                   # Blockfrost / Koios unified fetch
+      FFI/Blockfrost.{purs,js}
+      FFI/Koios.{purs,js}
+      FFI/Storage.{purs,js}           # localStorage wrappers
+      FFI/Clipboard.{purs,js}
+      FFI/Inspector.{purs,js}         # PS → WASM via globalThis
+      FFI/Json.{purs,js}              # JSON.stringify(_, null, 2) for Copy button
+
+scripts/fetch-tx-cbor.sh              # CLI helper: hash → CBOR hex via Blockfrost
+```
+
+## Open follow-ups to consider
+
+1. **Richer schema** — datum AST rendering (inline Plutus `Data`), redeemers (tag/index/data/ex_units), cert/withdrawal detail, bech32 addresses instead of hex. All fast-path Haskell edits. Start with `renderTx` in `Conway/Inspector.hs`; consult the new API via `Cardano.Ledger.Api` lenses (`rdmrsTxWitsL`, etc).
+2. **Koios proxy** (optional) — small Cloudflare Worker that echoes Koios responses with `Access-Control-Allow-Origin: *` added so anon browser use works. Would remove the "bearer token required for browser" friction. Don't do without asking.
+3. **Cachix for prebuiltDeps** — one-time team-wide cache so the first build isn't 24 min per contributor/CI runner.
+4. **Full-fat `wasm-dev` shell** — currently can't clone SRP forks at runtime inside the shell. Needs `pkgs.fetchgit` pre-materialization + a patched `cabal-wasm.project` in the shellHook. Partial work already in `flake.nix`'s `devShells.wasm-dev`.
+5. **Spec artifacts still point at the minimal schema** — update `specs/033-wasm-ledger-inspector/data-model.md` if you add more fields.
+
+## Commit / PR hygiene you must follow
+
+Read `~/.claude/CLAUDE.md` and the `workflow` / `purescript` / `haskell-wasm` / `nix` skills before touching code. Key rules from memory:
+
+- Never include AI attribution (no "Co-Authored-By: Claude" lines, no "Generated with…" footers).
+- Every issue/PR/CI reference in a reply **must** include a clickable URL.
+- Push feature branches for browser review; commit small focused changes; rebase-merge linear history.
+- Before every push: lint (`fourmolu`, `cabal-fmt`, `hlint`) + full local CI; don't push to trigger CI for debugging.
+- Skills live under `/code/llm-settings/shared/skills/` — commit there if you learn something generally useful.
+
+## Verification recipe
+
+```bash
+# from /code/cardano-node-clients-wasm-devx, branch fix/wasm-devx
+nix build .#packages.x86_64-linux.wasm-tx-inspector
+curl -s -H 'project_id: mainnetRuiuoEo0lhw6tJA3CGaVAoGM3kxIP11O' \
+  https://cardano-mainnet.blockfrost.io/api/v0/txs/62e842c2b864776b2aec846fed1c1ad5810fa4dc12e12d44e8a53b18fdc828f9/cbor \
+  | jq -r .cbor \
+  | nix shell 'gitlab:haskell-wasm/ghc-wasm-meta?host=gitlab.haskell.org' \
+      --command wasmtime result/wasm-tx-inspector.wasm \
+  | jq .
+```
+
+Expected: structural JSON with `"era":"Conway"`, 125 outputs, 3 mint policies, `"cert_count":0`.
+
+## Deploy preview after changes
+
+```bash
+nix build .#packages.x86_64-linux.tx-inspector-ui
+rm -rf /tmp/tx-inspector-surge && mkdir -p /tmp/tx-inspector-surge
+cp -rL result/* /tmp/tx-inspector-surge/
+nix shell 'nixpkgs#nodejs_20' -c npx --yes surge /tmp/tx-inspector-surge cardano-tx-inspector.surge.sh
+```
+
+## If you're unsure
+
+Ask before:
+- Adding cabal build-depends (it's the 24-min path; we should know why).
+- Changing `nix/wasm/mkCardanoLedgerWasm.nix` structure (that file is load-bearing for the DevX story; rerun the 11 s edit-cycle measurement after any change).
+- Adding a new flake input (we minimize them deliberately).
+- Deleting anything under `nix/wasm/`.
+
+Good luck.

--- a/docs/inspector/dist/index.html
+++ b/docs/inspector/dist/index.html
@@ -414,6 +414,23 @@
         color: var(--text);
       }
 
+      .inline-action {
+        min-height: 32px;
+        border: 1px solid var(--border-strong);
+        border-radius: 7px;
+        background: #ffffff;
+        color: var(--text);
+        padding: 0.36rem 0.58rem;
+        font-size: 0.84rem;
+        font-weight: 700;
+        white-space: nowrap;
+      }
+
+      .inline-action:hover {
+        border-color: var(--accent);
+        color: var(--accent-strong);
+      }
+
       .result-heading {
         align-items: center;
       }
@@ -439,11 +456,7 @@
         padding: 0.7rem 0.78rem;
       }
 
-      .metric-label,
-      .section-heading span,
-      .hash-group > span,
-      .output-meta,
-      .mint-row span {
+      .metric-label {
         color: var(--muted);
         font-size: 0.84rem;
       }
@@ -454,102 +467,113 @@
         font-size: 0.98rem;
       }
 
-      .inspection-grid {
+      .json-browser {
         display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        align-items: start;
-        gap: 14px;
-      }
-
-      .inspection-section {
-        display: grid;
-        gap: 10px;
-        align-content: start;
-        min-width: 0;
+        gap: 12px;
         border: 1px solid var(--border);
         border-radius: 8px;
         padding: 12px;
       }
 
-      .wide-section {
-        grid-column: 1 / -1;
-      }
-
-      .section-heading {
+      .browser-heading {
         display: flex;
-        align-items: baseline;
+        align-items: start;
         justify-content: space-between;
         gap: 1rem;
+        border-bottom: 1px solid var(--border);
+        padding-bottom: 12px;
       }
 
-      .section-heading h3 {
-        font-size: 0.96rem;
+      .browser-heading h3 {
+        font-size: 0.98rem;
       }
 
-      .output-list,
-      .mint-list,
-      .hash-group {
+      .browser-heading p,
+      .browser-summary {
+        color: var(--muted);
+        font-size: 0.86rem;
+      }
+
+      .breadcrumb-bar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-top: 0.45rem;
+      }
+
+      .breadcrumb-button {
+        min-height: 30px;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: var(--surface-soft);
+        color: var(--accent-strong);
+        padding: 0.25rem 0.55rem;
+        font-size: 0.82rem;
+        font-weight: 700;
+      }
+
+      .browser-row-list {
         display: grid;
         gap: 8px;
-        align-content: start;
-        min-width: 0;
       }
 
-      .output-row {
+      .browser-row {
         display: grid;
-        grid-template-columns: 3rem minmax(0, 1fr) minmax(11rem, 0.55fr);
-        gap: 0.75rem;
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 0.8rem;
         align-items: center;
         border: 1px solid var(--border);
         border-radius: 8px;
         background: #ffffff;
-        padding: 0.58rem 0.7rem;
+        padding: 0.62rem 0.7rem;
       }
 
-      .row-index {
-        color: var(--muted);
-        font-weight: 700;
+      .browser-row-main {
+        display: grid;
+        gap: 0.32rem;
+        min-width: 0;
       }
 
-      .output-main,
-      .output-meta,
-      .mint-row {
+      .browser-keyline,
+      .browser-actions {
         display: flex;
         align-items: center;
-        gap: 0.6rem;
+        gap: 0.5rem;
         min-width: 0;
       }
 
-      .output-main {
-        justify-content: space-between;
-      }
-
-      .output-main code,
-      .mint-row code,
-      .hash-list code {
-        min-width: 0;
+      .browser-keyline code {
+        max-width: min(42vw, 28rem);
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
       }
 
-      .output-meta {
-        justify-content: end;
+      .browser-summary {
+        overflow-wrap: anywhere;
       }
 
-      .mint-row {
-        justify-content: space-between;
+      .kind-badge {
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: var(--surface-soft);
+        color: var(--muted);
+        padding: 0.08rem 0.42rem;
+        font-size: 0.76rem;
+        font-weight: 700;
+      }
+
+      .scalar-value {
+        min-width: 0;
         border: 1px solid var(--border);
         border-radius: 8px;
         background: #ffffff;
-        padding: 0.58rem 0.7rem;
+        padding: 0.68rem;
       }
 
-      .hash-list {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 6px;
-        min-width: 0;
+      .scalar-value code {
+        display: block;
+        overflow-wrap: anywhere;
       }
 
       .raw-json-block {
@@ -674,20 +698,25 @@
           grid-template-columns: 1fr;
         }
 
-        .metric-grid,
-        .inspection-grid,
-        .output-row {
+        .metric-grid {
           grid-template-columns: 1fr;
         }
 
-        .section-heading,
-        .output-main,
-        .output-meta,
-        .mint-row {
-          align-items: start;
-          flex-direction: column;
+        .browser-heading,
+        .browser-row {
+          grid-template-columns: 1fr;
+        }
+
+        .browser-heading {
+          display: grid;
+        }
+
+        .browser-actions {
           justify-content: start;
-          gap: 0.35rem;
+        }
+
+        .browser-keyline code {
+          max-width: 100%;
         }
 
         .primary-action,
@@ -740,6 +769,6 @@
         >.
       </div>
     </footer>
-    <script src="index.js?v=inspection-panel-2"></script>
+    <script src="index.js?v=transaction-browser-1"></script>
   </body>
 </html>

--- a/docs/inspector/dist/index.html
+++ b/docs/inspector/dist/index.html
@@ -528,6 +528,20 @@
         padding: 0.62rem 0.7rem;
       }
 
+      .browser-row.is-expanded {
+        border-color: var(--accent);
+        background: #f7fffd;
+      }
+
+      .browser-children {
+        display: grid;
+        gap: 8px;
+        min-width: 0;
+        margin-left: 18px;
+        padding-left: 12px;
+        border-left: 2px solid var(--border);
+      }
+
       .browser-row-main {
         display: grid;
         gap: 0.32rem;
@@ -715,6 +729,11 @@
           justify-content: start;
         }
 
+        .browser-children {
+          margin-left: 8px;
+          padding-left: 8px;
+        }
+
         .browser-keyline code {
           max-width: 100%;
         }
@@ -769,6 +788,6 @@
         >.
       </div>
     </footer>
-    <script src="index.js?v=ledger-rpc-1"></script>
+    <script src="index.js?v=ledger-rpc-tree-1"></script>
   </body>
 </html>

--- a/docs/inspector/dist/index.html
+++ b/docs/inspector/dist/index.html
@@ -10,18 +10,75 @@
       href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
     />
     <style>
-      pre { overflow-x: auto; }
-      textarea { font-family: var(--pico-font-family-monospace); font-size: 0.875rem; }
-      input[type="text"], input[type="password"] { font-family: var(--pico-font-family-monospace); }
-      .muted { color: var(--pico-muted-color); font-size: 0.875rem; }
+      /* Tighten Pico's type and spacing for a denser, less-exaggerated look. */
+      :root {
+        --pico-font-size: 15px;
+        --pico-line-height: 1.5;
+        --pico-spacing: 0.75rem;
+        --pico-typography-spacing-vertical: 0.9rem;
+        --pico-form-element-spacing-vertical: 0.4rem;
+        --pico-form-element-spacing-horizontal: 0.65rem;
+        --pico-border-radius: 0.25rem;
+      }
+      h1 { font-size: 1.6rem; margin-bottom: 0.4rem; }
+      h2 { font-size: 1.2rem; margin-top: 0; }
+      h3 { font-size: 1.05rem; }
+      p { margin: 0.5rem 0; }
+      article { padding: 1rem 1.1rem; margin-block: 1rem; }
+      article > header { padding-block: 0.4rem; margin-block-end: 0.6rem; }
+      fieldset { margin-bottom: 0.6rem; }
+      fieldset legend { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--pico-muted-color); }
+      pre { overflow-x: auto; font-size: 0.8rem; padding: 0.75rem 1rem; }
+      textarea { font-family: var(--pico-font-family-monospace); font-size: 0.8rem; }
+      input[type="text"], input[type="password"] { font-family: var(--pico-font-family-monospace); font-size: 0.85rem; }
+      button { font-size: 0.9rem; }
+      .muted { color: var(--pico-muted-color); font-size: 0.85rem; }
       .warning { color: var(--pico-color-amber-550); }
-      .error { color: var(--pico-color-red-550); }
+      .error { border-color: var(--pico-color-red-550); }
+      nav.site-nav { padding-block: 0.5rem; }
+      nav.site-nav strong { font-size: 0.95rem; }
+      footer.site-footer { padding-block: 1.5rem; color: var(--pico-muted-color); font-size: 0.85rem; border-top: 1px solid var(--pico-muted-border-color); margin-top: 2rem; }
     </style>
   </head>
   <body>
+    <header class="container">
+      <nav class="site-nav">
+        <ul>
+          <li><strong>Conway tx inspector</strong></li>
+        </ul>
+        <ul>
+          <li>
+            <a
+              href="https://github.com/lambdasistemi/cardano-node-clients"
+              target="_blank"
+              rel="noopener noreferrer"
+              >GitHub ↗</a
+            >
+          </li>
+        </ul>
+      </nav>
+    </header>
     <main class="container">
       <div id="app"></div>
     </main>
+    <footer class="container site-footer">
+      <div>
+        Built with the upstream Haskell ledger, cross-compiled to
+        <code>wasm32-wasi</code> via
+        <a
+          href="https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta"
+          target="_blank"
+          rel="noopener noreferrer"
+          >ghc-wasm-meta</a
+        >. Source:
+        <a
+          href="https://github.com/lambdasistemi/cardano-node-clients"
+          target="_blank"
+          rel="noopener noreferrer"
+          >lambdasistemi/cardano-node-clients</a
+        >.
+      </div>
+    </footer>
     <script src="index.js"></script>
   </body>
 </html>

--- a/docs/inspector/dist/index.html
+++ b/docs/inspector/dist/index.html
@@ -3,65 +3,560 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="color-scheme" content="light dark" />
-    <title>Conway tx inspector — Haskell ledger, wasm32-wasi</title>
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
-    />
+    <meta name="color-scheme" content="light" />
+    <title>Conway tx inspector - Haskell ledger, wasm32-wasi</title>
+    <link rel="icon" href="data:," />
     <style>
-      /* Tighten Pico's type and spacing for a denser, less-exaggerated look. */
       :root {
-        --pico-font-size: 15px;
-        --pico-line-height: 1.5;
-        --pico-spacing: 0.75rem;
-        --pico-typography-spacing-vertical: 0.9rem;
-        --pico-form-element-spacing-vertical: 0.4rem;
-        --pico-form-element-spacing-horizontal: 0.65rem;
-        --pico-border-radius: 0.25rem;
+        color-scheme: light;
+        --page: #f5f7fa;
+        --surface: #ffffff;
+        --surface-soft: #f9fbfd;
+        --text: #17212f;
+        --muted: #5d6b7a;
+        --border: #d9e1ea;
+        --border-strong: #b9c6d4;
+        --accent: #0a7b83;
+        --accent-strong: #075f66;
+        --accent-soft: #e6f4f5;
+        --danger: #b42318;
+        --danger-soft: #fff0ed;
+        --warning: #835800;
+        --warning-soft: #fff7df;
+        --shadow: 0 14px 34px rgba(23, 33, 47, 0.08);
+        font-family:
+          ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+        font-size: 15px;
+        line-height: 1.5;
       }
-      h1 { font-size: 1.6rem; margin-bottom: 0.4rem; }
-      h2 { font-size: 1.2rem; margin-top: 0; }
-      h3 { font-size: 1.05rem; }
-      p { margin: 0.5rem 0; }
-      article { padding: 1rem 1.1rem; margin-block: 1rem; }
-      article > header { padding-block: 0.4rem; margin-block-end: 0.6rem; }
-      fieldset { margin-bottom: 0.6rem; }
-      fieldset legend { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--pico-muted-color); }
-      pre { overflow-x: auto; font-size: 0.8rem; padding: 0.75rem 1rem; }
-      textarea { font-family: var(--pico-font-family-monospace); font-size: 0.8rem; }
-      input[type="text"], input[type="password"] { font-family: var(--pico-font-family-monospace); font-size: 0.85rem; }
-      button { font-size: 0.9rem; }
-      .muted { color: var(--pico-muted-color); font-size: 0.85rem; }
-      .warning { color: var(--pico-color-amber-550); }
-      .error { border-color: var(--pico-color-red-550); }
-      nav.site-nav { padding-block: 0.5rem; }
-      nav.site-nav strong { font-size: 0.95rem; }
-      footer.site-footer { padding-block: 1.5rem; color: var(--pico-muted-color); font-size: 0.85rem; border-top: 1px solid var(--pico-muted-border-color); margin-top: 2rem; }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html {
+        background: var(--page);
+      }
+
+      body {
+        margin: 0;
+        min-width: 320px;
+        background: var(--page);
+        color: var(--text);
+      }
+
+      a {
+        color: var(--accent-strong);
+        text-decoration-thickness: 1px;
+        text-underline-offset: 0.18em;
+      }
+
+      button,
+      input,
+      textarea {
+        font: inherit;
+      }
+
+      button {
+        cursor: pointer;
+      }
+
+      button:disabled {
+        cursor: wait;
+        opacity: 0.68;
+      }
+
+      code,
+      pre,
+      textarea,
+      input[type="text"],
+      input[type="password"] {
+        font-family:
+          ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+          monospace;
+      }
+
+      code {
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        background: var(--surface-soft);
+        padding: 0.1rem 0.35rem;
+        color: #334155;
+        font-size: 0.88em;
+      }
+
+      .page-frame {
+        width: min(100% - 32px, 1180px);
+        margin-inline: auto;
+      }
+
+      .site-header {
+        background: rgba(255, 255, 255, 0.92);
+        border-bottom: 1px solid var(--border);
+      }
+
+      .topbar {
+        min-height: 64px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+
+      .brand {
+        display: flex;
+        flex-direction: column;
+        gap: 0.1rem;
+      }
+
+      .brand strong {
+        font-size: 1rem;
+      }
+
+      .brand span,
+      .site-footer {
+        color: var(--muted);
+        font-size: 0.88rem;
+      }
+
+      .header-link {
+        min-height: 40px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: var(--surface);
+        padding: 0.42rem 0.72rem;
+        color: var(--text);
+        text-decoration: none;
+      }
+
+      main.page-frame {
+        padding-block: 24px 18px;
+      }
+
+      .app-shell {
+        display: grid;
+        gap: 18px;
+      }
+
+      .intro-strip {
+        display: flex;
+        align-items: end;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+
+      .intro-strip h1,
+      .panel h2,
+      .panel h3,
+      .intro-strip p,
+      .panel p,
+      fieldset {
+        margin: 0;
+      }
+
+      .intro-strip h1 {
+        font-size: 1.65rem;
+        line-height: 1.15;
+      }
+
+      .intro-strip p {
+        max-width: 68ch;
+        color: var(--muted);
+        margin-top: 0.35rem;
+      }
+
+      .tech-pills {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: end;
+        gap: 0.45rem;
+      }
+
+      .tech-pills span {
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: var(--surface);
+        padding: 0.26rem 0.55rem;
+        color: var(--muted);
+        font-size: 0.82rem;
+        white-space: nowrap;
+      }
+
+      .workspace {
+        display: grid;
+        grid-template-columns: minmax(280px, 0.78fr) minmax(0, 1.22fr);
+        gap: 18px;
+        align-items: start;
+      }
+
+      .workspace-main {
+        display: grid;
+        gap: 18px;
+        min-width: 0;
+      }
+
+      .panel {
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: var(--surface);
+        box-shadow: var(--shadow);
+        padding: 18px;
+      }
+
+      .provider-panel {
+        position: sticky;
+        top: 16px;
+      }
+
+      .panel-heading {
+        display: flex;
+        align-items: start;
+        justify-content: space-between;
+        gap: 1rem;
+        border-bottom: 1px solid var(--border);
+        padding-bottom: 13px;
+        margin-bottom: 16px;
+      }
+
+      .provider-panel .panel-heading {
+        display: grid;
+        gap: 0.25rem;
+      }
+
+      .panel-heading h2 {
+        font-size: 1.06rem;
+        line-height: 1.25;
+      }
+
+      .panel-heading p {
+        color: var(--muted);
+        font-size: 0.9rem;
+        margin-top: 0.25rem;
+      }
+
+      .control-group {
+        min-width: 0;
+        border: 0;
+        padding: 0;
+      }
+
+      .control-group + .field-stack,
+      .field-stack + .control-group,
+      .control-group + .persist-block {
+        margin-top: 16px;
+      }
+
+      legend {
+        padding: 0;
+        color: var(--muted);
+        font-size: 0.76rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        margin-bottom: 0.5rem;
+      }
+
+      .option-stack,
+      .mode-options {
+        display: grid;
+        gap: 8px;
+      }
+
+      .mode-options {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .choice-option {
+        display: flex;
+        align-items: center;
+        gap: 0.58rem;
+        min-height: 42px;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: var(--surface-soft);
+        padding: 0.58rem 0.68rem;
+        color: var(--text);
+      }
+
+      .choice-option.is-selected {
+        border-color: var(--accent);
+        background: var(--accent-soft);
+        box-shadow: inset 0 0 0 1px var(--accent);
+      }
+
+      .choice-option input {
+        width: 1rem;
+        height: 1rem;
+        margin: 0;
+        accent-color: var(--accent);
+        flex: 0 0 auto;
+      }
+
+      .choice-copy {
+        min-width: 0;
+      }
+
+      .choice-title {
+        font-weight: 650;
+      }
+
+      .field-stack {
+        display: grid;
+        gap: 0.45rem;
+      }
+
+      .field-label {
+        display: flex;
+        justify-content: space-between;
+        gap: 0.75rem;
+        color: var(--text);
+        font-weight: 650;
+      }
+
+      input[type="text"],
+      input[type="password"],
+      textarea {
+        width: 100%;
+        min-width: 0;
+        border: 1px solid var(--border-strong);
+        border-radius: 7px;
+        background: #ffffff;
+        color: var(--text);
+        padding: 0.7rem 0.78rem;
+        outline: none;
+        transition:
+          border-color 120ms ease,
+          box-shadow 120ms ease;
+      }
+
+      input[type="text"],
+      input[type="password"] {
+        min-height: 42px;
+        font-size: 0.92rem;
+      }
+
+      textarea {
+        min-height: 180px;
+        resize: vertical;
+        font-size: 0.88rem;
+      }
+
+      input:focus,
+      textarea:focus,
+      button:focus-visible,
+      .header-link:focus-visible,
+      .choice-option:focus-within {
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--accent-soft);
+      }
+
+      .persist-block {
+        display: grid;
+        gap: 0.55rem;
+      }
+
+      .switch-row {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        font-weight: 650;
+      }
+
+      .switch-row input {
+        width: 2.35rem;
+        height: 1.2rem;
+        accent-color: var(--accent);
+      }
+
+      .warning-note {
+        border: 1px solid #efd89a;
+        border-radius: 8px;
+        background: var(--warning-soft);
+        padding: 0.72rem 0.82rem;
+        color: var(--warning);
+        font-size: 0.88rem;
+      }
+
+      .decode-form {
+        display: grid;
+        gap: 12px;
+      }
+
+      .hash-form {
+        grid-template-columns: minmax(0, 1fr) auto;
+        align-items: start;
+      }
+
+      .primary-action,
+      .secondary-action {
+        min-height: 42px;
+        border-radius: 8px;
+        border: 1px solid transparent;
+        padding: 0.62rem 0.9rem;
+        font-weight: 700;
+      }
+
+      .primary-action {
+        background: var(--accent);
+        color: #ffffff;
+      }
+
+      .primary-action:hover {
+        background: var(--accent-strong);
+      }
+
+      .secondary-action {
+        border-color: var(--border-strong);
+        background: var(--surface);
+        color: var(--text);
+      }
+
+      .result-heading {
+        align-items: center;
+      }
+
+      pre {
+        max-height: min(62vh, 620px);
+        overflow: auto;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: #101820;
+        color: #edf6f9;
+        padding: 1rem;
+        margin: 0;
+        font-size: 0.82rem;
+        line-height: 1.48;
+      }
+
+      .empty-state {
+        display: grid;
+        min-height: 160px;
+        place-items: center;
+        border: 1px dashed var(--border-strong);
+        border-radius: 8px;
+        background: var(--surface-soft);
+        color: var(--muted);
+        font-weight: 650;
+      }
+
+      .error-panel {
+        border-color: #efb2ac;
+        background: var(--danger-soft);
+      }
+
+      .error-panel p {
+        color: var(--danger);
+      }
+
+      .stderr-block {
+        display: grid;
+        gap: 0.6rem;
+        margin-top: 14px;
+      }
+
+      .stderr-block h3 {
+        font-size: 0.96rem;
+      }
+
+      .site-footer {
+        border-top: 1px solid var(--border);
+        padding-block: 18px 26px;
+      }
+
+      .site-footer div {
+        max-width: 82ch;
+      }
+
+      @media (max-width: 880px) {
+        .workspace {
+          grid-template-columns: 1fr;
+        }
+
+        .provider-panel {
+          position: static;
+        }
+      }
+
+      @media (max-width: 640px) {
+        .page-frame {
+          width: min(100% - 20px, 1180px);
+        }
+
+        .topbar {
+          min-height: 58px;
+        }
+
+        .brand span {
+          display: none;
+        }
+
+        main.page-frame {
+          padding-block: 16px 12px;
+        }
+
+        .intro-strip {
+          align-items: start;
+          flex-direction: column;
+        }
+
+        .intro-strip h1 {
+          font-size: 1.35rem;
+        }
+
+        .tech-pills {
+          justify-content: start;
+        }
+
+        .panel {
+          padding: 15px;
+        }
+
+        .panel-heading {
+          display: grid;
+          gap: 0.7rem;
+        }
+
+        .mode-options,
+        .hash-form {
+          grid-template-columns: 1fr;
+        }
+
+        .primary-action,
+        .secondary-action {
+          width: 100%;
+        }
+
+        .field-label {
+          align-items: start;
+          flex-direction: column;
+          gap: 0.2rem;
+        }
+      }
     </style>
   </head>
   <body>
-    <header class="container">
-      <nav class="site-nav">
-        <ul>
-          <li><strong>Conway tx inspector</strong></li>
-        </ul>
-        <ul>
-          <li>
-            <a
-              href="https://github.com/lambdasistemi/cardano-node-clients"
-              target="_blank"
-              rel="noopener noreferrer"
-              >GitHub ↗</a
-            >
-          </li>
-        </ul>
-      </nav>
+    <header class="site-header">
+      <div class="page-frame topbar">
+        <div class="brand">
+          <strong>Conway tx inspector</strong>
+          <span>Haskell ledger in the browser</span>
+        </div>
+        <a
+          class="header-link"
+          href="https://github.com/lambdasistemi/cardano-node-clients"
+          target="_blank"
+          rel="noopener noreferrer"
+          >GitHub</a
+        >
+      </div>
     </header>
-    <main class="container">
+    <main class="page-frame">
       <div id="app"></div>
     </main>
-    <footer class="container site-footer">
+    <footer class="page-frame site-footer">
       <div>
         Built with the upstream Haskell ledger, cross-compiled to
         <code>wasm32-wasi</code> via

--- a/docs/inspector/dist/index.html
+++ b/docs/inspector/dist/index.html
@@ -3,20 +3,25 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
     <title>Conway tx inspector — Haskell ledger, wasm32-wasi</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
+    />
     <style>
-      body { font-family: system-ui, sans-serif; max-width: 960px; margin: 2rem auto; padding: 0 1rem; line-height: 1.5; }
-      textarea { width: 100%; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.875rem; }
-      button { padding: 0.5rem 1rem; font-size: 1rem; margin-top: 0.5rem; }
-      code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background: #eee; padding: 0 0.25rem; border-radius: 3px; }
-      pre { background: #f4f4f4; padding: 1rem; overflow-x: auto; border-radius: 4px; }
-      h1 { margin-bottom: 0.25rem; }
-      h2 { margin-top: 1.5rem; }
-      p { margin: 0.75rem 0; }
+      pre { overflow-x: auto; }
+      textarea { font-family: var(--pico-font-family-monospace); font-size: 0.875rem; }
+      input[type="text"], input[type="password"] { font-family: var(--pico-font-family-monospace); }
+      .muted { color: var(--pico-muted-color); font-size: 0.875rem; }
+      .warning { color: var(--pico-color-amber-550); }
+      .error { color: var(--pico-color-red-550); }
     </style>
   </head>
   <body>
-    <div id="app"></div>
+    <main class="container">
+      <div id="app"></div>
+    </main>
     <script src="index.js"></script>
   </body>
 </html>

--- a/docs/inspector/dist/index.html
+++ b/docs/inspector/dist/index.html
@@ -769,6 +769,6 @@
         >.
       </div>
     </footer>
-    <script src="index.js?v=transaction-browser-1"></script>
+    <script src="index.js?v=ledger-rpc-1"></script>
   </body>
 </html>

--- a/docs/inspector/dist/index.html
+++ b/docs/inspector/dist/index.html
@@ -418,6 +418,152 @@
         align-items: center;
       }
 
+      .inspection-summary {
+        display: grid;
+        gap: 16px;
+      }
+
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 10px;
+      }
+
+      .metric-card {
+        display: grid;
+        gap: 0.25rem;
+        min-width: 0;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: var(--surface-soft);
+        padding: 0.7rem 0.78rem;
+      }
+
+      .metric-label,
+      .section-heading span,
+      .hash-group > span,
+      .output-meta,
+      .mint-row span {
+        color: var(--muted);
+        font-size: 0.84rem;
+      }
+
+      .metric-card strong {
+        min-width: 0;
+        overflow-wrap: anywhere;
+        font-size: 0.98rem;
+      }
+
+      .inspection-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        align-items: start;
+        gap: 14px;
+      }
+
+      .inspection-section {
+        display: grid;
+        gap: 10px;
+        align-content: start;
+        min-width: 0;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 12px;
+      }
+
+      .wide-section {
+        grid-column: 1 / -1;
+      }
+
+      .section-heading {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+
+      .section-heading h3 {
+        font-size: 0.96rem;
+      }
+
+      .output-list,
+      .mint-list,
+      .hash-group {
+        display: grid;
+        gap: 8px;
+        align-content: start;
+        min-width: 0;
+      }
+
+      .output-row {
+        display: grid;
+        grid-template-columns: 3rem minmax(0, 1fr) minmax(11rem, 0.55fr);
+        gap: 0.75rem;
+        align-items: center;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: #ffffff;
+        padding: 0.58rem 0.7rem;
+      }
+
+      .row-index {
+        color: var(--muted);
+        font-weight: 700;
+      }
+
+      .output-main,
+      .output-meta,
+      .mint-row {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        min-width: 0;
+      }
+
+      .output-main {
+        justify-content: space-between;
+      }
+
+      .output-main code,
+      .mint-row code,
+      .hash-list code {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .output-meta {
+        justify-content: end;
+      }
+
+      .mint-row {
+        justify-content: space-between;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: #ffffff;
+        padding: 0.58rem 0.7rem;
+      }
+
+      .hash-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        min-width: 0;
+      }
+
+      .raw-json-block {
+        display: grid;
+        gap: 10px;
+        margin-top: 16px;
+      }
+
+      .raw-json-block summary {
+        cursor: pointer;
+        color: var(--accent-strong);
+        font-weight: 700;
+      }
+
       pre {
         max-height: min(62vh, 620px);
         overflow: auto;
@@ -475,6 +621,10 @@
           grid-template-columns: 1fr;
         }
 
+        .metric-grid {
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
+
         .provider-panel {
           position: static;
         }
@@ -522,6 +672,22 @@
         .mode-options,
         .hash-form {
           grid-template-columns: 1fr;
+        }
+
+        .metric-grid,
+        .inspection-grid,
+        .output-row {
+          grid-template-columns: 1fr;
+        }
+
+        .section-heading,
+        .output-main,
+        .output-meta,
+        .mint-row {
+          align-items: start;
+          flex-direction: column;
+          justify-content: start;
+          gap: 0.35rem;
         }
 
         .primary-action,
@@ -574,6 +740,6 @@
         >.
       </div>
     </footer>
-    <script src="index.js"></script>
+    <script src="index.js?v=inspection-panel-2"></script>
   </body>
 </html>

--- a/docs/inspector/spago.lock
+++ b/docs/inspector/spago.lock
@@ -10,6 +10,7 @@
             "console",
             "effect",
             "either",
+            "exceptions",
             "foreign",
             "halogen",
             "maybe",

--- a/docs/inspector/spago.yaml
+++ b/docs/inspector/spago.yaml
@@ -13,6 +13,7 @@ package:
     - web-html
     - web-events
     - foreign
+    - exceptions
   bundle:
     module: Main
     outfile: dist/index.js

--- a/docs/inspector/src/FFI/Blockfrost.js
+++ b/docs/inspector/src/FFI/Blockfrost.js
@@ -1,0 +1,21 @@
+// Blockfrost CBOR fetch. Returns a Promise<string> of the hex, or throws.
+// Project ID goes in the header (not URL) to avoid leaking via Referer/logs.
+
+const BASES = {
+  mainnet: "https://cardano-mainnet.blockfrost.io/api/v0",
+  preprod: "https://cardano-preprod.blockfrost.io/api/v0",
+  preview: "https://cardano-preview.blockfrost.io/api/v0",
+};
+
+export const fetchTxCborImpl = (network) => (projectId) => (txHash) => async () => {
+  const base = BASES[network] || BASES.mainnet;
+  const resp = await fetch(`${base}/txs/${txHash}/cbor`, {
+    headers: { project_id: projectId },
+  });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => "");
+    throw new Error(`Blockfrost ${resp.status}: ${body.slice(0, 200)}`);
+  }
+  const json = await resp.json();
+  return json.cbor;
+};

--- a/docs/inspector/src/FFI/Blockfrost.purs
+++ b/docs/inspector/src/FFI/Blockfrost.purs
@@ -1,0 +1,31 @@
+module FFI.Blockfrost
+  ( Network(..)
+  , networkName
+  , fetchTxCbor
+  ) where
+
+import Prelude
+
+import Control.Promise (Promise, toAffE)
+import Effect (Effect)
+import Effect.Aff (Aff)
+
+data Network = Mainnet | Preprod | Preview
+
+derive instance eqNetwork :: Eq Network
+
+networkName :: Network -> String
+networkName = case _ of
+  Mainnet -> "mainnet"
+  Preprod -> "preprod"
+  Preview -> "preview"
+
+foreign import fetchTxCborImpl
+  :: String -- network
+  -> String -- projectId
+  -> String -- tx hash
+  -> Effect (Promise String)
+
+fetchTxCbor :: Network -> String -> String -> Aff String
+fetchTxCbor net projectId hash =
+  toAffE (fetchTxCborImpl (networkName net) projectId hash)

--- a/docs/inspector/src/FFI/Inspector.js
+++ b/docs/inspector/src/FFI/Inspector.js
@@ -2,3 +2,21 @@
 // Returns a Promise<{ stdout, stderr, exitOk }>, mapped to Aff by the FFI.
 export const runInspectorImpl = (stdinText) => () =>
   globalThis.runInspector(stdinText);
+
+export const runInspectorRpcImpl = (txCbor) => (method) => (pathText) => () => {
+  let path = [];
+  try {
+    const parsed = JSON.parse(pathText);
+    if (Array.isArray(parsed)) path = parsed.map(String);
+  } catch (_err) {
+    path = [];
+  }
+
+  return globalThis.runInspector(
+    JSON.stringify({
+      tx_cbor: txCbor,
+      method,
+      path,
+    })
+  );
+};

--- a/docs/inspector/src/FFI/Inspector.purs
+++ b/docs/inspector/src/FFI/Inspector.purs
@@ -1,6 +1,7 @@
 module FFI.Inspector
   ( InspectorResult
   , runInspector
+  , runInspectorRpc
   ) where
 
 import Prelude
@@ -16,6 +17,10 @@ type InspectorResult =
   }
 
 foreign import runInspectorImpl :: String -> Effect (Promise InspectorResult)
+foreign import runInspectorRpcImpl :: String -> String -> String -> Effect (Promise InspectorResult)
 
 runInspector :: String -> Aff InspectorResult
 runInspector = toAffE <<< runInspectorImpl
+
+runInspectorRpc :: String -> String -> String -> Aff InspectorResult
+runInspectorRpc txCbor method path = toAffE (runInspectorRpcImpl txCbor method path)

--- a/docs/inspector/src/FFI/Json.js
+++ b/docs/inspector/src/FFI/Json.js
@@ -7,3 +7,174 @@ export const prettyImpl = (text) => {
     return text;
   }
 };
+
+const emptyInspection = (title, subtitle = "") => ({
+  valid: false,
+  title,
+  subtitle,
+  metrics: [],
+  outputs: [],
+  mint: [],
+  inputs: [],
+  referenceInputs: [],
+  outputNote: "",
+  mintNote: "",
+  inputNote: "",
+});
+
+const text = (value) =>
+  value === null || value === undefined ? "" : String(value);
+
+const shortHex = (value, head = 12, tail = 8) => {
+  const s = text(value);
+  if (s.length <= head + tail + 1) return s;
+  return `${s.slice(0, head)}...${s.slice(-tail)}`;
+};
+
+const formatLovelace = (value) => {
+  const raw = text(value);
+  if (raw === "") return "n/a";
+
+  try {
+    const lovelace = BigInt(raw);
+    const ada = lovelace / 1000000n;
+    const fraction = (lovelace % 1000000n)
+      .toString()
+      .padStart(6, "0")
+      .replace(/0+$/, "");
+
+    return fraction === "" ? `${ada} ADA` : `${ada}.${fraction} ADA`;
+  } catch (_err) {
+    return raw;
+  }
+};
+
+const policyEntries = (assets) =>
+  assets && typeof assets === "object" && !Array.isArray(assets)
+    ? Object.entries(assets)
+    : [];
+
+const assetCount = (assets) =>
+  policyEntries(assets).reduce((total, [, policyAssets]) => {
+    if (!policyAssets || typeof policyAssets !== "object") return total;
+    return total + Object.keys(policyAssets).length;
+  }, 0);
+
+const policyCount = (assets) => policyEntries(assets).length;
+
+const plural = (count, singular, pluralText = `${singular}s`) =>
+  `${count} ${count === 1 ? singular : pluralText}`;
+
+const assetLabel = (assets) => {
+  const assetsN = assetCount(assets);
+  const policiesN = policyCount(assets);
+  if (assetsN === 0) return "none";
+  return `${plural(assetsN, "asset")} / ${plural(policiesN, "policy", "policies")}`;
+};
+
+const datumLabel = (datum) => {
+  if (!datum || typeof datum !== "object") return "unknown";
+  switch (datum.kind) {
+    case "no_datum":
+      return "none";
+    case "datum_hash":
+      return `hash ${shortHex(datum.hash)}`;
+    case "inline_datum":
+      return "inline datum";
+    default:
+      return text(datum.kind || "unknown").replace(/_/g, " ");
+  }
+};
+
+const txInLabel = (input) => {
+  if (!input || typeof input !== "object") return text(input);
+  return `${shortHex(input.tx_id)}#${text(input.index)}`;
+};
+
+const validityLabel = (slot) => (slot === null || slot === undefined ? "open" : text(slot));
+
+const metric = (label, value) => ({ label, value: text(value) });
+
+export const inspectImpl = (raw) => {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (_err) {
+    return emptyInspection("Raw output", "The decoder did not return JSON.");
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return emptyInspection("Raw output", "The decoder returned a non-object JSON value.");
+  }
+
+  const outputs = Array.isArray(parsed.outputs) ? parsed.outputs : [];
+  const inputs = Array.isArray(parsed.inputs) ? parsed.inputs : [];
+  const referenceInputs = Array.isArray(parsed.reference_inputs)
+    ? parsed.reference_inputs
+    : [];
+  const mint = parsed.mint && typeof parsed.mint === "object" ? parsed.mint : {};
+  const validity =
+    parsed.validity_interval && typeof parsed.validity_interval === "object"
+      ? parsed.validity_interval
+      : {};
+
+  const totalOutputAssets = outputs.reduce(
+    (total, output) => total + assetCount(output && output.assets),
+    0
+  );
+  const mintedAssets = assetCount(mint);
+
+  const outputRows = outputs.slice(0, 8).map((output, index) => ({
+    index: `#${index}`,
+    address: shortHex(output && output.address_hex, 18, 10),
+    coin: formatLovelace(output && output.coin_lovelace),
+    assets: assetLabel(output && output.assets),
+    datum: datumLabel(output && output.datum),
+  }));
+
+  const mintRows = policyEntries(mint)
+    .slice(0, 8)
+    .map(([policy, assets]) => ({
+      policy: shortHex(policy, 14, 10),
+      assets: assetLabel({ [policy]: assets }),
+    }));
+
+  const inputRows = inputs.slice(0, 8).map(txInLabel);
+  const referenceInputRows = referenceInputs.slice(0, 8).map(txInLabel);
+
+  return {
+    valid: true,
+    title: `${text(parsed.era || "Decoded")} transaction`,
+    subtitle: text(parsed.decoder || ""),
+    metrics: [
+      metric("Fee", formatLovelace(parsed.fee_lovelace)),
+      metric("Inputs", parsed.input_count ?? inputs.length),
+      metric("Reference inputs", parsed.reference_input_count ?? referenceInputs.length),
+      metric("Outputs", parsed.output_count ?? outputs.length),
+      metric("Output assets", totalOutputAssets),
+      metric("Mint policies", policyCount(mint)),
+      metric("Minted assets", mintedAssets),
+      metric("Certificates", parsed.cert_count ?? 0),
+      metric("Withdrawals", parsed.withdrawal_count ?? 0),
+      metric("Required signers", parsed.required_signer_count ?? 0),
+      metric("Valid from", validityLabel(validity.invalid_before)),
+      metric("Valid until", validityLabel(validity.invalid_hereafter)),
+    ],
+    outputs: outputRows,
+    mint: mintRows,
+    inputs: inputRows,
+    referenceInputs: referenceInputRows,
+    outputNote:
+      outputs.length > outputRows.length
+        ? `Showing first ${outputRows.length} of ${outputs.length} outputs.`
+        : "",
+    mintNote:
+      policyCount(mint) > mintRows.length
+        ? `Showing first ${mintRows.length} of ${policyCount(mint)} mint policies.`
+        : "",
+    inputNote:
+      inputs.length + referenceInputs.length > inputRows.length + referenceInputRows.length
+        ? "Input previews are truncated."
+        : "",
+  };
+};

--- a/docs/inspector/src/FFI/Json.js
+++ b/docs/inspector/src/FFI/Json.js
@@ -178,3 +178,153 @@ export const inspectImpl = (raw) => {
         : "",
   };
 };
+
+const pathRoot = "[]";
+
+const encodePath = (segments) => JSON.stringify(segments);
+
+const decodePath = (path) => {
+  try {
+    const parsed = JSON.parse(path);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (_err) {
+    return [];
+  }
+};
+
+const valueAt = (root, path) =>
+  path.reduce((cursor, segment) => {
+    if (cursor === null || cursor === undefined) return undefined;
+    return cursor[segment];
+  }, root);
+
+const kindOf = (value) => {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+};
+
+const prettyValue = (value) => JSON.stringify(value, null, 2);
+
+const copyText = (value) => {
+  const kind = kindOf(value);
+  if (kind === "object" || kind === "array") return prettyValue(value);
+  if (kind === "string") return value;
+  if (kind === "undefined") return "";
+  return String(value);
+};
+
+const fieldLabel = (segment) =>
+  typeof segment === "number" ? `#${segment}` : String(segment);
+
+const childCount = (value) => {
+  if (Array.isArray(value)) return value.length;
+  if (value && typeof value === "object") return Object.keys(value).length;
+  return 0;
+};
+
+const isContainer = (value) => {
+  const kind = kindOf(value);
+  return kind === "array" || kind === "object";
+};
+
+const valueSummary = (value) => {
+  const kind = kindOf(value);
+  switch (kind) {
+    case "array":
+      return plural(value.length, "item");
+    case "object":
+      return plural(Object.keys(value).length, "field");
+    case "string":
+      return shortHex(value, 40, 16);
+    case "undefined":
+      return "";
+    default:
+      return String(value);
+  }
+};
+
+const browserRows = (value, parentPath) => {
+  const kind = kindOf(value);
+  if (kind === "array") {
+    return value.map((child, index) => {
+      const path = parentPath.concat(index);
+      const childKind = kindOf(child);
+      return {
+        label: fieldLabel(index),
+        path: encodePath(path),
+        kind: childKind,
+        summary: valueSummary(child),
+        copyValue: copyText(child),
+        canDive: isContainer(child),
+      };
+    });
+  }
+
+  if (kind === "object") {
+    return Object.entries(value).map(([key, child]) => {
+      const path = parentPath.concat(key);
+      const childKind = kindOf(child);
+      return {
+        label: key,
+        path: encodePath(path),
+        kind: childKind,
+        summary: valueSummary(child),
+        copyValue: copyText(child),
+        canDive: isContainer(child),
+      };
+    });
+  }
+
+  return [];
+};
+
+const breadcrumbsFor = (path) => {
+  const breadcrumbs = [{ label: "tx", path: pathRoot }];
+  path.forEach((_segment, index) => {
+    const here = path.slice(0, index + 1);
+    breadcrumbs.push({
+      label: fieldLabel(path[index]),
+      path: encodePath(here),
+    });
+  });
+  return breadcrumbs;
+};
+
+export const browseImpl = (raw) => (pathText) => {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (_err) {
+    return {
+      valid: false,
+      title: "Raw output",
+      subtitle: "The decoder did not return JSON.",
+      currentPath: pathRoot,
+      currentJson: raw,
+      breadcrumbs: [{ label: "raw", path: pathRoot }],
+      rows: [],
+    };
+  }
+
+  const requestedPath = decodePath(pathText);
+  const current = valueAt(parsed, requestedPath);
+  const path = current === undefined ? [] : requestedPath;
+  const value = current === undefined ? parsed : current;
+  const breadcrumbs = breadcrumbsFor(path);
+  const label = breadcrumbs[breadcrumbs.length - 1]?.label || "tx";
+  const kind = kindOf(value);
+
+  return {
+    valid: true,
+    title: label,
+    subtitle:
+      kind === "array" || kind === "object"
+        ? `${kind} / ${valueSummary(value)}`
+        : kind,
+    currentPath: encodePath(path),
+    currentJson: copyText(value),
+    breadcrumbs,
+    rows: browserRows(value, path),
+  };
+};

--- a/docs/inspector/src/FFI/Json.js
+++ b/docs/inspector/src/FFI/Json.js
@@ -181,150 +181,63 @@ export const inspectImpl = (raw) => {
 
 const pathRoot = "[]";
 
-const encodePath = (segments) => JSON.stringify(segments);
+const invalidBrowser = (title, subtitle, currentJson = "") => ({
+  valid: false,
+  title,
+  subtitle,
+  currentPath: pathRoot,
+  currentJson,
+  breadcrumbs: [{ label: "tx", path: pathRoot }],
+  rows: [],
+});
 
-const decodePath = (path) => {
-  try {
-    const parsed = JSON.parse(path);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch (_err) {
-    return [];
+const normalizeBrowser = (browser) => {
+  if (!browser || typeof browser !== "object") {
+    return invalidBrowser("Transaction browser", "RPC response missing browser.");
   }
-};
-
-const valueAt = (root, path) =>
-  path.reduce((cursor, segment) => {
-    if (cursor === null || cursor === undefined) return undefined;
-    return cursor[segment];
-  }, root);
-
-const kindOf = (value) => {
-  if (value === null) return "null";
-  if (Array.isArray(value)) return "array";
-  return typeof value;
-};
-
-const prettyValue = (value) => JSON.stringify(value, null, 2);
-
-const copyText = (value) => {
-  const kind = kindOf(value);
-  if (kind === "object" || kind === "array") return prettyValue(value);
-  if (kind === "string") return value;
-  if (kind === "undefined") return "";
-  return String(value);
-};
-
-const fieldLabel = (segment) =>
-  typeof segment === "number" ? `#${segment}` : String(segment);
-
-const childCount = (value) => {
-  if (Array.isArray(value)) return value.length;
-  if (value && typeof value === "object") return Object.keys(value).length;
-  return 0;
-};
-
-const isContainer = (value) => {
-  const kind = kindOf(value);
-  return kind === "array" || kind === "object";
-};
-
-const valueSummary = (value) => {
-  const kind = kindOf(value);
-  switch (kind) {
-    case "array":
-      return plural(value.length, "item");
-    case "object":
-      return plural(Object.keys(value).length, "field");
-    case "string":
-      return shortHex(value, 40, 16);
-    case "undefined":
-      return "";
-    default:
-      return String(value);
-  }
-};
-
-const browserRows = (value, parentPath) => {
-  const kind = kindOf(value);
-  if (kind === "array") {
-    return value.map((child, index) => {
-      const path = parentPath.concat(index);
-      const childKind = kindOf(child);
-      return {
-        label: fieldLabel(index),
-        path: encodePath(path),
-        kind: childKind,
-        summary: valueSummary(child),
-        copyValue: copyText(child),
-        canDive: isContainer(child),
-      };
-    });
-  }
-
-  if (kind === "object") {
-    return Object.entries(value).map(([key, child]) => {
-      const path = parentPath.concat(key);
-      const childKind = kindOf(child);
-      return {
-        label: key,
-        path: encodePath(path),
-        kind: childKind,
-        summary: valueSummary(child),
-        copyValue: copyText(child),
-        canDive: isContainer(child),
-      };
-    });
-  }
-
-  return [];
-};
-
-const breadcrumbsFor = (path) => {
-  const breadcrumbs = [{ label: "tx", path: pathRoot }];
-  path.forEach((_segment, index) => {
-    const here = path.slice(0, index + 1);
-    breadcrumbs.push({
-      label: fieldLabel(path[index]),
-      path: encodePath(here),
-    });
-  });
-  return breadcrumbs;
-};
-
-export const browseImpl = (raw) => (pathText) => {
-  let parsed;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (_err) {
-    return {
-      valid: false,
-      title: "Raw output",
-      subtitle: "The decoder did not return JSON.",
-      currentPath: pathRoot,
-      currentJson: raw,
-      breadcrumbs: [{ label: "raw", path: pathRoot }],
-      rows: [],
-    };
-  }
-
-  const requestedPath = decodePath(pathText);
-  const current = valueAt(parsed, requestedPath);
-  const path = current === undefined ? [] : requestedPath;
-  const value = current === undefined ? parsed : current;
-  const breadcrumbs = breadcrumbsFor(path);
-  const label = breadcrumbs[breadcrumbs.length - 1]?.label || "tx";
-  const kind = kindOf(value);
 
   return {
-    valid: true,
-    title: label,
-    subtitle:
-      kind === "array" || kind === "object"
-        ? `${kind} / ${valueSummary(value)}`
-        : kind,
-    currentPath: encodePath(path),
-    currentJson: copyText(value),
-    breadcrumbs,
-    rows: browserRows(value, path),
+    valid: browser.valid === true,
+    title: String(browser.title ?? "tx"),
+    subtitle: String(browser.subtitle ?? ""),
+    currentPath: String(browser.currentPath ?? pathRoot),
+    currentJson: String(browser.currentJson ?? ""),
+    breadcrumbs: Array.isArray(browser.breadcrumbs)
+      ? browser.breadcrumbs.map((crumb) => ({
+          label: String(crumb?.label ?? "tx"),
+          path: String(crumb?.path ?? pathRoot),
+        }))
+      : [{ label: "tx", path: pathRoot }],
+    rows: Array.isArray(browser.rows)
+      ? browser.rows.map((row) => ({
+          label: String(row?.label ?? ""),
+          path: String(row?.path ?? pathRoot),
+          kind: String(row?.kind ?? ""),
+          summary: String(row?.summary ?? ""),
+          copyValue: String(row?.copyValue ?? ""),
+          canDive: row?.canDive === true,
+        }))
+      : [],
   };
+};
+
+export const rpcInspectionImpl = (raw) => {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && Object.prototype.hasOwnProperty.call(parsed, "inspection")) {
+      return JSON.stringify(parsed.inspection);
+    }
+  } catch (_err) {
+    return raw;
+  }
+  return raw;
+};
+
+export const rpcBrowserImpl = (raw) => {
+  try {
+    const parsed = JSON.parse(raw);
+    return normalizeBrowser(parsed?.browser);
+  } catch (_err) {
+    return invalidBrowser("Transaction browser", "RPC response was not JSON.", raw);
+  }
 };

--- a/docs/inspector/src/FFI/Json.purs
+++ b/docs/inspector/src/FFI/Json.purs
@@ -1,14 +1,19 @@
 module FFI.Json
-  ( Inspection
+  ( Breadcrumb
+  , Browser
+  , BrowserRow
+  , Inspection
   , Metric
   , MintRow
   , OutputRow
+  , browse
   , inspect
   , pretty
   ) where
 
 foreign import prettyImpl :: String -> String
 foreign import inspectImpl :: String -> Inspection
+foreign import browseImpl :: String -> String -> Browser
 
 type Metric =
   { label :: String
@@ -42,8 +47,35 @@ type Inspection =
   , inputNote :: String
   }
 
+type Breadcrumb =
+  { label :: String
+  , path :: String
+  }
+
+type BrowserRow =
+  { label :: String
+  , path :: String
+  , kind :: String
+  , summary :: String
+  , copyValue :: String
+  , canDive :: Boolean
+  }
+
+type Browser =
+  { valid :: Boolean
+  , title :: String
+  , subtitle :: String
+  , currentPath :: String
+  , currentJson :: String
+  , breadcrumbs :: Array Breadcrumb
+  , rows :: Array BrowserRow
+  }
+
 pretty :: String -> String
 pretty = prettyImpl
 
 inspect :: String -> Inspection
 inspect = inspectImpl
+
+browse :: String -> String -> Browser
+browse = browseImpl

--- a/docs/inspector/src/FFI/Json.purs
+++ b/docs/inspector/src/FFI/Json.purs
@@ -6,14 +6,16 @@ module FFI.Json
   , Metric
   , MintRow
   , OutputRow
-  , browse
   , inspect
   , pretty
+  , rpcBrowser
+  , rpcInspection
   ) where
 
 foreign import prettyImpl :: String -> String
 foreign import inspectImpl :: String -> Inspection
-foreign import browseImpl :: String -> String -> Browser
+foreign import rpcInspectionImpl :: String -> String
+foreign import rpcBrowserImpl :: String -> Browser
 
 type Metric =
   { label :: String
@@ -77,5 +79,8 @@ pretty = prettyImpl
 inspect :: String -> Inspection
 inspect = inspectImpl
 
-browse :: String -> String -> Browser
-browse = browseImpl
+rpcInspection :: String -> String
+rpcInspection = rpcInspectionImpl
+
+rpcBrowser :: String -> Browser
+rpcBrowser = rpcBrowserImpl

--- a/docs/inspector/src/FFI/Json.purs
+++ b/docs/inspector/src/FFI/Json.purs
@@ -1,8 +1,49 @@
 module FFI.Json
-  ( pretty
+  ( Inspection
+  , Metric
+  , MintRow
+  , OutputRow
+  , inspect
+  , pretty
   ) where
 
 foreign import prettyImpl :: String -> String
+foreign import inspectImpl :: String -> Inspection
+
+type Metric =
+  { label :: String
+  , value :: String
+  }
+
+type OutputRow =
+  { index :: String
+  , address :: String
+  , coin :: String
+  , assets :: String
+  , datum :: String
+  }
+
+type MintRow =
+  { policy :: String
+  , assets :: String
+  }
+
+type Inspection =
+  { valid :: Boolean
+  , title :: String
+  , subtitle :: String
+  , metrics :: Array Metric
+  , outputs :: Array OutputRow
+  , mint :: Array MintRow
+  , inputs :: Array String
+  , referenceInputs :: Array String
+  , outputNote :: String
+  , mintNote :: String
+  , inputNote :: String
+  }
 
 pretty :: String -> String
 pretty = prettyImpl
+
+inspect :: String -> Inspection
+inspect = inspectImpl

--- a/docs/inspector/src/FFI/Koios.js
+++ b/docs/inspector/src/FFI/Koios.js
@@ -25,6 +25,11 @@ export const fetchTxCborImpl = (network) => (bearer) => (txHash) => async () => 
     const body = await resp.text().catch(() => "");
     throw new Error(`Koios ${resp.status}: ${body.slice(0, 200)}`);
   }
+  // Koios returns CORS headers on preflight but NOT on the actual POST
+  // response, which browsers reject. The fetch above typically rejects as
+  // TypeError("Failed to fetch") before we get here — the wrapping in
+  // Main.purs surfaces that to the user. This .ok check only runs if the
+  // browser accepted the response (e.g. running from a same-origin proxy).
   const arr = await resp.json();
   if (!Array.isArray(arr) || arr.length === 0) {
     throw new Error("Koios: tx hash not found");

--- a/docs/inspector/src/FFI/Koios.js
+++ b/docs/inspector/src/FFI/Koios.js
@@ -1,0 +1,37 @@
+// Koios CBOR fetch. Returns a Promise<string> of the hex, or throws.
+//
+// Koios is free and keyless for basic use (rate-limited). A bearer token
+// can be supplied for higher limits; passed as empty string means no auth.
+// Docs: https://api.koios.rest/
+
+const BASES = {
+  mainnet: "https://api.koios.rest/api/v1",
+  preprod: "https://preprod.koios.rest/api/v1",
+  preview: "https://preview.koios.rest/api/v1",
+};
+
+export const fetchTxCborImpl = (network) => (bearer) => (txHash) => async () => {
+  const base = BASES[network] || BASES.mainnet;
+  const headers = { "Content-Type": "application/json" };
+  if (bearer && bearer.length > 0) {
+    headers["Authorization"] = `Bearer ${bearer}`;
+  }
+  const resp = await fetch(`${base}/tx_cbor`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ _tx_hashes: [txHash] }),
+  });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => "");
+    throw new Error(`Koios ${resp.status}: ${body.slice(0, 200)}`);
+  }
+  const arr = await resp.json();
+  if (!Array.isArray(arr) || arr.length === 0) {
+    throw new Error("Koios: tx hash not found");
+  }
+  const entry = arr[0];
+  if (!entry.cbor) {
+    throw new Error(`Koios: response missing 'cbor' field: ${JSON.stringify(entry).slice(0, 200)}`);
+  }
+  return entry.cbor;
+};

--- a/docs/inspector/src/FFI/Koios.purs
+++ b/docs/inspector/src/FFI/Koios.purs
@@ -1,0 +1,20 @@
+module FFI.Koios
+  ( fetchTxCbor
+  ) where
+
+import Prelude
+
+import Control.Promise (Promise, toAffE)
+import Effect (Effect)
+import Effect.Aff (Aff)
+import FFI.Blockfrost (Network, networkName)
+
+foreign import fetchTxCborImpl
+  :: String -- network
+  -> String -- bearer (empty string = none)
+  -> String -- tx hash
+  -> Effect (Promise String)
+
+fetchTxCbor :: Network -> String -> String -> Aff String
+fetchTxCbor net bearer hash =
+  toAffE (fetchTxCborImpl (networkName net) bearer hash)

--- a/docs/inspector/src/FFI/Storage.js
+++ b/docs/inspector/src/FFI/Storage.js
@@ -1,0 +1,12 @@
+// Thin wrappers over localStorage so the project ID persists across
+// page reloads. No cross-tab sync — if you want that, listen to the
+// 'storage' event in a later iteration.
+
+export const getItemImpl = (key) => () => {
+  const v = window.localStorage.getItem(key);
+  return v == null ? "" : v;
+};
+
+export const setItemImpl = (key) => (value) => () => {
+  window.localStorage.setItem(key, value);
+};

--- a/docs/inspector/src/FFI/Storage.purs
+++ b/docs/inspector/src/FFI/Storage.purs
@@ -1,0 +1,17 @@
+module FFI.Storage
+  ( getItem
+  , setItem
+  ) where
+
+import Prelude
+
+import Effect (Effect)
+
+foreign import getItemImpl :: String -> Effect String
+foreign import setItemImpl :: String -> String -> Effect Unit
+
+getItem :: String -> Effect String
+getItem = getItemImpl
+
+setItem :: String -> String -> Effect Unit
+setItem = setItemImpl

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -14,7 +14,7 @@ import Effect.Exception (message)
 import FFI.Blockfrost (Network(..))
 import FFI.Clipboard (copy) as Clipboard
 import FFI.Inspector (InspectorResult, runInspector)
-import FFI.Json (inspect, pretty) as Json
+import FFI.Json (browse, inspect, pretty) as Json
 import FFI.Storage as Storage
 import Provider (Provider(..))
 import Provider as Provider
@@ -80,6 +80,8 @@ type State =
   , result :: Maybe InspectorResult
   , running :: Boolean
   , copied :: Boolean
+  , copiedPath :: Maybe String
+  , browserPath :: String
   , fetchError :: Maybe String
   }
 
@@ -101,6 +103,8 @@ data Action
   | SetTxHex String
   | Decode
   | Copy
+  | CopyValue String String
+  | BrowseJson String
 
 inspectorComponent
   :: forall q i o m
@@ -121,6 +125,8 @@ inspectorComponent initial =
         , result: Nothing
         , running: false
         , copied: false
+        , copiedPath: Nothing
+        , browserPath: "[]"
         , fetchError: Nothing
         }
     , render
@@ -373,7 +379,9 @@ inspectorComponent initial =
                 [ HH.text "No result yet." ]
             ]
         Just r ->
-          let summary = Json.inspect r.stdout
+          let
+            summary = Json.inspect r.stdout
+            browser = Json.browse r.stdout state.browserPath
           in
             HH.section
               [ classNames [ "panel", "result-panel" ] ]
@@ -399,6 +407,10 @@ inspectorComponent initial =
                      then renderInspection summary
                      else []
                  )
+              <> ( if r.exitOk && browser.valid
+                     then [ renderBrowser state browser ]
+                     else []
+                 )
               <> [ renderRawJson r.stdout ]
               <> renderStderr r.stderr
               )
@@ -409,14 +421,88 @@ inspectorComponent initial =
         [ HH.div
             [ classNames [ "metric-grid" ] ]
             (map renderMetric summary.metrics)
-        , HH.div
-            [ classNames [ "inspection-grid" ] ]
-            ( renderOutputs summary
-            <> renderMint summary
-            <> renderInputs summary
-            )
         ]
     ]
+
+  renderBrowser state browser =
+    HH.div
+      [ classNames [ "json-browser" ] ]
+      [ HH.div
+          [ classNames [ "browser-heading" ] ]
+          [ HH.div_
+              [ HH.h3_ [ HH.text "Transaction browser" ]
+              , HH.div
+                  [ classNames [ "breadcrumb-bar" ] ]
+                  (map renderBreadcrumb browser.breadcrumbs)
+              , HH.p_ [ HH.text browser.subtitle ]
+              ]
+          , HH.button
+              [ HE.onClick (\_ -> CopyValue browser.currentPath browser.currentJson)
+              , classNames [ "inline-action" ]
+              ]
+              [ HH.text
+                  ( if state.copiedPath == Just browser.currentPath then
+                      "Copied"
+                    else
+                      "Copy current"
+                  )
+              ]
+          ]
+      , if Array.null browser.rows then
+          HH.div
+            [ classNames [ "scalar-value" ] ]
+            [ HH.code_ [ HH.text browser.currentJson ] ]
+        else
+          HH.div
+            [ classNames [ "browser-row-list" ] ]
+            (map (renderBrowserRow state) browser.rows)
+      ]
+
+  renderBreadcrumb crumb =
+    HH.button
+      [ HE.onClick (\_ -> BrowseJson crumb.path)
+      , classNames [ "breadcrumb-button" ]
+      ]
+      [ HH.text crumb.label ]
+
+  renderBrowserRow state row =
+    HH.div
+      [ classNames [ "browser-row" ] ]
+      [ HH.div
+          [ classNames [ "browser-row-main" ] ]
+          [ HH.div
+              [ classNames [ "browser-keyline" ] ]
+              [ HH.code_ [ HH.text row.label ]
+              , HH.span
+                  [ classNames [ "kind-badge" ] ]
+                  [ HH.text row.kind ]
+              ]
+          , HH.div
+              [ classNames [ "browser-summary" ] ]
+              [ HH.text row.summary ]
+          ]
+      , HH.div
+          [ classNames [ "browser-actions" ] ]
+          [ if row.canDive then
+              HH.button
+                [ HE.onClick (\_ -> BrowseJson row.path)
+                , classNames [ "inline-action" ]
+                ]
+                [ HH.text "Open" ]
+            else HH.text ""
+          , HH.button
+              [ HE.onClick (\_ -> CopyValue row.path row.copyValue)
+              , classNames [ "inline-action" ]
+              ]
+              [ HH.text
+                  ( if state.copiedPath == Just row.path then
+                      "Copied"
+                    else
+                      "Copy"
+                  )
+              ]
+          ]
+      ]
 
   renderMetric metric =
     HH.div
@@ -425,94 +511,6 @@ inspectorComponent initial =
           [ classNames [ "metric-label" ] ]
           [ HH.text metric.label ]
       , HH.strong_ [ HH.text metric.value ]
-      ]
-
-  renderOutputs summary =
-    if Array.null summary.outputs then []
-    else
-      [ HH.div
-          [ classNames [ "inspection-section", "wide-section" ] ]
-          [ HH.div
-              [ classNames [ "section-heading" ] ]
-              [ HH.h3_ [ HH.text "Outputs" ]
-              , HH.span_ [ HH.text summary.outputNote ]
-              ]
-          , HH.div
-              [ classNames [ "output-list" ] ]
-              (map renderOutput summary.outputs)
-          ]
-      ]
-
-  renderOutput output =
-    HH.div
-      [ classNames [ "output-row" ] ]
-      [ HH.span
-          [ classNames [ "row-index" ] ]
-          [ HH.text output.index ]
-      , HH.div
-          [ classNames [ "output-main" ] ]
-          [ HH.code_ [ HH.text output.address ]
-          , HH.span_ [ HH.text output.coin ]
-          ]
-      , HH.div
-          [ classNames [ "output-meta" ] ]
-          [ HH.span_ [ HH.text output.assets ]
-          , HH.span_ [ HH.text output.datum ]
-          ]
-      ]
-
-  renderMint summary =
-    if Array.null summary.mint then []
-    else
-      [ HH.div
-          [ classNames [ "inspection-section" ] ]
-          [ HH.div
-              [ classNames [ "section-heading" ] ]
-              [ HH.h3_ [ HH.text "Mint" ]
-              , HH.span_ [ HH.text summary.mintNote ]
-              ]
-          , HH.div
-              [ classNames [ "mint-list" ] ]
-              (map renderMintRow summary.mint)
-          ]
-      ]
-
-  renderMintRow row =
-    HH.div
-      [ classNames [ "mint-row" ] ]
-      [ HH.code_ [ HH.text row.policy ]
-      , HH.span_ [ HH.text row.assets ]
-      ]
-
-  renderInputs summary =
-    if Array.null summary.inputs && Array.null summary.referenceInputs then []
-    else
-      [ HH.div
-          [ classNames [ "inspection-section" ] ]
-          [ HH.div
-              [ classNames [ "section-heading" ] ]
-              [ HH.h3_ [ HH.text "Inputs" ]
-              , HH.span_ [ HH.text summary.inputNote ]
-              ]
-          , if Array.null summary.inputs then HH.text ""
-            else
-              HH.div
-                [ classNames [ "hash-group" ] ]
-                [ HH.span_ [ HH.text "Spending" ]
-                , HH.div
-                    [ classNames [ "hash-list" ] ]
-                    (map (\input -> HH.code_ [ HH.text input ]) summary.inputs)
-                ]
-          , if Array.null summary.referenceInputs then HH.text ""
-            else
-              HH.div
-                [ classNames [ "hash-group" ] ]
-                [ HH.span_ [ HH.text "Reference" ]
-                , HH.div
-                    [ classNames [ "hash-list" ] ]
-                    (map (\input -> HH.code_ [ HH.text input ]) summary.referenceInputs)
-                ]
-          ]
       ]
 
   renderRawJson stdout =
@@ -568,13 +566,21 @@ inspectorComponent initial =
           else do
             Storage.setItem blockfrostKey ""
             Storage.setItem koiosKey ""
-    SelectMode m -> H.modify_ _ { mode = m, fetchError = Nothing }
-    SelectNetwork n -> H.modify_ _ { network = n, fetchError = Nothing }
-    SetTxHash s -> H.modify_ _ { txHash = s, copied = false, fetchError = Nothing }
-    SetTxHex s -> H.modify_ _ { txHex = s, copied = false, fetchError = Nothing }
+    SelectMode m -> H.modify_ _ { mode = m, fetchError = Nothing, copiedPath = Nothing }
+    SelectNetwork n -> H.modify_ _ { network = n, fetchError = Nothing, copiedPath = Nothing }
+    SetTxHash s -> H.modify_ _ { txHash = s, copied = false, copiedPath = Nothing, fetchError = Nothing }
+    SetTxHex s -> H.modify_ _ { txHex = s, copied = false, copiedPath = Nothing, fetchError = Nothing }
     Decode -> do
       st <- H.get
-      H.modify_ _ { running = true, result = Nothing, copied = false, fetchError = Nothing }
+      H.modify_
+        _
+          { running = true
+          , result = Nothing
+          , copied = false
+          , copiedPath = Nothing
+          , browserPath = "[]"
+          , fetchError = Nothing
+          }
       hexE <- case st.mode of
         ByHex -> pure (Right (String.trim st.txHex))
         ByHash ->
@@ -601,14 +607,19 @@ inspectorComponent initial =
                       in pure (Left diag)
                     Right cbor -> pure (Right cbor)
       case hexE of
-        Left err -> H.modify_ _ { running = false, fetchError = Just err }
+        Left err -> H.modify_ _ { running = false, fetchError = Just err, browserPath = "[]" }
         Right h -> do
           r <- H.liftAff (runInspector h)
-          H.modify_ _ { running = false, result = Just r }
+          H.modify_ _ { running = false, result = Just r, browserPath = "[]" }
     Copy -> do
       mr <- H.gets _.result
       case mr of
         Nothing -> pure unit
         Just r -> do
           H.liftAff (Clipboard.copy (Json.pretty r.stdout))
-          H.modify_ _ { copied = true }
+          H.modify_ _ { copied = true, copiedPath = Nothing }
+    CopyValue path value -> do
+      H.liftAff (Clipboard.copy value)
+      H.modify_ _ { copied = false, copiedPath = Just path }
+    BrowseJson path ->
+      H.modify_ _ { browserPath = path, copiedPath = Nothing }

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -2,12 +2,21 @@ module Main (main) where
 
 import Prelude
 
+import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
+import Data.String (trim) as String
 import Effect (Effect)
+import Effect.Aff (attempt)
 import Effect.Aff.Class (class MonadAff)
+import Effect.Class (liftEffect)
+import Effect.Exception (message)
+import FFI.Blockfrost (Network(..))
 import FFI.Clipboard (copy) as Clipboard
 import FFI.Inspector (InspectorResult, runInspector)
 import FFI.Json (pretty) as Json
+import FFI.Storage as Storage
+import Provider (Provider(..))
+import Provider as Provider
 import Halogen as H
 import Halogen.Aff as HA
 import Halogen.HTML as HH
@@ -15,31 +24,80 @@ import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Halogen.VDom.Driver (runUI)
 
+blockfrostKey :: String
+blockfrostKey = "blockfrost_project_id"
+
+koiosKey :: String
+koiosKey = "koios_bearer_token"
+
+providerKey :: String
+providerKey = "provider"
+
 main :: Effect Unit
 main = HA.runHalogenAff do
   body <- HA.awaitBody
-  runUI inspectorComponent unit body
+  bf   <- liftEffect (Storage.getItem blockfrostKey)
+  kOS  <- liftEffect (Storage.getItem koiosKey)
+  prov <- liftEffect (Storage.getItem providerKey)
+  let initialProv = case prov of
+        "Koios"      -> Koios
+        _            -> Blockfrost
+  runUI (inspectorComponent { bf, koios: kOS, prov: initialProv }) unit body
+
+data Mode = ByHash | ByHex
+
+derive instance eqMode :: Eq Mode
 
 type State =
-  { input :: String
+  { provider :: Provider
+  , blockfrostKey :: String
+  , koiosBearer :: String
+  , mode :: Mode
+  , network :: Network
+  , txHash :: String
+  , txHex :: String
   , result :: Maybe InspectorResult
   , running :: Boolean
   , copied :: Boolean
+  , fetchError :: Maybe String
+  }
+
+type InitialKeys =
+  { bf :: String
+  , koios :: String
+  , prov :: Provider
   }
 
 data Action
-  = SetInput String
+  = SetBlockfrostKey String
+  | SetKoiosBearer String
+  | SelectProvider Provider
+  | SelectMode Mode
+  | SelectNetwork Network
+  | SetTxHash String
+  | SetTxHex String
   | Decode
   | Copy
 
-inspectorComponent :: forall q i o m. MonadAff m => H.Component q i o m
-inspectorComponent =
+inspectorComponent
+  :: forall q i o m
+   . MonadAff m
+  => InitialKeys
+  -> H.Component q i o m
+inspectorComponent initial =
   H.mkComponent
     { initialState: \_ ->
-        { input: ""
+        { provider: initial.prov
+        , blockfrostKey: initial.bf
+        , koiosBearer: initial.koios
+        , mode: ByHash
+        , network: Mainnet
+        , txHash: ""
+        , txHex: ""
         , result: Nothing
         , running: false
         , copied: false
+        , fetchError: Nothing
         }
     , render
     , eval: H.mkEval H.defaultEval { handleAction = handleAction }
@@ -51,68 +109,239 @@ inspectorComponent =
       [ HH.h1_ [ HH.text "Conway tx inspector" ]
       , HH.p_
           [ HH.text
-              "This page decodes Cardano Conway-era transactions using the upstream Haskell ledger code "
+              "Decodes Cardano Conway-era transactions using the upstream Haskell ledger code "
           , HH.strong_ [ HH.text "unchanged" ]
           , HH.text " — the same "
           , HH.code_ [ HH.text "cardano-ledger-conway" ]
           , HH.text " + "
           , HH.code_ [ HH.text "cardano-ledger-binary" ]
-          , HH.text
-              " packages IntersectMBO ships for node and CLI, cross-compiled to "
+          , HH.text " packages IntersectMBO ships for node and CLI, cross-compiled to "
           , HH.code_ [ HH.text "wasm32-wasi" ]
-          , HH.text
-              " via GHC's WASM backend and loaded here through a browser WASI shim. No re-implementation, no CBOR re-encode: bytes in, ledger decoder runs, structural JSON out."
+          , HH.text " and loaded in the browser via a WASI shim."
           ]
-      , HH.p_
-          [ HH.text "Paste a Conway-era transaction CBOR hex. You can fetch one via Blockfrost: "
-          , HH.code_ [ HH.text "GET /txs/{hash}/cbor" ]
-          , HH.text "."
-          ]
-      , HH.textarea
-          [ HP.value state.input
-          , HP.placeholder "Conway tx hex..."
-          , HP.rows 8
-          , HE.onValueInput SetInput
-          ]
-      , HH.div_
-          [ HH.button
-              [ HP.disabled state.running
-              , HE.onClick (\_ -> Decode)
-              ]
-              [ HH.text (if state.running then "Decoding..." else "Decode") ]
-          ]
-      , case state.result of
-          Nothing -> HH.text ""
-          Just r ->
-            HH.div_
-              [ HH.div_
-                  [ HH.h2_ [ HH.text (if r.exitOk then "Decoded JSON" else "Error") ]
-                  , if r.exitOk
-                      then
-                        HH.button
-                          [ HE.onClick (\_ -> Copy)
-                          , HP.style "margin-left: 1rem; font-size: 0.875rem;"
-                          ]
-                          [ HH.text (if state.copied then "Copied!" else "Copy JSON") ]
-                      else HH.text ""
-                  ]
-              , HH.pre_ [ HH.text (Json.pretty r.stdout) ]
-              , if r.stderr == "" then HH.text ""
-                else
-                  HH.div_
-                    [ HH.h2_ [ HH.text "stderr" ]
-                    , HH.pre_ [ HH.text r.stderr ]
-                    ]
-              ]
+      , renderProvider state
+      , renderModeTabs state
+      , renderBody state
+      , renderResult state
       ]
 
+  renderProvider state =
+    HH.div_
+      [ HH.h2_ [ HH.text "Chain data provider" ]
+      , HH.div
+          [ HP.style "margin-bottom: 0.5rem;" ]
+          [ HH.text "Source: "
+          , providerRadio state Blockfrost "Blockfrost (API key required)"
+          , providerRadio state Koios      "Koios (keyless, rate-limited)"
+          ]
+      , HH.p_
+          [ HH.text "Used only for the "
+          , HH.strong_ [ HH.text "by tx hash" ]
+          , HH.text " mode. Keys are kept in your browser's localStorage; the CBOR never leaves your machine once fetched."
+          ]
+      , case state.provider of
+          Blockfrost ->
+            HH.div_
+              [ HH.input
+                  [ HP.type_ HP.InputText
+                  , HP.placeholder "Blockfrost project_id (mainnet.../preprod.../preview...)"
+                  , HP.value state.blockfrostKey
+                  , HE.onValueInput SetBlockfrostKey
+                  , HP.style "width: 100%; font-family: ui-monospace, monospace;"
+                  ]
+              , HH.p
+                  [ HP.style "margin-top: 0.25rem; font-size: 0.85rem; color: #555;" ]
+                  [ HH.text "Free tier at "
+                  , HH.a
+                      [ HP.href "https://blockfrost.io/"
+                      , HP.target "_blank"
+                      , HP.rel "noopener noreferrer"
+                      ]
+                      [ HH.text "blockfrost.io" ]
+                  , HH.text "."
+                  ]
+              ]
+          Koios ->
+            HH.div_
+              [ HH.input
+                  [ HP.type_ HP.InputText
+                  , HP.placeholder "Optional Koios bearer token (leave blank for anon)"
+                  , HP.value state.koiosBearer
+                  , HE.onValueInput SetKoiosBearer
+                  , HP.style "width: 100%; font-family: ui-monospace, monospace;"
+                  ]
+              , HH.p
+                  [ HP.style "margin-top: 0.25rem; font-size: 0.85rem; color: #555;" ]
+                  [ HH.text "Free keyless use works; bearer token lifts rate limits. Docs at "
+                  , HH.a
+                      [ HP.href "https://api.koios.rest/"
+                      , HP.target "_blank"
+                      , HP.rel "noopener noreferrer"
+                      ]
+                      [ HH.text "api.koios.rest" ]
+                  , HH.text "."
+                  ]
+              ]
+      , HH.div
+          [ HP.style "margin-top: 0.5rem; font-size: 0.9rem;" ]
+          [ HH.text "Network: "
+          , networkRadio state Mainnet "mainnet"
+          , networkRadio state Preprod "preprod"
+          , networkRadio state Preview "preview"
+          ]
+      ]
+
+  providerRadio state prov label =
+    HH.label
+      [ HP.style "margin-right: 1rem; cursor: pointer;" ]
+      [ HH.input
+          [ HP.type_ HP.InputRadio
+          , HP.name "provider"
+          , HP.checked (state.provider == prov)
+          , HE.onChange (\_ -> SelectProvider prov)
+          ]
+      , HH.text (" " <> label)
+      ]
+
+  networkRadio state net label =
+    HH.label
+      [ HP.style "margin-right: 1rem; cursor: pointer;" ]
+      [ HH.input
+          [ HP.type_ HP.InputRadio
+          , HP.name "network"
+          , HP.checked (state.network == net)
+          , HE.onChange (\_ -> SelectNetwork net)
+          ]
+      , HH.text (" " <> label)
+      ]
+
+  renderModeTabs state =
+    HH.div
+      [ HP.style "margin-top: 1.5rem;" ]
+      [ HH.h2_ [ HH.text "Input" ]
+      , HH.div_
+          [ modeButton state ByHash "By tx hash"
+          , modeButton state ByHex  "By CBOR hex"
+          ]
+      ]
+
+  modeButton state mode label =
+    HH.button
+      [ HE.onClick (\_ -> SelectMode mode)
+      , HP.style (
+          "margin-right: 0.5rem; padding: 0.35rem 0.75rem; font-size: 0.9rem; "
+            <> (if state.mode == mode
+                 then "border: 1px solid #333; background: #eee;"
+                 else "border: 1px solid #ccc; background: transparent;"))
+      ]
+      [ HH.text label ]
+
+  renderBody state = case state.mode of
+    ByHash ->
+      HH.div_
+        [ HH.input
+            [ HP.type_ HP.InputText
+            , HP.placeholder "64-char tx hash"
+            , HP.value state.txHash
+            , HE.onValueInput SetTxHash
+            , HP.style "width: 100%; font-family: ui-monospace, monospace;"
+            ]
+        , HH.div_
+            [ HH.button
+                [ HP.disabled state.running
+                , HE.onClick (\_ -> Decode)
+                ]
+                [ HH.text (if state.running then "Fetching & decoding..." else "Fetch & decode") ]
+            ]
+        ]
+    ByHex ->
+      HH.div_
+        [ HH.textarea
+            [ HP.value state.txHex
+            , HP.placeholder "Conway tx CBOR hex..."
+            , HP.rows 8
+            , HE.onValueInput SetTxHex
+            ]
+        , HH.div_
+            [ HH.button
+                [ HP.disabled state.running
+                , HE.onClick (\_ -> Decode)
+                ]
+                [ HH.text (if state.running then "Decoding..." else "Decode") ]
+            ]
+        ]
+
+  renderResult state =
+    case state.fetchError of
+      Just err ->
+        HH.div
+          [ HP.style "color: #b00; margin-top: 1rem;" ]
+          [ HH.strong_ [ HH.text "Fetch error: " ]
+          , HH.text err
+          ]
+      Nothing -> case state.result of
+        Nothing -> HH.text ""
+        Just r ->
+          HH.div_
+            [ HH.div_
+                [ HH.h2_ [ HH.text (if r.exitOk then "Decoded JSON" else "Error") ]
+                , if r.exitOk
+                    then
+                      HH.button
+                        [ HE.onClick (\_ -> Copy)
+                        , HP.style "margin-left: 1rem; font-size: 0.875rem;"
+                        ]
+                        [ HH.text (if state.copied then "Copied!" else "Copy JSON") ]
+                    else HH.text ""
+                ]
+            , HH.pre_ [ HH.text (Json.pretty r.stdout) ]
+            , if r.stderr == "" then HH.text ""
+              else
+                HH.div_
+                  [ HH.h2_ [ HH.text "stderr" ]
+                  , HH.pre_ [ HH.text r.stderr ]
+                  ]
+            ]
+
   handleAction = case _ of
-    SetInput s -> H.modify_ _ { input = s, copied = false }
+    SetBlockfrostKey s -> do
+      H.modify_ _ { blockfrostKey = s }
+      liftEffect (Storage.setItem blockfrostKey s)
+    SetKoiosBearer s -> do
+      H.modify_ _ { koiosBearer = s }
+      liftEffect (Storage.setItem koiosKey s)
+    SelectProvider p -> do
+      H.modify_ _ { provider = p, fetchError = Nothing }
+      liftEffect (Storage.setItem providerKey (Provider.providerName p))
+    SelectMode m -> H.modify_ _ { mode = m, fetchError = Nothing }
+    SelectNetwork n -> H.modify_ _ { network = n, fetchError = Nothing }
+    SetTxHash s -> H.modify_ _ { txHash = s, copied = false, fetchError = Nothing }
+    SetTxHex s -> H.modify_ _ { txHex = s, copied = false, fetchError = Nothing }
     Decode -> do
-      H.modify_ _ { running = true, result = Nothing, copied = false }
-      hex <- H.gets _.input
-      r <- H.liftAff (runInspector hex)
-      H.modify_ _ { running = false, result = Just r }
+      st <- H.get
+      H.modify_ _ { running = true, result = Nothing, copied = false, fetchError = Nothing }
+      hexE <- case st.mode of
+        ByHex -> pure (Right (String.trim st.txHex))
+        ByHash ->
+          let key = case st.provider of
+                Blockfrost -> String.trim st.blockfrostKey
+                Koios      -> String.trim st.koiosBearer
+              trimmedHash = String.trim st.txHash
+          in
+            if Provider.needsKey st.provider && key == ""
+              then pure (Left (Provider.providerName st.provider <> " key not set."))
+              else if trimmedHash == ""
+                then pure (Left "Tx hash is empty.")
+                else do
+                  e <- H.liftAff (attempt (Provider.fetchTxCbor st.provider st.network key trimmedHash))
+                  case e of
+                    Left err -> pure (Left (message err))
+                    Right cbor -> pure (Right cbor)
+      case hexE of
+        Left err -> H.modify_ _ { running = false, fetchError = Just err }
+        Right h -> do
+          r <- H.liftAff (runInspector h)
+          H.modify_ _ { running = false, result = Just r }
     Copy -> do
       mr <- H.gets _.result
       case mr of

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Prelude
 
+import Data.Array as Array
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.String (trim) as String
@@ -13,7 +14,7 @@ import Effect.Exception (message)
 import FFI.Blockfrost (Network(..))
 import FFI.Clipboard (copy) as Clipboard
 import FFI.Inspector (InspectorResult, runInspector)
-import FFI.Json (pretty) as Json
+import FFI.Json (inspect, pretty) as Json
 import FFI.Storage as Storage
 import Provider (Provider(..))
 import Provider as Provider
@@ -184,11 +185,11 @@ inspectorComponent initial =
                   [ classNames [ "field-label" ] ]
                   [ HH.text "Blockfrost project ID"
                   , HH.a
-                      [ HP.href "https://blockfrost.io/auth/signup"
+                      [ HP.href "https://blockfrost.io/dashboard"
                       , HP.target "_blank"
                       , HP.rel "noopener noreferrer"
                       ]
-                      [ HH.text "Signup" ]
+                      [ HH.text "Dashboard" ]
                   ]
               Koios ->
                 HH.label
@@ -372,29 +373,164 @@ inspectorComponent initial =
                 [ HH.text "No result yet." ]
             ]
         Just r ->
-          HH.section
-            [ classNames [ "panel", "result-panel" ] ]
-            [ HH.div
-                [ classNames [ "panel-heading", "result-heading" ] ]
-                [ HH.h2_ [ HH.text (if r.exitOk then "Decoded JSON" else "Error") ]
-                , if r.exitOk
-                    then
-                      HH.button
-                        [ HE.onClick (\_ -> Copy)
-                        , classNames [ "secondary-action" ]
+          let summary = Json.inspect r.stdout
+          in
+            HH.section
+              [ classNames [ "panel", "result-panel" ] ]
+              ( [ HH.div
+                    [ classNames [ "panel-heading", "result-heading" ] ]
+                    [ HH.div_
+                        [ HH.h2_ [ HH.text (if r.exitOk then "Inspection" else "Error") ]
+                        , if r.exitOk && summary.valid
+                            then HH.p_ [ HH.text summary.title ]
+                            else HH.text ""
                         ]
-                        [ HH.text (if state.copied then "Copied" else "Copy JSON") ]
-                    else HH.text ""
+                    , if r.exitOk
+                        then
+                          HH.button
+                            [ HE.onClick (\_ -> Copy)
+                            , classNames [ "secondary-action" ]
+                            ]
+                            [ HH.text (if state.copied then "Copied" else "Copy JSON") ]
+                        else HH.text ""
+                    ]
                 ]
-            , HH.pre_ [ HH.text (Json.pretty r.stdout) ]
-            , if r.stderr == "" then HH.text ""
-              else
-                HH.div
-                  [ classNames [ "stderr-block" ] ]
-                  [ HH.h3_ [ HH.text "stderr" ]
-                  , HH.pre_ [ HH.text r.stderr ]
-                  ]
-            ]
+              <> ( if r.exitOk && summary.valid
+                     then renderInspection summary
+                     else []
+                 )
+              <> [ renderRawJson r.stdout ]
+              <> renderStderr r.stderr
+              )
+
+  renderInspection summary =
+    [ HH.div
+        [ classNames [ "inspection-summary" ] ]
+        [ HH.div
+            [ classNames [ "metric-grid" ] ]
+            (map renderMetric summary.metrics)
+        , HH.div
+            [ classNames [ "inspection-grid" ] ]
+            ( renderOutputs summary
+            <> renderMint summary
+            <> renderInputs summary
+            )
+        ]
+    ]
+
+  renderMetric metric =
+    HH.div
+      [ classNames [ "metric-card" ] ]
+      [ HH.span
+          [ classNames [ "metric-label" ] ]
+          [ HH.text metric.label ]
+      , HH.strong_ [ HH.text metric.value ]
+      ]
+
+  renderOutputs summary =
+    if Array.null summary.outputs then []
+    else
+      [ HH.div
+          [ classNames [ "inspection-section", "wide-section" ] ]
+          [ HH.div
+              [ classNames [ "section-heading" ] ]
+              [ HH.h3_ [ HH.text "Outputs" ]
+              , HH.span_ [ HH.text summary.outputNote ]
+              ]
+          , HH.div
+              [ classNames [ "output-list" ] ]
+              (map renderOutput summary.outputs)
+          ]
+      ]
+
+  renderOutput output =
+    HH.div
+      [ classNames [ "output-row" ] ]
+      [ HH.span
+          [ classNames [ "row-index" ] ]
+          [ HH.text output.index ]
+      , HH.div
+          [ classNames [ "output-main" ] ]
+          [ HH.code_ [ HH.text output.address ]
+          , HH.span_ [ HH.text output.coin ]
+          ]
+      , HH.div
+          [ classNames [ "output-meta" ] ]
+          [ HH.span_ [ HH.text output.assets ]
+          , HH.span_ [ HH.text output.datum ]
+          ]
+      ]
+
+  renderMint summary =
+    if Array.null summary.mint then []
+    else
+      [ HH.div
+          [ classNames [ "inspection-section" ] ]
+          [ HH.div
+              [ classNames [ "section-heading" ] ]
+              [ HH.h3_ [ HH.text "Mint" ]
+              , HH.span_ [ HH.text summary.mintNote ]
+              ]
+          , HH.div
+              [ classNames [ "mint-list" ] ]
+              (map renderMintRow summary.mint)
+          ]
+      ]
+
+  renderMintRow row =
+    HH.div
+      [ classNames [ "mint-row" ] ]
+      [ HH.code_ [ HH.text row.policy ]
+      , HH.span_ [ HH.text row.assets ]
+      ]
+
+  renderInputs summary =
+    if Array.null summary.inputs && Array.null summary.referenceInputs then []
+    else
+      [ HH.div
+          [ classNames [ "inspection-section" ] ]
+          [ HH.div
+              [ classNames [ "section-heading" ] ]
+              [ HH.h3_ [ HH.text "Inputs" ]
+              , HH.span_ [ HH.text summary.inputNote ]
+              ]
+          , if Array.null summary.inputs then HH.text ""
+            else
+              HH.div
+                [ classNames [ "hash-group" ] ]
+                [ HH.span_ [ HH.text "Spending" ]
+                , HH.div
+                    [ classNames [ "hash-list" ] ]
+                    (map (\input -> HH.code_ [ HH.text input ]) summary.inputs)
+                ]
+          , if Array.null summary.referenceInputs then HH.text ""
+            else
+              HH.div
+                [ classNames [ "hash-group" ] ]
+                [ HH.span_ [ HH.text "Reference" ]
+                , HH.div
+                    [ classNames [ "hash-list" ] ]
+                    (map (\input -> HH.code_ [ HH.text input ]) summary.referenceInputs)
+                ]
+          ]
+      ]
+
+  renderRawJson stdout =
+    HH.details
+      [ classNames [ "raw-json-block" ] ]
+      [ HH.summary_ [ HH.text "Raw JSON" ]
+      , HH.pre_ [ HH.text (Json.pretty stdout) ]
+      ]
+
+  renderStderr stderr =
+    if stderr == "" then []
+    else
+      [ HH.div
+          [ classNames [ "stderr-block" ] ]
+          [ HH.h3_ [ HH.text "stderr" ]
+          , HH.pre_ [ HH.text stderr ]
+          ]
+      ]
 
   classNames :: forall r a. Array String -> HP.IProp (class :: String | r) a
   classNames names = HP.classes (map HH.ClassName names)

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -13,8 +13,8 @@ import Effect.Class (liftEffect)
 import Effect.Exception (message)
 import FFI.Blockfrost (Network(..))
 import FFI.Clipboard (copy) as Clipboard
-import FFI.Inspector (InspectorResult, runInspector)
-import FFI.Json (browse, inspect, pretty) as Json
+import FFI.Inspector (InspectorResult, runInspectorRpc)
+import FFI.Json (Browser, inspect, pretty, rpcBrowser, rpcInspection) as Json
 import FFI.Storage as Storage
 import Provider (Provider(..))
 import Provider as Provider
@@ -78,6 +78,8 @@ type State =
   , txHash :: String
   , txHex :: String
   , result :: Maybe InspectorResult
+  , txCbor :: Maybe String
+  , browser :: Maybe Json.Browser
   , running :: Boolean
   , copied :: Boolean
   , copiedPath :: Maybe String
@@ -123,6 +125,8 @@ inspectorComponent initial =
         , txHash: ""
         , txHex: ""
         , result: Nothing
+        , txCbor: Nothing
+        , browser: Nothing
         , running: false
         , copied: false
         , copiedPath: Nothing
@@ -381,7 +385,6 @@ inspectorComponent initial =
         Just r ->
           let
             summary = Json.inspect r.stdout
-            browser = Json.browse r.stdout state.browserPath
           in
             HH.section
               [ classNames [ "panel", "result-panel" ] ]
@@ -407,13 +410,17 @@ inspectorComponent initial =
                      then renderInspection summary
                      else []
                  )
-              <> ( if r.exitOk && browser.valid
-                     then [ renderBrowser state browser ]
-                     else []
-                 )
+              <> renderBrowserMaybe state r.exitOk
               <> [ renderRawJson r.stdout ]
               <> renderStderr r.stderr
               )
+
+  renderBrowserMaybe state exitOk =
+    case state.browser of
+      Just browser ->
+        if exitOk && browser.valid then [ renderBrowser state browser ]
+        else []
+      Nothing -> []
 
   renderInspection summary =
     [ HH.div
@@ -576,6 +583,8 @@ inspectorComponent initial =
         _
           { running = true
           , result = Nothing
+          , txCbor = Nothing
+          , browser = Nothing
           , copied = false
           , copiedPath = Nothing
           , browserPath = "[]"
@@ -609,8 +618,18 @@ inspectorComponent initial =
       case hexE of
         Left err -> H.modify_ _ { running = false, fetchError = Just err, browserPath = "[]" }
         Right h -> do
-          r <- H.liftAff (runInspector h)
-          H.modify_ _ { running = false, result = Just r, browserPath = "[]" }
+          rpcResult <- H.liftAff (runInspectorRpc h "inspect" "[]")
+          let
+            inspectionResult = rpcResult { stdout = Json.rpcInspection rpcResult.stdout }
+            browser = Json.rpcBrowser rpcResult.stdout
+          H.modify_
+            _
+              { running = false
+              , result = Just inspectionResult
+              , txCbor = Just h
+              , browser = if rpcResult.exitOk && browser.valid then Just browser else Nothing
+              , browserPath = browser.currentPath
+              }
     Copy -> do
       mr <- H.gets _.result
       case mr of
@@ -622,4 +641,20 @@ inspectorComponent initial =
       H.liftAff (Clipboard.copy value)
       H.modify_ _ { copied = false, copiedPath = Just path }
     BrowseJson path ->
-      H.modify_ _ { browserPath = path, copiedPath = Nothing }
+      do
+        mt <- H.gets _.txCbor
+        case mt of
+          Nothing ->
+            H.modify_ _ { browserPath = path, copiedPath = Nothing }
+          Just txCbor -> do
+            H.modify_ _ { browserPath = path, copiedPath = Nothing }
+            rpcResult <- H.liftAff (runInspectorRpc txCbor "browse" path)
+            let browser = Json.rpcBrowser rpcResult.stdout
+            H.modify_
+              _
+                { browser = if rpcResult.exitOk && browser.valid then Just browser else Nothing
+                , browserPath = browser.currentPath
+                , fetchError =
+                    if rpcResult.exitOk && browser.valid then Nothing
+                    else Just (if rpcResult.stderr == "" then "Haskell RPC browse failed." else rpcResult.stderr)
+                }

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -80,11 +80,18 @@ type State =
   , result :: Maybe InspectorResult
   , txCbor :: Maybe String
   , browser :: Maybe Json.Browser
+  , browserNodes :: Array BrowserNode
+  , expandedPaths :: Array String
   , running :: Boolean
   , copied :: Boolean
   , copiedPath :: Maybe String
   , browserPath :: String
   , fetchError :: Maybe String
+  }
+
+type BrowserNode =
+  { path :: String
+  , browser :: Json.Browser
   }
 
 type InitialKeys =
@@ -127,6 +134,8 @@ inspectorComponent initial =
         , result: Nothing
         , txCbor: Nothing
         , browser: Nothing
+        , browserNodes: []
+        , expandedPaths: []
         , running: false
         , copied: false
         , copiedPath: Nothing
@@ -438,9 +447,6 @@ inspectorComponent initial =
           [ classNames [ "browser-heading" ] ]
           [ HH.div_
               [ HH.h3_ [ HH.text "Transaction browser" ]
-              , HH.div
-                  [ classNames [ "breadcrumb-bar" ] ]
-                  (map renderBreadcrumb browser.breadcrumbs)
               , HH.p_ [ HH.text browser.subtitle ]
               ]
           , HH.button
@@ -455,61 +461,111 @@ inspectorComponent initial =
                   )
               ]
           ]
-      , if Array.null browser.rows then
-          HH.div
-            [ classNames [ "scalar-value" ] ]
-            [ HH.code_ [ HH.text browser.currentJson ] ]
-        else
-          HH.div
-            [ classNames [ "browser-row-list" ] ]
-            (map (renderBrowserRow state) browser.rows)
+      , HH.div
+          [ classNames [ "browser-row-list" ] ]
+          (renderTreeRows state browser)
       ]
 
-  renderBreadcrumb crumb =
-    HH.button
-      [ HE.onClick (\_ -> BrowseJson crumb.path)
-      , classNames [ "breadcrumb-button" ]
-      ]
-      [ HH.text crumb.label ]
-
-  renderBrowserRow state row =
-    HH.div
-      [ classNames [ "browser-row" ] ]
+  renderTreeRows state browser =
+    if Array.null browser.rows then
       [ HH.div
-          [ classNames [ "browser-row-main" ] ]
+          [ classNames [ "scalar-value" ] ]
+          [ HH.code_ [ HH.text browser.currentJson ] ]
+      ]
+    else
+      Array.concatMap (renderTreeRow state) browser.rows
+
+  renderTreeRow state row =
+    let
+      expanded = isExpanded row.path state.expandedPaths
+      child = browserAt row.path state.browserNodes
+    in
+      [ HH.div
+          [ classNames
+              ( if expanded then
+                  [ "browser-row", "is-expanded" ]
+                else
+                  [ "browser-row" ]
+              )
+          ]
           [ HH.div
-              [ classNames [ "browser-keyline" ] ]
-              [ HH.code_ [ HH.text row.label ]
-              , HH.span
-                  [ classNames [ "kind-badge" ] ]
-                  [ HH.text row.kind ]
+              [ classNames [ "browser-row-main" ] ]
+              [ HH.div
+                  [ classNames [ "browser-keyline" ] ]
+                  [ HH.code_ [ HH.text row.label ]
+                  , HH.span
+                      [ classNames [ "kind-badge" ] ]
+                      [ HH.text row.kind ]
+                  ]
+              , HH.div
+                  [ classNames [ "browser-summary" ] ]
+                  [ HH.text row.summary ]
               ]
           , HH.div
-              [ classNames [ "browser-summary" ] ]
-              [ HH.text row.summary ]
-          ]
-      , HH.div
-          [ classNames [ "browser-actions" ] ]
-          [ if row.canDive then
-              HH.button
-                [ HE.onClick (\_ -> BrowseJson row.path)
-                , classNames [ "inline-action" ]
-                ]
-                [ HH.text "Open" ]
-            else HH.text ""
-          , HH.button
-              [ HE.onClick (\_ -> CopyValue row.path row.copyValue)
-              , classNames [ "inline-action" ]
-              ]
-              [ HH.text
-                  ( if state.copiedPath == Just row.path then
-                      "Copied"
-                    else
-                      "Copy"
-                  )
+              [ classNames [ "browser-actions" ] ]
+              [ if row.canDive then
+                  HH.button
+                    [ HE.onClick (\_ -> BrowseJson row.path)
+                    , classNames [ "inline-action" ]
+                    ]
+                    [ HH.text (if expanded then "Close" else "Open") ]
+                else HH.text ""
+              , HH.button
+                  [ HE.onClick (\_ -> CopyValue row.path row.copyValue)
+                  , classNames [ "inline-action" ]
+                  ]
+                  [ HH.text
+                      ( if state.copiedPath == Just row.path then
+                          "Copied"
+                        else
+                          "Copy"
+                      )
+                  ]
               ]
           ]
-      ]
+      ] <> if expanded then
+        [ HH.div
+            [ classNames [ "browser-children" ] ]
+            ( case child of
+                Just browser ->
+                  renderTreeRows state browser
+                Nothing ->
+                  [ HH.div
+                      [ classNames [ "scalar-value" ] ]
+                      [ HH.code_ [ HH.text "Loading..." ] ]
+                  ]
+            )
+        ]
+      else []
+
+  isExpanded path paths =
+    Array.elem path paths
+
+  browserAt path nodes =
+    _.browser <$> Array.find (\node -> node.path == path) nodes
+
+  upsertBrowserNode path browser nodes =
+    if Array.any (\node -> node.path == path) nodes then
+      map
+        ( \node ->
+            if node.path == path then
+              { path, browser }
+            else
+              node
+        )
+        nodes
+    else
+      Array.snoc nodes { path, browser }
+
+  expandPath path paths =
+    if Array.elem path paths then paths
+    else Array.snoc paths path
+
+  closePath path paths =
+    Array.filter (_ /= path) paths
+
+  rootBrowserNodes browser =
+    [ { path: browser.currentPath, browser } ]
 
   renderMetric metric =
     HH.div
@@ -585,6 +641,8 @@ inspectorComponent initial =
           , result = Nothing
           , txCbor = Nothing
           , browser = Nothing
+          , browserNodes = []
+          , expandedPaths = []
           , copied = false
           , copiedPath = Nothing
           , browserPath = "[]"
@@ -628,6 +686,10 @@ inspectorComponent initial =
               , result = Just inspectionResult
               , txCbor = Just h
               , browser = if rpcResult.exitOk && browser.valid then Just browser else Nothing
+              , browserNodes =
+                  if rpcResult.exitOk && browser.valid then rootBrowserNodes browser
+                  else []
+              , expandedPaths = []
               , browserPath = browser.currentPath
               }
     Copy -> do
@@ -642,8 +704,10 @@ inspectorComponent initial =
       H.modify_ _ { copied = false, copiedPath = Just path }
     BrowseJson path ->
       do
-        mt <- H.gets _.txCbor
-        case mt of
+        st <- H.get
+        if isExpanded path st.expandedPaths then
+          H.modify_ _ { expandedPaths = closePath path st.expandedPaths, copiedPath = Nothing }
+        else case st.txCbor of
           Nothing ->
             H.modify_ _ { browserPath = path, copiedPath = Nothing }
           Just txCbor -> do
@@ -652,7 +716,16 @@ inspectorComponent initial =
             let browser = Json.rpcBrowser rpcResult.stdout
             H.modify_
               _
-                { browser = if rpcResult.exitOk && browser.valid then Just browser else Nothing
+                { browserNodes =
+                    if rpcResult.exitOk && browser.valid then
+                      upsertBrowserNode path browser st.browserNodes
+                    else
+                      st.browserNodes
+                , expandedPaths =
+                    if rpcResult.exitOk && browser.valid then
+                      expandPath path st.expandedPaths
+                    else
+                      st.expandedPaths
                 , browserPath = browser.currentPath
                 , fetchError =
                     if rpcResult.exitOk && browser.valid then Nothing

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -132,7 +132,7 @@ inspectorComponent initial =
           [ HP.style "margin-bottom: 0.5rem;" ]
           [ HH.text "Source: "
           , providerRadio state Blockfrost "Blockfrost (API key required)"
-          , providerRadio state Koios      "Koios (keyless — CORS-blocked in browser; works from CLI)"
+          , providerRadio state Koios      "Koios (bearer token required in browser; free tier at koios.rest)"
           ]
       , HH.p_
           [ HH.text "Used only for the "
@@ -165,21 +165,28 @@ inspectorComponent initial =
             HH.div_
               [ HH.input
                   [ HP.type_ HP.InputText
-                  , HP.placeholder "Optional Koios bearer token (leave blank for anon)"
+                  , HP.placeholder "Koios bearer token (required for browser use)"
                   , HP.value state.koiosBearer
                   , HE.onValueInput SetKoiosBearer
                   , HP.style "width: 100%; font-family: ui-monospace, monospace;"
                   ]
               , HH.p
                   [ HP.style "margin-top: 0.25rem; font-size: 0.85rem; color: #555;" ]
-                  [ HH.text "Free keyless use works; bearer token lifts rate limits. Docs at "
+                  [ HH.text "Koios intentionally strips CORS on unauthenticated requests (see "
                   , HH.a
-                      [ HP.href "https://api.koios.rest/"
+                      [ HP.href "https://github.com/cardano-community/koios-artifacts/issues/397"
                       , HP.target "_blank"
                       , HP.rel "noopener noreferrer"
                       ]
-                      [ HH.text "api.koios.rest" ]
-                  , HH.text "."
+                      [ HH.text "issue #397" ]
+                  , HH.text "). Free bearer tokens at "
+                  , HH.a
+                      [ HP.href "https://koios.rest/pricing/Pricing.html"
+                      , HP.target "_blank"
+                      , HP.rel "noopener noreferrer"
+                      ]
+                      [ HH.text "koios.rest/pricing" ]
+                  , HH.text " — the free tier covers 50k req/day. Without a token, use the CLI script and paste in 'By CBOR hex' mode."
                   ]
               ]
       , HH.div
@@ -339,7 +346,9 @@ inspectorComponent initial =
                       let raw = message err
                           diag = case st.provider of
                             Koios | raw == "Failed to fetch" ->
-                              "Koios is blocked by browser CORS (server doesn't echo ACAO on POST responses). Use CLI: scripts/fetch-tx-cbor.sh <hash>, then paste the hex in 'By CBOR hex' mode. Or switch to Blockfrost."
+                              if String.trim st.koiosBearer == ""
+                                then "Koios blocks anonymous browser requests by design (CORS stripped). Register at koios.rest/pricing for a free bearer token (50k req/day), paste it above, and retry. Or use scripts/fetch-tx-cbor.sh <hash> locally and paste the hex."
+                                else "Koios rejected the request. Check the bearer token is valid and the network matches (mainnet/preprod/preview)."
                             _ -> raw
                       in pure (Left diag)
                     Right cbor -> pure (Right cbor)

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -23,6 +23,7 @@ import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Halogen.VDom.Driver (runUI)
+import Web.DOM.ParentNode (QuerySelector(..))
 
 blockfrostKey :: String
 blockfrostKey = "blockfrost_project_id"
@@ -39,6 +40,7 @@ persistKeysStorageKey = "persist_api_keys"
 main :: Effect Unit
 main = HA.runHalogenAff do
   body    <- HA.awaitBody
+  app     <- HA.selectElement (QuerySelector "#app")
   persist <- liftEffect (Storage.getItem persistKeysStorageKey)
   let persistInitial = persist == "true"
   bf   <- liftEffect
@@ -49,6 +51,9 @@ main = HA.runHalogenAff do
   let initialProv = case prov of
         "Koios"      -> Koios
         _            -> Blockfrost
+      mountTarget = case app of
+        Just el -> el
+        Nothing -> body
   runUI
     ( inspectorComponent
         { bf
@@ -56,7 +61,7 @@ main = HA.runHalogenAff do
         , prov: initialProv
         , persistKeys: persistInitial
         }
-    ) unit body
+    ) unit mountTarget
 
 data Mode = ByHash | ByHex
 
@@ -123,150 +128,198 @@ inspectorComponent initial =
   where
 
   render state =
-    HH.div_
-      [ HH.p
-          [ HP.class_ (HH.ClassName "muted") ]
-          [ HH.text
-              "Decodes Cardano Conway-era transactions using the upstream Haskell ledger code "
-          , HH.strong_ [ HH.text "unchanged" ]
-          , HH.text " — same "
-          , HH.code_ [ HH.text "cardano-ledger-conway" ]
-          , HH.text " + "
-          , HH.code_ [ HH.text "cardano-ledger-binary" ]
-          , HH.text " that node and CLI use, cross-compiled to "
-          , HH.code_ [ HH.text "wasm32-wasi" ]
-          , HH.text " and loaded via a WASI shim."
+    HH.div
+      [ classNames [ "app-shell" ] ]
+      [ HH.section
+          [ classNames [ "intro-strip" ] ]
+          [ HH.div_
+              [ HH.h1_ [ HH.text "Conway tx inspector" ]
+              , HH.p_
+                  [ HH.text
+                      "Decode Conway transaction CBOR in the browser with the upstream Haskell ledger compiled to "
+                  , HH.code_ [ HH.text "wasm32-wasi" ]
+                  , HH.text "."
+                  ]
+              ]
+          , HH.div
+              [ classNames [ "tech-pills" ] ]
+              [ HH.span_ [ HH.text "cardano-ledger-conway" ]
+              , HH.span_ [ HH.text "cardano-ledger-binary" ]
+              , HH.span_ [ HH.text "WASI" ]
+              ]
           ]
-      , renderProvider state
-      , renderModeTabs state
-      , renderResult state
+      , HH.div
+          [ classNames [ "workspace" ] ]
+          [ renderProvider state
+          , HH.div
+              [ classNames [ "workspace-main" ] ]
+              [ renderModeTabs state
+              , renderResult state
+              ]
+          ]
       ]
 
   renderProvider state =
-    HH.article_
-      [ HH.header_ [ HH.h2_ [ HH.text "Chain data provider" ] ]
-      , HH.p_
-          [ HH.text "Pick a provider. Both offer a free tier that needs a quick signup — paste the resulting credential below. Used only in the "
-          , HH.strong_ [ HH.text "by tx hash" ]
-          , HH.text " mode."
+    HH.section
+      [ classNames [ "panel", "provider-panel" ] ]
+      [ HH.div
+          [ classNames [ "panel-heading" ] ]
+          [ HH.h2_ [ HH.text "Chain data" ]
+          , HH.p_ [ HH.text "Credentials stay in memory unless persistence is enabled." ]
           ]
-      , HH.fieldset_
-          [ HH.legend_ [ HH.text "Source" ]
-          , providerRadio state Blockfrost "Blockfrost"
-          , providerRadio state Koios      "Koios"
+      , HH.fieldset
+          [ classNames [ "control-group" ] ]
+          [ HH.legend_ [ HH.text "Provider" ]
+          , HH.div
+              [ classNames [ "option-stack" ] ]
+              [ providerRadio state Blockfrost "Blockfrost"
+              , providerRadio state Koios      "Koios"
+              ]
           ]
-      , case state.provider of
-          Blockfrost ->
-            HH.label_
-              [ HH.text "Blockfrost project ID (free tier at "
-              , HH.a
-                  [ HP.href "https://blockfrost.io/auth/signup"
-                  , HP.target "_blank"
-                  , HP.rel "noopener noreferrer"
+      , HH.div
+          [ classNames [ "field-stack" ] ]
+          [ case state.provider of
+              Blockfrost ->
+                HH.label
+                  [ classNames [ "field-label" ] ]
+                  [ HH.text "Blockfrost project ID"
+                  , HH.a
+                      [ HP.href "https://blockfrost.io/auth/signup"
+                      , HP.target "_blank"
+                      , HP.rel "noopener noreferrer"
+                      ]
+                      [ HH.text "Signup" ]
                   ]
-                  [ HH.text "blockfrost.io signup" ]
-              , HH.text ")"
-              , HH.input
+              Koios ->
+                HH.label
+                  [ classNames [ "field-label" ] ]
+                  [ HH.text "Koios bearer token"
+                  , HH.a
+                      [ HP.href "https://koios.rest/auth/Auth.html"
+                      , HP.target "_blank"
+                      , HP.rel "noopener noreferrer"
+                      ]
+                      [ HH.text "Auth" ]
+                  ]
+          , case state.provider of
+              Blockfrost ->
+                HH.input
                   [ HP.type_ HP.InputPassword
                   , HP.placeholder "mainnet... / preprod... / preview..."
                   , HP.value state.blockfrostKey
                   , HE.onValueInput SetBlockfrostKey
                   ]
-              ]
-          Koios ->
-            HH.label_
-              [ HH.text "Koios bearer token (free tier at "
-              , HH.a
-                  [ HP.href "https://koios.rest/auth/Auth.html"
-                  , HP.target "_blank"
-                  , HP.rel "noopener noreferrer"
-                  ]
-                  [ HH.text "koios.rest auth" ]
-              , HH.text ")"
-              , HH.input
+              Koios ->
+                HH.input
                   [ HP.type_ HP.InputPassword
                   , HP.placeholder "eyJhbGciOi..."
                   , HP.value state.koiosBearer
                   , HE.onValueInput SetKoiosBearer
                   ]
-              ]
-      , HH.fieldset_
+          ]
+      , HH.fieldset
+          [ classNames [ "control-group" ] ]
           [ HH.legend_ [ HH.text "Network" ]
-          , networkRadio state Mainnet "mainnet"
-          , networkRadio state Preprod "preprod"
-          , networkRadio state Preview "preview"
+          , HH.div
+              [ classNames [ "option-stack", "compact-options" ] ]
+              [ networkRadio state Mainnet "mainnet"
+              , networkRadio state Preprod "preprod"
+              , networkRadio state Preview "preview"
+              ]
           ]
       , renderPersistToggle state
       ]
 
   renderPersistToggle state =
-    HH.fieldset_
-      [ HH.label_
+    HH.div
+      [ classNames [ "persist-block" ] ]
+      [ HH.label
+          [ classNames [ "switch-row" ] ]
           [ HH.input
               [ HP.type_ HP.InputCheckbox
               , HH.attr (HH.AttrName "role") "switch"
               , HP.checked state.persistKeys
               , HE.onChecked TogglePersist
               ]
-          , HH.text " Persist API credentials across sessions"
+          , HH.span_ [ HH.text "Persist API credentials" ]
           ]
-      , HH.small
-          [ HP.class_ (HH.ClassName "warning") ]
-          [ HH.text
-              "⚠ When enabled, the credential is saved in your browser's localStorage "
-          , HH.strong_ [ HH.text "in cleartext" ]
+      , HH.p
+          [ classNames [ "warning-note" ] ]
+          [ HH.strong_ [ HH.text "Warning: " ]
           , HH.text
-              ". Any JavaScript running on this origin (including future updates of this page) can read it. When disabled (default), the credential stays in memory only and is lost on reload."
+              "when enabled, credentials are saved in localStorage in cleartext. When disabled, they stay in memory only."
           ]
       ]
 
   providerRadio state prov label =
-    HH.label_
+    HH.label
+      [ choiceClass (state.provider == prov) ]
       [ HH.input
           [ HP.type_ HP.InputRadio
           , HP.name "provider"
           , HP.checked (state.provider == prov)
           , HE.onChange (\_ -> SelectProvider prov)
           ]
-      , HH.text (" " <> label)
+      , HH.span
+          [ classNames [ "choice-copy" ] ]
+          [ HH.span
+              [ classNames [ "choice-title" ] ]
+              [ HH.text label ]
+          ]
       ]
 
   networkRadio state net label =
-    HH.label_
+    HH.label
+      [ choiceClass (state.network == net) ]
       [ HH.input
           [ HP.type_ HP.InputRadio
           , HP.name "network"
           , HP.checked (state.network == net)
           , HE.onChange (\_ -> SelectNetwork net)
           ]
-      , HH.text (" " <> label)
+      , HH.span
+          [ classNames [ "choice-title" ] ]
+          [ HH.text label ]
       ]
 
   renderModeTabs state =
-    HH.article_
-      [ HH.header_ [ HH.h2_ [ HH.text "Input" ] ]
-      , HH.fieldset_
+    HH.section
+      [ classNames [ "panel", "input-panel" ] ]
+      [ HH.div
+          [ classNames [ "panel-heading" ] ]
+          [ HH.h2_ [ HH.text "Input" ]
+          , HH.p_ [ HH.text "Fetch by transaction hash or paste raw CBOR hex." ]
+          ]
+      , HH.fieldset
+          [ classNames [ "control-group" ] ]
           [ HH.legend_ [ HH.text "Mode" ]
-          , modeRadio state ByHash "By tx hash"
-          , modeRadio state ByHex  "By CBOR hex"
+          , HH.div
+              [ classNames [ "mode-options" ] ]
+              [ modeRadio state ByHash "Tx hash"
+              , modeRadio state ByHex  "CBOR hex"
+              ]
           ]
       , renderBody state
       ]
 
   modeRadio state mode label =
-    HH.label_
+    HH.label
+      [ choiceClass (state.mode == mode) ]
       [ HH.input
           [ HP.type_ HP.InputRadio
           , HP.name "mode"
           , HP.checked (state.mode == mode)
           , HE.onChange (\_ -> SelectMode mode)
           ]
-      , HH.text (" " <> label)
+      , HH.span
+          [ classNames [ "choice-title" ] ]
+          [ HH.text label ]
       ]
 
   renderBody state = case state.mode of
     ByHash ->
-      HH.div_
+      HH.div
+        [ classNames [ "decode-form", "hash-form" ] ]
         [ HH.input
             [ HP.type_ HP.InputText
             , HP.placeholder "64-char tx hash"
@@ -275,20 +328,23 @@ inspectorComponent initial =
             ]
         , HH.button
             [ HP.disabled state.running
+            , classNames [ "primary-action" ]
             , HE.onClick (\_ -> Decode)
             ]
-            [ HH.text (if state.running then "Fetching & decoding..." else "Fetch & decode") ]
+            [ HH.text (if state.running then "Fetching..." else "Fetch and decode") ]
         ]
     ByHex ->
-      HH.div_
+      HH.div
+        [ classNames [ "decode-form" ] ]
         [ HH.textarea
             [ HP.value state.txHex
             , HP.placeholder "Conway tx CBOR hex..."
-            , HP.rows 8
+            , HP.rows 9
             , HE.onValueInput SetTxHex
             ]
         , HH.button
             [ HP.disabled state.running
+            , classNames [ "primary-action" ]
             , HE.onClick (\_ -> Decode)
             ]
             [ HH.text (if state.running then "Decoding..." else "Decode") ]
@@ -297,34 +353,60 @@ inspectorComponent initial =
   renderResult state =
     case state.fetchError of
       Just err ->
-        HH.article
-          [ HP.class_ (HH.ClassName "error") ]
-          [ HH.strong_ [ HH.text "Fetch error: " ]
-          , HH.text err
+        HH.section
+          [ classNames [ "panel", "result-panel", "error-panel" ] ]
+          [ HH.div
+              [ classNames [ "panel-heading" ] ]
+              [ HH.h2_ [ HH.text "Fetch error" ] ]
+          , HH.p_ [ HH.text err ]
           ]
       Nothing -> case state.result of
-        Nothing -> HH.text ""
+        Nothing ->
+          HH.section
+            [ classNames [ "panel", "result-panel", "empty-result" ] ]
+            [ HH.div
+                [ classNames [ "panel-heading" ] ]
+                [ HH.h2_ [ HH.text "Decoded JSON" ] ]
+            , HH.div
+                [ classNames [ "empty-state" ] ]
+                [ HH.text "No result yet." ]
+            ]
         Just r ->
-          HH.article_
-            [ HH.header_
+          HH.section
+            [ classNames [ "panel", "result-panel" ] ]
+            [ HH.div
+                [ classNames [ "panel-heading", "result-heading" ] ]
                 [ HH.h2_ [ HH.text (if r.exitOk then "Decoded JSON" else "Error") ]
                 , if r.exitOk
                     then
                       HH.button
                         [ HE.onClick (\_ -> Copy)
-                        , HP.class_ (HH.ClassName "secondary")
+                        , classNames [ "secondary-action" ]
                         ]
-                        [ HH.text (if state.copied then "Copied!" else "Copy JSON") ]
+                        [ HH.text (if state.copied then "Copied" else "Copy JSON") ]
                     else HH.text ""
                 ]
             , HH.pre_ [ HH.text (Json.pretty r.stdout) ]
             , if r.stderr == "" then HH.text ""
               else
-                HH.div_
+                HH.div
+                  [ classNames [ "stderr-block" ] ]
                   [ HH.h3_ [ HH.text "stderr" ]
                   , HH.pre_ [ HH.text r.stderr ]
                   ]
             ]
+
+  classNames :: forall r a. Array String -> HP.IProp (class :: String | r) a
+  classNames names = HP.classes (map HH.ClassName names)
+
+  choiceClass :: forall r a. Boolean -> HP.IProp (class :: String | r) a
+  choiceClass selected =
+    classNames
+      ( if selected then
+          [ "choice-option", "is-selected" ]
+        else
+          [ "choice-option" ]
+      )
 
   handleAction = case _ of
     SetBlockfrostKey s -> do

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -139,7 +139,6 @@ inspectorComponent initial =
           ]
       , renderProvider state
       , renderModeTabs state
-      , renderBody state
       , renderResult state
       ]
 

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -124,18 +124,18 @@ inspectorComponent initial =
 
   render state =
     HH.div_
-      [ HH.h1_ [ HH.text "Conway tx inspector" ]
-      , HH.p_
+      [ HH.p
+          [ HP.class_ (HH.ClassName "muted") ]
           [ HH.text
               "Decodes Cardano Conway-era transactions using the upstream Haskell ledger code "
           , HH.strong_ [ HH.text "unchanged" ]
-          , HH.text " — the same "
+          , HH.text " — same "
           , HH.code_ [ HH.text "cardano-ledger-conway" ]
           , HH.text " + "
           , HH.code_ [ HH.text "cardano-ledger-binary" ]
-          , HH.text " packages IntersectMBO ships for node and CLI, cross-compiled to "
+          , HH.text " that node and CLI use, cross-compiled to "
           , HH.code_ [ HH.text "wasm32-wasi" ]
-          , HH.text " and loaded in the browser via a WASI shim."
+          , HH.text " and loaded via a WASI shim."
           ]
       , renderProvider state
       , renderModeTabs state

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -33,16 +33,30 @@ koiosKey = "koios_bearer_token"
 providerKey :: String
 providerKey = "provider"
 
+persistKeysStorageKey :: String
+persistKeysStorageKey = "persist_api_keys"
+
 main :: Effect Unit
 main = HA.runHalogenAff do
-  body <- HA.awaitBody
-  bf   <- liftEffect (Storage.getItem blockfrostKey)
-  kOS  <- liftEffect (Storage.getItem koiosKey)
+  body    <- HA.awaitBody
+  persist <- liftEffect (Storage.getItem persistKeysStorageKey)
+  let persistInitial = persist == "true"
+  bf   <- liftEffect
+    (if persistInitial then Storage.getItem blockfrostKey else pure "")
+  kOS  <- liftEffect
+    (if persistInitial then Storage.getItem koiosKey else pure "")
   prov <- liftEffect (Storage.getItem providerKey)
   let initialProv = case prov of
         "Koios"      -> Koios
         _            -> Blockfrost
-  runUI (inspectorComponent { bf, koios: kOS, prov: initialProv }) unit body
+  runUI
+    ( inspectorComponent
+        { bf
+        , koios: kOS
+        , prov: initialProv
+        , persistKeys: persistInitial
+        }
+    ) unit body
 
 data Mode = ByHash | ByHex
 
@@ -52,6 +66,7 @@ type State =
   { provider :: Provider
   , blockfrostKey :: String
   , koiosBearer :: String
+  , persistKeys :: Boolean
   , mode :: Mode
   , network :: Network
   , txHash :: String
@@ -66,12 +81,14 @@ type InitialKeys =
   { bf :: String
   , koios :: String
   , prov :: Provider
+  , persistKeys :: Boolean
   }
 
 data Action
   = SetBlockfrostKey String
   | SetKoiosBearer String
   | SelectProvider Provider
+  | TogglePersist Boolean
   | SelectMode Mode
   | SelectNetwork Network
   | SetTxHash String
@@ -90,6 +107,7 @@ inspectorComponent initial =
         { provider: initial.prov
         , blockfrostKey: initial.bf
         , koiosBearer: initial.koios
+        , persistKeys: initial.persistKeys
         , mode: ByHash
         , network: Mainnet
         , txHash: ""
@@ -126,81 +144,85 @@ inspectorComponent initial =
       ]
 
   renderProvider state =
-    HH.div_
-      [ HH.h2_ [ HH.text "Chain data provider" ]
-      , HH.div
-          [ HP.style "margin-bottom: 0.5rem;" ]
-          [ HH.text "Source: "
-          , providerRadio state Blockfrost "Blockfrost (API key required)"
-          , providerRadio state Koios      "Koios (bearer token required in browser; free tier at koios.rest)"
-          ]
+    HH.article_
+      [ HH.header_ [ HH.h2_ [ HH.text "Chain data provider" ] ]
       , HH.p_
-          [ HH.text "Used only for the "
+          [ HH.text "Pick a provider. Both offer a free tier that needs a quick signup — paste the resulting credential below. Used only in the "
           , HH.strong_ [ HH.text "by tx hash" ]
-          , HH.text " mode. Keys are kept in your browser's localStorage; the CBOR never leaves your machine once fetched."
+          , HH.text " mode."
+          ]
+      , HH.fieldset_
+          [ HH.legend_ [ HH.text "Source" ]
+          , providerRadio state Blockfrost "Blockfrost"
+          , providerRadio state Koios      "Koios"
           ]
       , case state.provider of
           Blockfrost ->
-            HH.div_
-              [ HH.input
-                  [ HP.type_ HP.InputText
-                  , HP.placeholder "Blockfrost project_id (mainnet.../preprod.../preview...)"
+            HH.label_
+              [ HH.text "Blockfrost project ID (free tier at "
+              , HH.a
+                  [ HP.href "https://blockfrost.io/auth/signup"
+                  , HP.target "_blank"
+                  , HP.rel "noopener noreferrer"
+                  ]
+                  [ HH.text "blockfrost.io signup" ]
+              , HH.text ")"
+              , HH.input
+                  [ HP.type_ HP.InputPassword
+                  , HP.placeholder "mainnet... / preprod... / preview..."
                   , HP.value state.blockfrostKey
                   , HE.onValueInput SetBlockfrostKey
-                  , HP.style "width: 100%; font-family: ui-monospace, monospace;"
-                  ]
-              , HH.p
-                  [ HP.style "margin-top: 0.25rem; font-size: 0.85rem; color: #555;" ]
-                  [ HH.text "Free tier at "
-                  , HH.a
-                      [ HP.href "https://blockfrost.io/"
-                      , HP.target "_blank"
-                      , HP.rel "noopener noreferrer"
-                      ]
-                      [ HH.text "blockfrost.io" ]
-                  , HH.text "."
                   ]
               ]
           Koios ->
-            HH.div_
-              [ HH.input
-                  [ HP.type_ HP.InputText
-                  , HP.placeholder "Koios bearer token (required for browser use)"
+            HH.label_
+              [ HH.text "Koios bearer token (free tier at "
+              , HH.a
+                  [ HP.href "https://koios.rest/auth/Auth.html"
+                  , HP.target "_blank"
+                  , HP.rel "noopener noreferrer"
+                  ]
+                  [ HH.text "koios.rest auth" ]
+              , HH.text ")"
+              , HH.input
+                  [ HP.type_ HP.InputPassword
+                  , HP.placeholder "eyJhbGciOi..."
                   , HP.value state.koiosBearer
                   , HE.onValueInput SetKoiosBearer
-                  , HP.style "width: 100%; font-family: ui-monospace, monospace;"
-                  ]
-              , HH.p
-                  [ HP.style "margin-top: 0.25rem; font-size: 0.85rem; color: #555;" ]
-                  [ HH.text "Koios intentionally strips CORS on unauthenticated requests (see "
-                  , HH.a
-                      [ HP.href "https://github.com/cardano-community/koios-artifacts/issues/397"
-                      , HP.target "_blank"
-                      , HP.rel "noopener noreferrer"
-                      ]
-                      [ HH.text "issue #397" ]
-                  , HH.text "). Free bearer tokens at "
-                  , HH.a
-                      [ HP.href "https://koios.rest/pricing/Pricing.html"
-                      , HP.target "_blank"
-                      , HP.rel "noopener noreferrer"
-                      ]
-                      [ HH.text "koios.rest/pricing" ]
-                  , HH.text " — the free tier covers 50k req/day. Without a token, use the CLI script and paste in 'By CBOR hex' mode."
                   ]
               ]
-      , HH.div
-          [ HP.style "margin-top: 0.5rem; font-size: 0.9rem;" ]
-          [ HH.text "Network: "
+      , HH.fieldset_
+          [ HH.legend_ [ HH.text "Network" ]
           , networkRadio state Mainnet "mainnet"
           , networkRadio state Preprod "preprod"
           , networkRadio state Preview "preview"
           ]
+      , renderPersistToggle state
+      ]
+
+  renderPersistToggle state =
+    HH.fieldset_
+      [ HH.label_
+          [ HH.input
+              [ HP.type_ HP.InputCheckbox
+              , HH.attr (HH.AttrName "role") "switch"
+              , HP.checked state.persistKeys
+              , HE.onChecked TogglePersist
+              ]
+          , HH.text " Persist API credentials across sessions"
+          ]
+      , HH.small
+          [ HP.class_ (HH.ClassName "warning") ]
+          [ HH.text
+              "⚠ When enabled, the credential is saved in your browser's localStorage "
+          , HH.strong_ [ HH.text "in cleartext" ]
+          , HH.text
+              ". Any JavaScript running on this origin (including future updates of this page) can read it. When disabled (default), the credential stays in memory only and is lost on reload."
+          ]
       ]
 
   providerRadio state prov label =
-    HH.label
-      [ HP.style "margin-right: 1rem; cursor: pointer;" ]
+    HH.label_
       [ HH.input
           [ HP.type_ HP.InputRadio
           , HP.name "provider"
@@ -211,8 +233,7 @@ inspectorComponent initial =
       ]
 
   networkRadio state net label =
-    HH.label
-      [ HP.style "margin-right: 1rem; cursor: pointer;" ]
+    HH.label_
       [ HH.input
           [ HP.type_ HP.InputRadio
           , HP.name "network"
@@ -223,25 +244,26 @@ inspectorComponent initial =
       ]
 
   renderModeTabs state =
-    HH.div
-      [ HP.style "margin-top: 1.5rem;" ]
-      [ HH.h2_ [ HH.text "Input" ]
-      , HH.div_
-          [ modeButton state ByHash "By tx hash"
-          , modeButton state ByHex  "By CBOR hex"
+    HH.article_
+      [ HH.header_ [ HH.h2_ [ HH.text "Input" ] ]
+      , HH.fieldset_
+          [ HH.legend_ [ HH.text "Mode" ]
+          , modeRadio state ByHash "By tx hash"
+          , modeRadio state ByHex  "By CBOR hex"
           ]
+      , renderBody state
       ]
 
-  modeButton state mode label =
-    HH.button
-      [ HE.onClick (\_ -> SelectMode mode)
-      , HP.style (
-          "margin-right: 0.5rem; padding: 0.35rem 0.75rem; font-size: 0.9rem; "
-            <> (if state.mode == mode
-                 then "border: 1px solid #333; background: #eee;"
-                 else "border: 1px solid #ccc; background: transparent;"))
+  modeRadio state mode label =
+    HH.label_
+      [ HH.input
+          [ HP.type_ HP.InputRadio
+          , HP.name "mode"
+          , HP.checked (state.mode == mode)
+          , HE.onChange (\_ -> SelectMode mode)
+          ]
+      , HH.text (" " <> label)
       ]
-      [ HH.text label ]
 
   renderBody state = case state.mode of
     ByHash ->
@@ -251,15 +273,12 @@ inspectorComponent initial =
             , HP.placeholder "64-char tx hash"
             , HP.value state.txHash
             , HE.onValueInput SetTxHash
-            , HP.style "width: 100%; font-family: ui-monospace, monospace;"
             ]
-        , HH.div_
-            [ HH.button
-                [ HP.disabled state.running
-                , HE.onClick (\_ -> Decode)
-                ]
-                [ HH.text (if state.running then "Fetching & decoding..." else "Fetch & decode") ]
+        , HH.button
+            [ HP.disabled state.running
+            , HE.onClick (\_ -> Decode)
             ]
+            [ HH.text (if state.running then "Fetching & decoding..." else "Fetch & decode") ]
         ]
     ByHex ->
       HH.div_
@@ -269,34 +288,32 @@ inspectorComponent initial =
             , HP.rows 8
             , HE.onValueInput SetTxHex
             ]
-        , HH.div_
-            [ HH.button
-                [ HP.disabled state.running
-                , HE.onClick (\_ -> Decode)
-                ]
-                [ HH.text (if state.running then "Decoding..." else "Decode") ]
+        , HH.button
+            [ HP.disabled state.running
+            , HE.onClick (\_ -> Decode)
             ]
+            [ HH.text (if state.running then "Decoding..." else "Decode") ]
         ]
 
   renderResult state =
     case state.fetchError of
       Just err ->
-        HH.div
-          [ HP.style "color: #b00; margin-top: 1rem;" ]
+        HH.article
+          [ HP.class_ (HH.ClassName "error") ]
           [ HH.strong_ [ HH.text "Fetch error: " ]
           , HH.text err
           ]
       Nothing -> case state.result of
         Nothing -> HH.text ""
         Just r ->
-          HH.div_
-            [ HH.div_
+          HH.article_
+            [ HH.header_
                 [ HH.h2_ [ HH.text (if r.exitOk then "Decoded JSON" else "Error") ]
                 , if r.exitOk
                     then
                       HH.button
                         [ HE.onClick (\_ -> Copy)
-                        , HP.style "margin-left: 1rem; font-size: 0.875rem;"
+                        , HP.class_ (HH.ClassName "secondary")
                         ]
                         [ HH.text (if state.copied then "Copied!" else "Copy JSON") ]
                     else HH.text ""
@@ -305,7 +322,7 @@ inspectorComponent initial =
             , if r.stderr == "" then HH.text ""
               else
                 HH.div_
-                  [ HH.h2_ [ HH.text "stderr" ]
+                  [ HH.h3_ [ HH.text "stderr" ]
                   , HH.pre_ [ HH.text r.stderr ]
                   ]
             ]
@@ -313,13 +330,27 @@ inspectorComponent initial =
   handleAction = case _ of
     SetBlockfrostKey s -> do
       H.modify_ _ { blockfrostKey = s }
-      liftEffect (Storage.setItem blockfrostKey s)
+      persist <- H.gets _.persistKeys
+      when persist (liftEffect (Storage.setItem blockfrostKey s))
     SetKoiosBearer s -> do
       H.modify_ _ { koiosBearer = s }
-      liftEffect (Storage.setItem koiosKey s)
+      persist <- H.gets _.persistKeys
+      when persist (liftEffect (Storage.setItem koiosKey s))
     SelectProvider p -> do
       H.modify_ _ { provider = p, fetchError = Nothing }
       liftEffect (Storage.setItem providerKey (Provider.providerName p))
+    TogglePersist on -> do
+      H.modify_ _ { persistKeys = on }
+      liftEffect (Storage.setItem persistKeysStorageKey (if on then "true" else "false"))
+      st <- H.get
+      liftEffect
+        if on
+          then do
+            Storage.setItem blockfrostKey st.blockfrostKey
+            Storage.setItem koiosKey st.koiosBearer
+          else do
+            Storage.setItem blockfrostKey ""
+            Storage.setItem koiosKey ""
     SelectMode m -> H.modify_ _ { mode = m, fetchError = Nothing }
     SelectNetwork n -> H.modify_ _ { network = n, fetchError = Nothing }
     SetTxHash s -> H.modify_ _ { txHash = s, copied = false, fetchError = Nothing }
@@ -347,7 +378,7 @@ inspectorComponent initial =
                           diag = case st.provider of
                             Koios | raw == "Failed to fetch" ->
                               if String.trim st.koiosBearer == ""
-                                then "Koios blocks anonymous browser requests by design (CORS stripped). Register at koios.rest/pricing for a free bearer token (50k req/day), paste it above, and retry. Or use scripts/fetch-tx-cbor.sh <hash> locally and paste the hex."
+                                then "Koios blocks anonymous browser requests by design. Sign up (free) at koios.rest/auth, paste the bearer token above, and retry."
                                 else "Koios rejected the request. Check the bearer token is valid and the network matches (mainnet/preprod/preview)."
                             _ -> raw
                       in pure (Left diag)

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -132,7 +132,7 @@ inspectorComponent initial =
           [ HP.style "margin-bottom: 0.5rem;" ]
           [ HH.text "Source: "
           , providerRadio state Blockfrost "Blockfrost (API key required)"
-          , providerRadio state Koios      "Koios (keyless, rate-limited)"
+          , providerRadio state Koios      "Koios (keyless — CORS-blocked in browser; works from CLI)"
           ]
       , HH.p_
           [ HH.text "Used only for the "
@@ -335,7 +335,13 @@ inspectorComponent initial =
                 else do
                   e <- H.liftAff (attempt (Provider.fetchTxCbor st.provider st.network key trimmedHash))
                   case e of
-                    Left err -> pure (Left (message err))
+                    Left err ->
+                      let raw = message err
+                          diag = case st.provider of
+                            Koios | raw == "Failed to fetch" ->
+                              "Koios is blocked by browser CORS (server doesn't echo ACAO on POST responses). Use CLI: scripts/fetch-tx-cbor.sh <hash>, then paste the hex in 'By CBOR hex' mode. Or switch to Blockfrost."
+                            _ -> raw
+                      in pure (Left diag)
                     Right cbor -> pure (Right cbor)
       case hexE of
         Left err -> H.modify_ _ { running = false, fetchError = Just err }

--- a/docs/inspector/src/Provider.purs
+++ b/docs/inspector/src/Provider.purs
@@ -1,0 +1,37 @@
+module Provider
+  ( Provider(..)
+  , providerName
+  , needsKey
+  , fetchTxCbor
+  ) where
+
+import Prelude
+
+import Effect.Aff (Aff)
+import FFI.Blockfrost (Network)
+import FFI.Blockfrost as Blockfrost
+import FFI.Koios as Koios
+
+data Provider = Blockfrost | Koios
+
+derive instance eqProvider :: Eq Provider
+
+providerName :: Provider -> String
+providerName = case _ of
+  Blockfrost -> "Blockfrost"
+  Koios      -> "Koios"
+
+-- | Blockfrost requires a project ID. Koios accepts an optional bearer
+-- token for higher rate limits; it works without one, so the key field
+-- is optional.
+needsKey :: Provider -> Boolean
+needsKey = case _ of
+  Blockfrost -> true
+  Koios      -> false
+
+-- | Unified fetch. `key` is the project ID for Blockfrost or an optional
+-- bearer token for Koios (empty string = no auth).
+fetchTxCbor :: Provider -> Network -> String -> String -> Aff String
+fetchTxCbor = case _ of
+  Blockfrost -> Blockfrost.fetchTxCbor
+  Koios      -> Koios.fetchTxCbor

--- a/flake.nix
+++ b/flake.nix
@@ -110,32 +110,70 @@
             default = project.shell;
 
             # Fast-iteration shell for the wasm-tx-inspector Haskell source.
-            # Mounts the locked FOD deps cache + the wasm32-wasi toolchain, so
-            # editing Inspector.hs + running `wasm32-wasi-cabal build` inside
-            # docs/wasm/tx-inspector rebuilds in seconds (dist-newstyle stays
-            # warm between invocations, no Nix sandbox re-entry).
+            #
+            # Mounts prebuiltDeps (compiled full ledger closure, patched
+            # project file with SRP forks inlined, precompiled dist-newstyle)
+            # plus the wasm32-wasi toolchain. `wasm32-wasi-cabal build` uses
+            # the precompiled libs — only Inspector.hs recompiles.
+            #
+            # First run populates a host-writable workspace under
+            # $WASM_DEV_WORKSPACE; subsequent edits rebuild in seconds
+            # because dist-newstyle stays warm between shell sessions.
             #
             # Usage:
             #   nix develop .#wasm-dev
-            #   cd nix/wasm/tx-inspector
-            #   export CABAL_DIR=$WASM_CABAL_DIR
+            #   cd $WASM_DEV_WORKSPACE
             #   wasm32-wasi-cabal --project-file=cabal-wasm.project build wasm-tx-inspector
-            wasm-dev = pkgs.mkShell {
-              buildInputs = [
-                ghc-wasm-meta.packages.${system}.all_9_12
-                ghc-wasm-meta.packages.${system}.wasi-sdk
-                pkgs.just
-                pkgs.pkg-config
-                pkgs.wasmtime
-              ] ++ wasmTargets.wasm-tx-inspector.passthru.deps.nativeBuildInputs or [];
+            wasm-dev =
+              let
+                preBuilt = wasmTargets.wasm-tx-inspector.passthru.prebuiltDeps;
+                txInspectorSrc = ./nix/wasm/tx-inspector;
+                cLibsLib = [
+                  "${ghc-wasm-meta.packages.${system}.wasi-sdk}"
+                ];
+              in
+              pkgs.mkShell {
+                buildInputs = [
+                  ghc-wasm-meta.packages.${system}.all_9_12
+                  ghc-wasm-meta.packages.${system}.wasi-sdk
+                  pkgs.just
+                  pkgs.pkg-config
+                  pkgs.wasmtime
+                ];
 
-              shellHook = ''
-                export WASM_CABAL_DIR="${wasmTargets.wasm-tx-inspector.passthru.deps}"
-                echo "wasm-tx-inspector dev shell ready."
-                echo "  WASM_CABAL_DIR=$WASM_CABAL_DIR   (locked FOD deps cache)"
-                echo "  tools: wasm32-wasi-ghc, wasm32-wasi-cabal, wasi-sdk, wasmtime"
-              '';
-            };
+                shellHook = ''
+                  export WASM_PREBUILT_DEPS="${preBuilt}"
+                  export WASM_DEV_WORKSPACE="$PWD/.wasm-dev-workspace"
+
+                  if [ ! -d "$WASM_DEV_WORKSPACE" ]; then
+                    echo "wasm-dev: materializing workspace from prebuiltDeps (first run)..."
+                    mkdir -p "$WASM_DEV_WORKSPACE"
+                    cp -rL ${txInspectorSrc}/* "$WASM_DEV_WORKSPACE/"
+                    chmod -R u+w "$WASM_DEV_WORKSPACE"
+                    # Replace the SRP-laden project file with the pre-patched
+                    # one from prebuiltDeps (SRP stanzas already rewritten to
+                    # nix-store `packages:` paths).
+                    cp -L "$WASM_PREBUILT_DEPS/cabal-wasm.project" \
+                          "$WASM_DEV_WORKSPACE/cabal-wasm.project"
+                    # Seed dist-newstyle with the pre-compiled library graph.
+                    cp -rL "$WASM_PREBUILT_DEPS/dist-newstyle" \
+                           "$WASM_DEV_WORKSPACE/dist-newstyle"
+                    chmod -R u+w "$WASM_DEV_WORKSPACE"
+                    echo "wasm-dev: workspace ready at $WASM_DEV_WORKSPACE"
+                  fi
+
+                  export CABAL_DIR="$WASM_DEV_WORKSPACE/.cabal"
+                  if [ ! -d "$CABAL_DIR" ]; then
+                    cp -rL "$WASM_PREBUILT_DEPS/cabal" "$CABAL_DIR"
+                    chmod -R u+w "$CABAL_DIR"
+                  fi
+
+                  echo "wasm-tx-inspector dev shell ready."
+                  echo "  WASM_DEV_WORKSPACE=$WASM_DEV_WORKSPACE  (edit here; dist-newstyle stays warm)"
+                  echo "  CABAL_DIR=$CABAL_DIR                   (compiled deps cache)"
+                  echo "  cd \$WASM_DEV_WORKSPACE && wasm32-wasi-cabal --project-file=cabal-wasm.project build wasm-tx-inspector"
+                '';
+              };
           };
         };
     };

--- a/nix/wasm/mkCardanoLedgerWasm.nix
+++ b/nix/wasm/mkCardanoLedgerWasm.nix
@@ -128,7 +128,21 @@ let
     EOF
   '';
 
+  # Metadata-only filter: .cabal files + the wasm project file.
+  # Deliberately excludes .hs sources so the derivation hash of anything
+  # consuming `srcMetadata` is stable across Haskell edits.
+  #
+  # CRITICAL: set `name` to match the underlying src's final path component
+  # so the extracted sandbox path (`/build/<name>`) is identical between
+  # prebuiltDeps and wasm. Cabal bakes absolute paths into dist-newstyle
+  # metadata and compiled artifacts; mismatched sandbox paths cause cabal
+  # to treat the cached compile as stale and rebuild the whole closure.
+  #
+  # `cleanSourceWith` defaults `name` to "source" when not set, regardless
+  # of the underlying src's directory name — that's what broke the cache in
+  # the first attempt.
   srcMetadata = lib.cleanSourceWith {
+    name = builtins.baseNameOf (toString src);
     inherit src;
     filter = name: type:
       let baseName = baseNameOf (toString name);
@@ -240,6 +254,73 @@ let
     outputHash = dependenciesHash;
   };
 
+  # prebuiltDeps: compile the full ledger-closure library graph once.
+  #
+  # Input: srcMetadata (cabal files + project file only — NO .hs files) + the
+  # FOD deps tarball cache. Output: $out = a full $CABAL_DIR plus dist-newstyle
+  # tree with every dependency library already compiled for wasm32-wasi, plus
+  # the patched project file with SRP stanzas rewritten to local `packages:`.
+  #
+  # Because src is metadata-only, this derivation's hash is stable across
+  # Haskell source edits — rebuilds only when cabal files / project file /
+  # forks.json / ghc-wasm-meta / c-libs change.
+  #
+  # This is a regular (non-FOD) derivation: the compile output is not
+  # reproducible byte-for-byte across machines (GHC WASM is non-deterministic),
+  # but Nix's regular content-addressing caches it per-machine and per-team
+  # Cachix — good enough for incremental iteration. Only the exe compile +
+  # link in the downstream `wasm` derivation re-runs on Haskell source edits.
+  prebuiltDeps = pkgs.stdenv.mkDerivation {
+    pname = "cardano-ledger-wasm-prebuilt-deps";
+    version = "0.1.0";
+    src = srcMetadata;
+
+    nativeBuildInputs = [ ghcWasmMeta pkgs.git ] ++ cLibsInputs;
+
+    configurePhase = ''
+      export HOME=$NIX_BUILD_TOP/home
+      mkdir -p $HOME
+      ${lib.optionalString (cLibs != null) "export PKG_CONFIG_PATH=${cLibsPkgConfigPath}"}
+
+      export CABAL_DIR=$NIX_BUILD_TOP/cabal
+      mkdir -p $CABAL_DIR
+      cp -rL ${deps}/* $CABAL_DIR/
+      chmod -R u+w $CABAL_DIR
+
+      # Rewrite source-repository-package stanzas to packages: <store-path>
+      # once, here, so both prebuiltDeps (this derivation) and the downstream
+      # wasm derivation share the same patched project file.
+      sed -i '/^source-repository-package/,/^$/d' ${projectFile}
+      cat >> ${projectFile} <<'EOF'
+      ${forkPackagesBlock}
+      EOF
+    '';
+
+    buildPhase = ''
+      export CABAL_DIR=$NIX_BUILD_TOP/cabal
+      ${lib.optionalString (cLibs != null) "export PKG_CONFIG_PATH=${cLibsPkgConfigPath}"}
+      wasm32-wasi-cabal --project-file=${projectFile} build \
+        --only-dependencies \
+        ${cabalExtraDirsArgs} \
+        ${buildTargetsArg}
+    '';
+
+    installPhase = ''
+      mkdir -p $out
+      cp -rL $CABAL_DIR $out/cabal
+      cp -rL dist-newstyle $out/dist-newstyle
+      # Preserve the patched project file so the wasm phase can reuse it.
+      cp ${projectFile} $out/${projectFile}
+      chmod -R u+w $out
+    '';
+  };
+
+  # wasm: compile the inspector exe against prebuiltDeps' compiled closure.
+  #
+  # Input: the FULL source tree (including .hs) + prebuiltDeps output.
+  # Haskell source edits rehash THIS derivation only; prebuiltDeps is reused
+  # from the cache, so the ledger closure does not recompile. Expected rebuild
+  # time on Inspector.hs edits: 1-3 minutes (inspector lib + exe + link).
   wasm = pkgs.stdenv.mkDerivation {
     pname = "cardano-ledger-wasm";
     version = "0.1.0";
@@ -254,16 +335,19 @@ let
 
       export CABAL_DIR=$NIX_BUILD_TOP/cabal
       mkdir -p $CABAL_DIR
-      cp -rL ${deps}/* $CABAL_DIR/
+      cp -rL ${prebuiltDeps}/cabal/* $CABAL_DIR/
       chmod -R u+w $CABAL_DIR
 
-      # Replace source-repository-package stanzas with direct package paths
-      # pointing at pre-fetched nix store clones, so the offline build phase
-      # does not need network to clone forks.
-      sed -i '/^source-repository-package/,/^$/d' ${projectFile}
-      cat >> ${projectFile} <<'EOF'
-      ${forkPackagesBlock}
-      EOF
+      # Reuse the compiled dist-newstyle from prebuiltDeps; cabal sees the
+      # library deps as already up-to-date and skips their rebuild.
+      cp -rL ${prebuiltDeps}/dist-newstyle dist-newstyle
+      chmod -R u+w dist-newstyle
+
+      # Drop the consumer's source project file; use the patched one from
+      # prebuiltDeps so SRP stanzas are already rewritten to packages: paths.
+      rm -f ${projectFile}
+      cp ${prebuiltDeps}/${projectFile} ${projectFile}
+      chmod u+w ${projectFile}
     '';
 
     buildPhase = ''
@@ -283,7 +367,7 @@ let
     '';
 
     passthru = {
-      inherit deps;
+      inherit deps prebuiltDeps;
       forks = forks;
     };
   };

--- a/nix/wasm/tx-inspector/wasm-tx-inspector/app/Main.hs
+++ b/nix/wasm/tx-inspector/wasm-tx-inspector/app/Main.hs
@@ -1,30 +1,33 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | WASI reactor entry: read Conway tx hex on stdin, write JSON on stdout.
---   Error category on stderr, non-zero exit, no partial JSON on stdout.
+{- | WASI reactor entry: read either raw Conway tx hex or a JSON RPC envelope
+  on stdin, write JSON on stdout. Error category on stderr, non-zero exit,
+  no partial JSON on stdout.
+-}
 module Main (main) where
 
-import qualified Conway.Inspector       as Inspector
-import qualified Data.Aeson             as Aeson
-import qualified Data.ByteString        as BS
-import qualified Data.ByteString.Char8  as BS8
-import qualified Data.ByteString.Lazy   as BSL
-import           System.Exit            (exitFailure, exitSuccess)
-import           System.IO              (hPutStrLn, stderr, stdout)
+import qualified Conway.Inspector as Inspector
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Text as T
+import System.Exit (exitFailure, exitSuccess)
+import System.IO (hPutStrLn, stderr, stdout)
 
 main :: IO ()
 main = do
     input <- BS.getContents
-    case Inspector.inspect (stripNewlines input) of
+    case Inspector.rpc input of
         Left (Inspector.MalformedHex err) -> die "malformed_hex" err
         Left (Inspector.MalformedCbor err) -> die "malformed_cbor" err
+        Left (Inspector.MalformedRpc err) -> die "malformed_rpc" err
+        Left (Inspector.UnknownRpcMethod method) ->
+            die "unknown_rpc_method" (T.unpack method)
         Right value -> do
             BSL.hPut stdout (Aeson.encode value)
             BSL.hPut stdout "\n"
             exitSuccess
   where
-    stripNewlines = BS.filter (\c -> c /= 0x0a && c /= 0x0d && c /= 0x20 && c /= 0x09)
-
     die category detail = do
         hPutStrLn stderr (category <> ": " <> detail)
         exitFailure

--- a/nix/wasm/tx-inspector/wasm-tx-inspector/src/Conway/Inspector.hs
+++ b/nix/wasm/tx-inspector/wasm-tx-inspector/src/Conway/Inspector.hs
@@ -1,55 +1,122 @@
-{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeApplications #-}
 
--- | Conway transaction inspector.
---
---   Decoder-only: no signature checking, no script evaluation, no fee
---   validation. The hard work (CBOR → Conway `Tx`) is delegated to the
---   upstream Haskell ledger packages; this module only projects the decoded
---   value into a lossy human-oriented JSON.
-module Conway.Inspector
-    ( inspect
-    , InspectError(..)
-    ) where
+{- | Conway transaction inspector.
 
-import qualified Cardano.Crypto.Hash            as Crypto
-import qualified Cardano.Ledger.Address         as Addr
-import qualified Cardano.Ledger.Api             as L
-import qualified Cardano.Ledger.BaseTypes       as BaseTypes
-import qualified Cardano.Ledger.Binary          as Binary
-import qualified Cardano.Ledger.Coin            as Coin
-import qualified Cardano.Ledger.Conway          as Conway
-import           Cardano.Ledger.Core            (TxLevel (..))
-import qualified Cardano.Ledger.Hashes          as Hashes
-import qualified Cardano.Ledger.Mary.Value      as Mary
-import qualified Cardano.Ledger.Plutus.Data     as PData
-import qualified Cardano.Ledger.TxIn            as TxIn
-import           Data.Aeson                     ((.=))
-import qualified Data.Aeson                     as Aeson
-import qualified Data.Aeson.Key                 as AesonKey
-import qualified Data.Aeson.KeyMap              as KeyMap
-import qualified Data.ByteString                as BS
-import qualified Data.ByteString.Base16         as B16
-import qualified Data.ByteString.Lazy           as BSL
-import qualified Data.ByteString.Short          as SBS
-import           Data.Foldable                  (toList)
-import qualified Data.Map.Strict                as Map
-import qualified Data.Text                      as T
-import qualified Data.Text.Encoding             as T
-import           Lens.Micro                     ((^.))
+  Decoder-only: no signature checking, no script evaluation, no fee
+  validation. The hard work (CBOR → Conway `Tx`) is delegated to the
+  upstream Haskell ledger packages. Browser-facing calls use a small RPC
+  envelope so each UI interaction can go back through the ledger value
+  instead of navigating a stale client-side JSON projection.
+-}
+module Conway.Inspector (
+    inspect,
+    rpc,
+    InspectError (..),
+) where
+
+import qualified Cardano.Crypto.Hash as Crypto
+import qualified Cardano.Ledger.Address as Addr
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as BaseTypes
+import qualified Cardano.Ledger.Binary as Binary
+import qualified Cardano.Ledger.Coin as Coin
+import qualified Cardano.Ledger.Conway as Conway
+import Cardano.Ledger.Core (TxLevel (..))
+import qualified Cardano.Ledger.Hashes as Hashes
+import qualified Cardano.Ledger.Mary.Value as Mary
+import qualified Cardano.Ledger.Plutus.Data as PData
+import qualified Cardano.Ledger.TxIn as TxIn
+import Control.Monad ((>=>))
+import Data.Aeson ((.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as AesonKey
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString.Short as SBS
+import Data.Foldable (toList)
+import Data.List (stripPrefix)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import Lens.Micro ((^.))
+import Text.Read (readMaybe)
 
 data InspectError
     = MalformedHex String
     | MalformedCbor String
+    | MalformedRpc String
+    | UnknownRpcMethod T.Text
     deriving (Show)
+
+data RpcRequest = RpcRequest
+    { rrTxCbor :: T.Text
+    , rrMethod :: T.Text
+    , rrPath :: [T.Text]
+    }
+
+instance Aeson.FromJSON RpcRequest where
+    parseJSON = Aeson.withObject "RpcRequest" $ \o ->
+        RpcRequest
+            <$> o Aeson..: "tx_cbor"
+            <*> o Aeson..: "method"
+            <*> o Aeson..:? "path" Aeson..!= []
 
 -- | Hex → bytes → Conway tx → JSON.
 inspect :: BS.ByteString -> Either InspectError Aeson.Value
 inspect hexBytes = do
-    raw <- hexDecode hexBytes
-    tx  <- decodeConway (BSL.fromStrict raw)
+    tx <- decodeTx hexBytes
     pure (renderTx tx)
+
+{- | Browser/runtime RPC. If stdin is not a JSON RPC request, fall back to the
+  legacy raw-CBOR inspection path used by CLI recipes.
+-}
+rpc :: BS.ByteString -> Either InspectError Aeson.Value
+rpc input =
+    case Aeson.eitherDecodeStrict' input of
+        Right request -> runRpc request
+        Left err
+            | looksLikeRpc input -> Left (MalformedRpc err)
+            | otherwise -> inspect input
+
+looksLikeRpc :: BS.ByteString -> Bool
+looksLikeRpc input =
+    case BS.dropWhile isJsonWhitespace input of
+        bs | BS.null bs -> False
+        bs -> BS.head bs == 0x7b
+  where
+    isJsonWhitespace c = c == 0x20 || c == 0x09 || c == 0x0a || c == 0x0d
+
+runRpc :: RpcRequest -> Either InspectError Aeson.Value
+runRpc request = do
+    tx <- decodeTx (T.encodeUtf8 (rrTxCbor request))
+    case rrMethod request of
+        "inspect" ->
+            pure $
+                Aeson.object
+                    [ "rpc" .= ("conway-tx-inspector/v1" :: T.Text)
+                    , "method" .= rrMethod request
+                    , "inspection" .= renderTx tx
+                    , "browser" .= browserJson tx (rrPath request)
+                    ]
+        "browse" ->
+            pure $
+                Aeson.object
+                    [ "rpc" .= ("conway-tx-inspector/v1" :: T.Text)
+                    , "method" .= rrMethod request
+                    , "browser" .= browserJson tx (rrPath request)
+                    ]
+        other -> Left (UnknownRpcMethod other)
+
+decodeTx ::
+    BS.ByteString ->
+    Either InspectError (L.Tx TopTx Conway.ConwayEra)
+decodeTx =
+    hexDecode >=> decodeConway . BSL.fromStrict
 
 hexDecode :: BS.ByteString -> Either InspectError BS.ByteString
 hexDecode bs =
@@ -65,78 +132,215 @@ decodeConway bs =
         Left err -> Left (MalformedCbor (show err))
         Right tx -> Right tx
 
+browserJson ::
+    L.Tx TopTx Conway.ConwayEra ->
+    [T.Text] ->
+    Aeson.Value
+browserJson tx requestedPath =
+    let root = renderTx tx
+        current = valueAt root requestedPath
+        path = if current == Nothing then [] else requestedPath
+        value = fromMaybe root current
+        breadcrumbs = breadcrumbsFor path
+        currentLabel = case reverse breadcrumbs of
+            Aeson.Object crumb : _ ->
+                case KeyMap.lookup "label" crumb of
+                    Just (Aeson.String label) -> label
+                    _ -> "tx"
+            _ -> "tx"
+        kind = kindOf value
+     in Aeson.object
+            [ "valid" .= True
+            , "title" .= currentLabel
+            , "subtitle"
+                .= if kind == "array" || kind == "object"
+                    then kind <> " / " <> valueSummary value
+                    else kind
+            , "currentPath" .= encodePath path
+            , "currentJson" .= copyText value
+            , "breadcrumbs" .= breadcrumbs
+            , "rows" .= browserRows path value
+            ]
+
+valueAt :: Aeson.Value -> [T.Text] -> Maybe Aeson.Value
+valueAt = foldl step . Just
+  where
+    step Nothing _ = Nothing
+    step (Just (Aeson.Object o)) key =
+        KeyMap.lookup (AesonKey.fromText key) o
+    step (Just (Aeson.Array a)) key = do
+        ix <- pathIndex key
+        listAt ix (toList a)
+    step _ _ = Nothing
+
+listAt :: Int -> [a] -> Maybe a
+listAt index xs
+    | index < 0 = Nothing
+    | otherwise = case drop index xs of
+        value : _ -> Just value
+        [] -> Nothing
+
+pathIndex :: T.Text -> Maybe Int
+pathIndex =
+    stripPrefix "#" . T.unpack >=> readMaybe
+
+kindOf :: Aeson.Value -> T.Text
+kindOf Aeson.Null = "null"
+kindOf (Aeson.Bool _) = "boolean"
+kindOf (Aeson.Number _) = "number"
+kindOf (Aeson.String _) = "string"
+kindOf (Aeson.Array _) = "array"
+kindOf (Aeson.Object _) = "object"
+
+valueSummary :: Aeson.Value -> T.Text
+valueSummary (Aeson.Array a) =
+    plural (length (toList a)) "item"
+valueSummary (Aeson.Object o) =
+    plural (length (KeyMap.toList o)) "field"
+valueSummary (Aeson.String t) =
+    shortText t
+valueSummary Aeson.Null =
+    "null"
+valueSummary value =
+    copyText value
+
+plural :: Int -> T.Text -> T.Text
+plural n label =
+    T.pack (show n) <> " " <> label <> if n == 1 then "" else "s"
+
+shortText :: T.Text -> T.Text
+shortText text =
+    let limit = 56
+     in if T.length text <= limit
+            then text
+            else T.take 40 text <> "..." <> T.takeEnd 12 text
+
+copyText :: Aeson.Value -> T.Text
+copyText (Aeson.String t) = t
+copyText value =
+    T.decodeUtf8 (BSL.toStrict (Aeson.encode value))
+
+browserRows :: [T.Text] -> Aeson.Value -> [Aeson.Value]
+browserRows parentPath (Aeson.Array a) =
+    [ browserRow parentPath (T.pack ("#" <> show ix)) child
+    | (ix, child) <- zip [0 :: Int ..] (toList a)
+    ]
+browserRows parentPath (Aeson.Object o) =
+    [ browserRow parentPath (AesonKey.toText key) child
+    | (key, child) <- KeyMap.toList o
+    ]
+browserRows _ _ =
+    []
+
+browserRow :: [T.Text] -> T.Text -> Aeson.Value -> Aeson.Value
+browserRow parentPath label value =
+    let path = parentPath <> [label]
+     in Aeson.object
+            [ "label" .= label
+            , "path" .= encodePath path
+            , "kind" .= kindOf value
+            , "summary" .= valueSummary value
+            , "copyValue" .= copyText value
+            , "canDive" .= isContainer value
+            ]
+
+isContainer :: Aeson.Value -> Bool
+isContainer (Aeson.Array _) = True
+isContainer (Aeson.Object _) = True
+isContainer _ = False
+
+breadcrumbsFor :: [T.Text] -> [Aeson.Value]
+breadcrumbsFor path =
+    Aeson.object
+        [ "label" .= ("tx" :: T.Text)
+        , "path" .= encodePath []
+        ]
+        : [ Aeson.object
+                [ "label" .= label
+                , "path" .= encodePath (take n path)
+                ]
+          | (n, label) <- zip [1 :: Int ..] path
+          ]
+
+encodePath :: [T.Text] -> T.Text
+encodePath path =
+    T.decodeUtf8 (BSL.toStrict (Aeson.encode path))
+
 renderTx :: L.Tx TopTx Conway.ConwayEra -> Aeson.Value
 renderTx tx =
-    let body        = tx ^. L.bodyTxL
-        inputs      = toList (body ^. L.inputsTxBodyL)
-        refIns      = toList (body ^. L.referenceInputsTxBodyL)
-        outputs     = toList (body ^. L.outputsTxBodyL)
-        fee         = body ^. L.feeTxBodyL
-        vldt        = body ^. L.vldtTxBodyL
-        mint        = body ^. L.mintTxBodyL
-        certs       = toList (body ^. L.certsTxBodyL)
+    let body = tx ^. L.bodyTxL
+        inputs = toList (body ^. L.inputsTxBodyL)
+        refIns = toList (body ^. L.referenceInputsTxBodyL)
+        outputs = toList (body ^. L.outputsTxBodyL)
+        fee = body ^. L.feeTxBodyL
+        vldt = body ^. L.vldtTxBodyL
+        mint = body ^. L.mintTxBodyL
+        certs = toList (body ^. L.certsTxBodyL)
         withdrawals = body ^. L.withdrawalsTxBodyL
-        reqSigners  = toList (body ^. L.reqSignerHashesTxBodyL)
-    in
-        Aeson.Object $ KeyMap.fromList
-            [ "era"                   .= ("Conway" :: T.Text)
-            , "decoder"               .= ("cardano-ledger-conway + cardano-ledger-binary (wasm32-wasi, GHC 9.12)" :: T.Text)
-            , "fee_lovelace"          .= T.pack (show (Coin.unCoin fee))
-            , "validity_interval"     .= validityJson vldt
-            , "input_count"           .= length inputs
-            , "reference_input_count" .= length refIns
-            , "output_count"          .= length outputs
-            , "cert_count"            .= length certs
-            , "withdrawal_count"      .= withdrawalsCount withdrawals
-            , "required_signer_count" .= length reqSigners
-            , "inputs"                .= map txInJson inputs
-            , "reference_inputs"      .= map txInJson refIns
-            , "outputs"               .= map txOutJson outputs
-            , "mint"                  .= multiAssetJson mint
-            ]
+        reqSigners = toList (body ^. L.reqSignerHashesTxBodyL)
+     in Aeson.Object $
+            KeyMap.fromList
+                [ "era" .= ("Conway" :: T.Text)
+                , "decoder" .= ("cardano-ledger-conway + cardano-ledger-binary (wasm32-wasi, GHC 9.12)" :: T.Text)
+                , "fee_lovelace" .= T.pack (show (Coin.unCoin fee))
+                , "validity_interval" .= validityJson vldt
+                , "input_count" .= length inputs
+                , "reference_input_count" .= length refIns
+                , "output_count" .= length outputs
+                , "cert_count" .= length certs
+                , "withdrawal_count" .= withdrawalsCount withdrawals
+                , "required_signer_count" .= length reqSigners
+                , "inputs" .= map txInJson inputs
+                , "reference_inputs" .= map txInJson refIns
+                , "outputs" .= map txOutJson outputs
+                , "mint" .= multiAssetJson mint
+                ]
 
 validityJson :: L.ValidityInterval -> Aeson.Value
 validityJson (L.ValidityInterval before hereafter) =
     Aeson.object
-        [ "invalid_before"    .= renderSlot before
+        [ "invalid_before" .= renderSlot before
         , "invalid_hereafter" .= renderSlot hereafter
         ]
   where
     renderSlot :: BaseTypes.StrictMaybe BaseTypes.SlotNo -> Aeson.Value
-    renderSlot BaseTypes.SNothing  = Aeson.Null
+    renderSlot BaseTypes.SNothing = Aeson.Null
     renderSlot (BaseTypes.SJust s) = Aeson.toJSON (T.pack (show (BaseTypes.unSlotNo s)))
 
--- | Withdrawals are wrapped in a newtype; reach into the Map and count.
---   Ledger versions differ on the exact constructor / accessor; use Show
---   to bootstrap — replaceable with a proper accessor later.
+{- | Withdrawals are wrapped in a newtype; reach into the Map and count.
+  Ledger versions differ on the exact constructor / accessor; use Show
+  to bootstrap — replaceable with a proper accessor later.
+-}
 withdrawalsCount :: L.Withdrawals -> Int
 withdrawalsCount (L.Withdrawals m) = Map.size m
 
 -- | Render a Conway TxOut with address, value (coin + assets), and datum.
 txOutJson :: L.TxOut Conway.ConwayEra -> Aeson.Value
 txOutJson txOut =
-    let value              = txOut ^. L.valueTxOutL
+    let value = txOut ^. L.valueTxOutL
         Mary.MaryValue c m = value
-    in Aeson.object
-        [ "address_hex"   .= T.decodeUtf8 (B16.encode (Addr.serialiseAddr (txOut ^. L.addrTxOutL)))
-        , "coin_lovelace" .= T.pack (show (Coin.unCoin c))
-        , "assets"        .= multiAssetJson m
-        , "datum"         .= datumJson (txOut ^. L.datumTxOutL)
-        ]
+     in Aeson.object
+            [ "address_hex" .= T.decodeUtf8 (B16.encode (Addr.serialiseAddr (txOut ^. L.addrTxOutL)))
+            , "coin_lovelace" .= T.pack (show (Coin.unCoin c))
+            , "assets" .= multiAssetJson m
+            , "datum" .= datumJson (txOut ^. L.datumTxOutL)
+            ]
 
 multiAssetJson :: Mary.MultiAsset -> Aeson.Value
 multiAssetJson (Mary.MultiAsset m) =
-    Aeson.Object $ KeyMap.fromList
-        [ ( AesonKey.fromText (policyHex pid)
-          , Aeson.Object $ KeyMap.fromList
-              [ ( AesonKey.fromText (assetNameHex an)
-                , Aeson.String (T.pack (show q))
-                )
-              | (an, q) <- Map.toList assetMap
-              ]
-          )
-        | (pid, assetMap) <- Map.toList m
-        ]
+    Aeson.Object $
+        KeyMap.fromList
+            [ ( AesonKey.fromText (policyHex pid)
+              , Aeson.Object $
+                    KeyMap.fromList
+                        [ ( AesonKey.fromText (assetNameHex an)
+                          , Aeson.String (T.pack (show q))
+                          )
+                        | (an, q) <- Map.toList assetMap
+                        ]
+              )
+            | (pid, assetMap) <- Map.toList m
+            ]
   where
     policyHex :: Mary.PolicyID -> T.Text
     policyHex (Mary.PolicyID (Hashes.ScriptHash h)) =
@@ -147,7 +351,7 @@ multiAssetJson (Mary.MultiAsset m) =
 -- | Render TxOut datum state. The ledger's `Datum era` is three-cased.
 datumJson :: PData.Datum Conway.ConwayEra -> Aeson.Value
 datumJson PData.NoDatum =
-    Aeson.object [ "kind" .= ("no_datum" :: T.Text) ]
+    Aeson.object ["kind" .= ("no_datum" :: T.Text)]
 datumJson (PData.DatumHash h) =
     Aeson.object
         [ "kind" .= ("datum_hash" :: T.Text)

--- a/nix/wasm/tx-inspector/wasm-tx-inspector/src/Conway/Inspector.hs
+++ b/nix/wasm/tx-inspector/wasm-tx-inspector/src/Conway/Inspector.hs
@@ -8,11 +8,6 @@
 --   validation. The hard work (CBOR → Conway `Tx`) is delegated to the
 --   upstream Haskell ledger packages; this module only projects the decoded
 --   value into a lossy human-oriented JSON.
---
---   Current schema is first-cut — richer output (addresses / values /
---   datum / redeemers / mint breakdown) is blocked on
---   lambdasistemi/cardano-node-clients#70 (DevX fix: per-edit rebuild is
---   currently ~24 min, which makes API exploration prohibitively slow).
 module Conway.Inspector
     ( inspect
     , InspectError(..)
@@ -27,14 +22,19 @@ import qualified Cardano.Ledger.Coin            as Coin
 import qualified Cardano.Ledger.Conway          as Conway
 import           Cardano.Ledger.Core            (TxLevel (..))
 import qualified Cardano.Ledger.Hashes          as Hashes
+import qualified Cardano.Ledger.Mary.Value      as Mary
+import qualified Cardano.Ledger.Plutus.Data     as PData
 import qualified Cardano.Ledger.TxIn            as TxIn
 import           Data.Aeson                     ((.=))
 import qualified Data.Aeson                     as Aeson
+import qualified Data.Aeson.Key                 as AesonKey
 import qualified Data.Aeson.KeyMap              as KeyMap
 import qualified Data.ByteString                as BS
 import qualified Data.ByteString.Base16         as B16
 import qualified Data.ByteString.Lazy           as BSL
+import qualified Data.ByteString.Short          as SBS
 import           Data.Foldable                  (toList)
+import qualified Data.Map.Strict                as Map
 import qualified Data.Text                      as T
 import qualified Data.Text.Encoding             as T
 import           Lens.Micro                     ((^.))
@@ -67,12 +67,16 @@ decodeConway bs =
 
 renderTx :: L.Tx TopTx Conway.ConwayEra -> Aeson.Value
 renderTx tx =
-    let body    = tx ^. L.bodyTxL
-        inputs  = toList (body ^. L.inputsTxBodyL)
-        refIns  = toList (body ^. L.referenceInputsTxBodyL)
-        outputs = toList (body ^. L.outputsTxBodyL)
-        fee     = body ^. L.feeTxBodyL
-        vldt    = body ^. L.vldtTxBodyL
+    let body        = tx ^. L.bodyTxL
+        inputs      = toList (body ^. L.inputsTxBodyL)
+        refIns      = toList (body ^. L.referenceInputsTxBodyL)
+        outputs     = toList (body ^. L.outputsTxBodyL)
+        fee         = body ^. L.feeTxBodyL
+        vldt        = body ^. L.vldtTxBodyL
+        mint        = body ^. L.mintTxBodyL
+        certs       = toList (body ^. L.certsTxBodyL)
+        withdrawals = body ^. L.withdrawalsTxBodyL
+        reqSigners  = toList (body ^. L.reqSignerHashesTxBodyL)
     in
         Aeson.Object $ KeyMap.fromList
             [ "era"                   .= ("Conway" :: T.Text)
@@ -82,9 +86,13 @@ renderTx tx =
             , "input_count"           .= length inputs
             , "reference_input_count" .= length refIns
             , "output_count"          .= length outputs
+            , "cert_count"            .= length certs
+            , "withdrawal_count"      .= withdrawalsCount withdrawals
+            , "required_signer_count" .= length reqSigners
             , "inputs"                .= map txInJson inputs
             , "reference_inputs"      .= map txInJson refIns
             , "outputs"               .= map txOutJson outputs
+            , "mint"                  .= multiAssetJson mint
             ]
 
 validityJson :: L.ValidityInterval -> Aeson.Value
@@ -98,15 +106,57 @@ validityJson (L.ValidityInterval before hereafter) =
     renderSlot BaseTypes.SNothing  = Aeson.Null
     renderSlot (BaseTypes.SJust s) = Aeson.toJSON (T.pack (show (BaseTypes.unSlotNo s)))
 
--- | Render a Conway TxOut with address (hex) + coin.
---   Multi-asset breakdown needs `cardano-ledger-mary` in build-depends; adding
---   a new build-dep resets the prebuiltDeps cache and triggers a 20-min rebuild
---   (tracked in the DevX notes). Deferred to a dedicated cabal-bump cycle.
+-- | Withdrawals are wrapped in a newtype; reach into the Map and count.
+--   Ledger versions differ on the exact constructor / accessor; use Show
+--   to bootstrap — replaceable with a proper accessor later.
+withdrawalsCount :: L.Withdrawals -> Int
+withdrawalsCount (L.Withdrawals m) = Map.size m
+
+-- | Render a Conway TxOut with address, value (coin + assets), and datum.
 txOutJson :: L.TxOut Conway.ConwayEra -> Aeson.Value
 txOutJson txOut =
-    Aeson.object
+    let value              = txOut ^. L.valueTxOutL
+        Mary.MaryValue c m = value
+    in Aeson.object
         [ "address_hex"   .= T.decodeUtf8 (B16.encode (Addr.serialiseAddr (txOut ^. L.addrTxOutL)))
-        , "coin_lovelace" .= T.pack (show (Coin.unCoin (txOut ^. L.coinTxOutL)))
+        , "coin_lovelace" .= T.pack (show (Coin.unCoin c))
+        , "assets"        .= multiAssetJson m
+        , "datum"         .= datumJson (txOut ^. L.datumTxOutL)
+        ]
+
+multiAssetJson :: Mary.MultiAsset -> Aeson.Value
+multiAssetJson (Mary.MultiAsset m) =
+    Aeson.Object $ KeyMap.fromList
+        [ ( AesonKey.fromText (policyHex pid)
+          , Aeson.Object $ KeyMap.fromList
+              [ ( AesonKey.fromText (assetNameHex an)
+                , Aeson.String (T.pack (show q))
+                )
+              | (an, q) <- Map.toList assetMap
+              ]
+          )
+        | (pid, assetMap) <- Map.toList m
+        ]
+  where
+    policyHex :: Mary.PolicyID -> T.Text
+    policyHex (Mary.PolicyID (Hashes.ScriptHash h)) =
+        T.decodeUtf8 (B16.encode (Crypto.hashToBytes h))
+    assetNameHex :: Mary.AssetName -> T.Text
+    assetNameHex (Mary.AssetName sbs) = T.decodeUtf8 (B16.encode (SBS.fromShort sbs))
+
+-- | Render TxOut datum state. The ledger's `Datum era` is three-cased.
+datumJson :: PData.Datum Conway.ConwayEra -> Aeson.Value
+datumJson PData.NoDatum =
+    Aeson.object [ "kind" .= ("no_datum" :: T.Text) ]
+datumJson (PData.DatumHash h) =
+    Aeson.object
+        [ "kind" .= ("datum_hash" :: T.Text)
+        , "hash" .= T.decodeUtf8 (B16.encode (Crypto.hashToBytes (Hashes.extractHash h)))
+        ]
+datumJson (PData.Datum _) =
+    Aeson.object
+        [ "kind" .= ("inline_datum" :: T.Text)
+        , "note" .= ("Plutus Data AST rendering deferred" :: T.Text)
         ]
 
 txInJson :: TxIn.TxIn -> Aeson.Value

--- a/nix/wasm/tx-inspector/wasm-tx-inspector/src/Conway/Inspector.hs
+++ b/nix/wasm/tx-inspector/wasm-tx-inspector/src/Conway/Inspector.hs
@@ -19,6 +19,7 @@ module Conway.Inspector
     ) where
 
 import qualified Cardano.Crypto.Hash            as Crypto
+import qualified Cardano.Ledger.Address         as Addr
 import qualified Cardano.Ledger.Api             as L
 import qualified Cardano.Ledger.BaseTypes       as BaseTypes
 import qualified Cardano.Ledger.Binary          as Binary
@@ -71,17 +72,42 @@ renderTx tx =
         refIns  = toList (body ^. L.referenceInputsTxBodyL)
         outputs = toList (body ^. L.outputsTxBodyL)
         fee     = body ^. L.feeTxBodyL
+        vldt    = body ^. L.vldtTxBodyL
     in
         Aeson.Object $ KeyMap.fromList
             [ "era"                   .= ("Conway" :: T.Text)
             , "decoder"               .= ("cardano-ledger-conway + cardano-ledger-binary (wasm32-wasi, GHC 9.12)" :: T.Text)
             , "fee_lovelace"          .= T.pack (show (Coin.unCoin fee))
+            , "validity_interval"     .= validityJson vldt
             , "input_count"           .= length inputs
             , "reference_input_count" .= length refIns
             , "output_count"          .= length outputs
             , "inputs"                .= map txInJson inputs
             , "reference_inputs"      .= map txInJson refIns
+            , "outputs"               .= map txOutJson outputs
             ]
+
+validityJson :: L.ValidityInterval -> Aeson.Value
+validityJson (L.ValidityInterval before hereafter) =
+    Aeson.object
+        [ "invalid_before"    .= renderSlot before
+        , "invalid_hereafter" .= renderSlot hereafter
+        ]
+  where
+    renderSlot :: BaseTypes.StrictMaybe BaseTypes.SlotNo -> Aeson.Value
+    renderSlot BaseTypes.SNothing  = Aeson.Null
+    renderSlot (BaseTypes.SJust s) = Aeson.toJSON (T.pack (show (BaseTypes.unSlotNo s)))
+
+-- | Render a Conway TxOut with address (hex) + coin.
+--   Multi-asset breakdown needs `cardano-ledger-mary` in build-depends; adding
+--   a new build-dep resets the prebuiltDeps cache and triggers a 20-min rebuild
+--   (tracked in the DevX notes). Deferred to a dedicated cabal-bump cycle.
+txOutJson :: L.TxOut Conway.ConwayEra -> Aeson.Value
+txOutJson txOut =
+    Aeson.object
+        [ "address_hex"   .= T.decodeUtf8 (B16.encode (Addr.serialiseAddr (txOut ^. L.addrTxOutL)))
+        , "coin_lovelace" .= T.pack (show (Coin.unCoin (txOut ^. L.coinTxOutL)))
+        ]
 
 txInJson :: TxIn.TxIn -> Aeson.Value
 txInJson (TxIn.TxIn (TxIn.TxId safeHash) (BaseTypes.TxIx ix)) =

--- a/nix/wasm/tx-inspector/wasm-tx-inspector/wasm-tx-inspector.cabal
+++ b/nix/wasm/tx-inspector/wasm-tx-inspector/wasm-tx-inspector.cabal
@@ -18,7 +18,10 @@ library
                   , cardano-ledger-binary
                   , cardano-ledger-conway
                   , cardano-ledger-core
+                  , cardano-ledger-mary
+                  , containers
                   , microlens
+                  , plutus-ledger-api
                   , text
   default-language: Haskell2010
   ghc-options:      -Wall

--- a/scripts/fetch-tx-cbor.sh
+++ b/scripts/fetch-tx-cbor.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# fetch-tx-cbor.sh — grab a Cardano tx's CBOR hex for the inspector demo.
+#
+# Usage:
+#   fetch-tx-cbor.sh <tx-hash>           # mainnet, hex to stdout
+#   fetch-tx-cbor.sh <tx-hash> preprod   # preprod testnet
+#   fetch-tx-cbor.sh <tx-hash> | wl-copy       # pipe into clipboard (wayland)
+#   fetch-tx-cbor.sh <tx-hash> | xclip -sel c  # pipe into clipboard (X11)
+#   fetch-tx-cbor.sh <tx-hash> | pbcopy        # pipe into clipboard (macOS)
+#
+# If no arg: fetches the most recent tx of the most recent mainnet block.
+# If $BLOCKFROST_PROJECT_ID is set, uses that; otherwise falls back to the
+# demo keys in memory.
+
+set -euo pipefail
+
+NETWORK="${2:-mainnet}"
+
+case "$NETWORK" in
+    mainnet)
+        BASE="https://cardano-mainnet.blockfrost.io/api/v0"
+        PID="${BLOCKFROST_PROJECT_ID:-mainnetRuiuoEo0lhw6tJA3CGaVAoGM3kxIP11O}"
+        ;;
+    preprod)
+        BASE="https://cardano-preprod.blockfrost.io/api/v0"
+        PID="${BLOCKFROST_PROJECT_ID:-preprodwj5hJFlpil9JqOSszqDvfyKgYFfkcs0m}"
+        ;;
+    *)
+        echo "unknown network: $NETWORK (expected mainnet or preprod)" >&2
+        exit 2
+        ;;
+esac
+
+HASH="${1:-}"
+if [ -z "$HASH" ]; then
+    HASH=$(curl -sS -H "project_id: $PID" "$BASE/blocks/latest/txs" | jq -r '.[0]')
+    echo "no hash given; using latest: $HASH (network=$NETWORK)" >&2
+fi
+
+curl -sS -H "project_id: $PID" "$BASE/txs/$HASH/cbor" | jq -r .cbor


### PR DESCRIPTION
Closes #70.

## TL;DR

Editing `Conway/Inspector.hs` used to trigger a full 24-minute rebuild of the ledger closure. After this PR it rebuilds in **11 seconds** (measured). On top of that, the schema got expanded, the browser UI can fetch transactions from Blockfrost or Koios, credentials are password-typed and opt-in persistent, and the inspector page now has a purpose-built responsive layout instead of Pico.css defaults.

Live demo: https://cardano-tx-inspector.surge.sh

## What landed

### 1. DevX fix — `mkCardanoLedgerWasm` split ([75d72e3](../commit/75d72e3))

Root cause: the old `wasm` derivation had `src = <full tree including .hs>` → any Haskell edit changed the derivation hash → Nix sandbox rebuilt cabal from scratch → 24 min.

Split into:
- **`prebuiltDeps`** (new) — `src = srcMetadata` (`*.cabal` + project file only). Runs `wasm32-wasi-cabal build --only-dependencies`. Emits `$out/{cabal,dist-newstyle,cabal-wasm.project}`. Hash stable across Haskell source edits.
- **`wasm`** — copies prebuiltDeps' CABAL_DIR + dist-newstyle + patched project file, runs `wasm32-wasi-cabal build <target>`. Cabal sees deps as up-to-date; only inspector lib + exe + link.

Critical detail: `srcMetadata` must set `name = builtins.baseNameOf (toString src)`. Default `"source"` yields `/build/source` while the `wasm` derivation extracts to `/build/tx-inspector` — cabal bakes absolute paths into `dist-newstyle/cache/plan.json` and compiled artifacts; mismatched sandbox paths cause cabal to treat every cached compile as stale and rebuild the whole closure. With matching names, cabal honors the cache.

### 2. Schema expansion ([4d16718](../commit/4d16718), [f52bc17](../commit/f52bc17))

Measured iteration cycles on top of the split:
```
cycle 1  add outputs (address_hex + coin_lovelace)        12.2 s
cycle 2  add validity — wrong import                       7.2 s (compile fail)
cycle 2b fix to L.ValidityInterval                        12.3 s
cycle 3  add multi-asset + cardano-ledger-mary dep        23.5 min (cabal-bump path)
cycle 3- revert cabal byte-identical                      11.3 s (cache restored)
```

Inspector now emits:
```json
{
  "era", "decoder", "fee_lovelace",
  "validity_interval": {"invalid_before", "invalid_hereafter"},
  "input_count", "reference_input_count", "output_count",
  "cert_count", "withdrawal_count", "required_signer_count",
  "inputs": [...], "reference_inputs": [...],
  "outputs": [{"address_hex", "coin_lovelace", "assets", "datum"}],
  "mint": {...}
}
```

### 3. Provider selector + persistent credentials ([e911bbb](../commit/e911bbb), [9c22b86](../commit/9c22b86), [c4a168d](../commit/c4a168d), [9ff2fcd](../commit/9ff2fcd))

Browser UI (PureScript + Halogen) can now fetch CBOR by tx hash rather than only accept paste-in hex. Two providers:
- **Blockfrost** — header `project_id`; project creation and authorization at https://blockfrost.io/dashboard.
- **Koios** — bearer token; free tier at koios.rest/auth/Auth.html. Koios [intentionally strips CORS on anonymous requests](https://github.com/cardano-community/koios-artifacts/issues/397) (documented; registering lifts it).

Persistence is opt-in. Off by default — credentials stay in memory, lost on reload. On → `localStorage` in cleartext, with an inline warning right under the toggle.

Credential inputs are `type=password`; provider, network, and mode choices are explicit touch-sized controls.

### 4. Responsive inspector layout ([9ff2fcd](../commit/9ff2fcd), [9a61b04](../commit/9a61b04), [23477d2](../commit/23477d2))

The first pass used Pico.css v2 via CDN. That was removed because the page still looked like a generic classless document and, worse, the app was mounted on `body`, leaving the footer above the inspector UI while `#app` stayed unused.

Current layout:
- Halogen mounts into `#app`, with `body` only as a fallback.
- `dist/index.html` ships a small custom stylesheet, no Pico CDN dependency.
- Desktop uses a two-column work surface: chain-data controls on the left, input/result panels on the right.
- Mobile stacks into full-width touch controls with no horizontal overflow at 390 px.
- The missing favicon request is suppressed with a data-URL favicon, keeping the console clean during browser checks.

### 5. Helper script ([38caa21](../commit/38caa21))

`scripts/fetch-tx-cbor.sh <hash> [mainnet|preprod]` — fetches CBOR hex via Blockfrost. Honors `BLOCKFROST_PROJECT_ID`; falls back to demo keys. Useful for CLI-based testing.

### 6. Handover correction ([6f427e6](../commit/6f427e6))

`HANDOVER.md` had an invalid quick PureScript iteration command. The branch name contains `/`, so the flake ref must use `?ref=fix/remove-nodePackages`; quoted brace expansion also cannot produce two installables. The corrected command is now documented and was verified with `spago build`.

## DevX — measured (1000× speedup per iteration)

| scenario | before | after |
|---|---|---|
| First build (cold cache) | ~24 min | ~24 min (unchanged; prebuiltDeps has to populate once) |
| Edit `Inspector.hs` (no dep change) | ~24 min | **~11 s** |
| Edit cabal build-depends | ~24 min | ~23 min (prebuiltDeps rehashes; acceptable rare cost) |
| Edit `Main.purs` (PS UI only) | ~30 s | ~30 s |

Remaining gap (cabal-file edits still force prebuiltDeps rebuild) is noted but not a showstopper — it's a known, rare cost per new dep.

## Acceptance (#70 checklist)

- [x] `time nix build .#wasm-tx-inspector` after editing only `Inspector.hs` is < 3 min — **11 s measured**
- [x] Responsive inspector layout shipped and deployed
- [x] Credentials are password-typed and opt-in persistent with an explicit cleartext warning
- [x] Correctness preserved: `.wasm` output decodes fixture + mainnet txs identically
- [x] Other targets unaffected: `wasm-smoke`, `wasm-ledger-smoke`, `tx-inspector-ui` flow through the same builder, still evaluate cleanly
- [ ] `nix develop .#wasm-dev` for host-side `wasm32-wasi-cabal build` — shell ships with a materialized workspace, but SRP-fork clones still need network in that mode; limitation acknowledged, not a regression

## Latest verification

- `nix shell 'github:paolino/purescript-overlay?ref=fix/remove-nodePackages#purs' 'github:paolino/purescript-overlay?ref=fix/remove-nodePackages#spago-unstable' -c spago build`
- `nix build .#packages.x86_64-linux.tx-inspector-ui`
- `git diff --check`
- Playwright live preview checks at 1440 px and 390 px: no horizontal overflow, no console warnings/errors, CBOR mode switches to the textarea on mobile.
- Published to Surge: https://cardano-tx-inspector.surge.sh

## Base branch

Based on `033-wasm-ledger-inspector` (PR #69); will rebase onto `main` once #69 merges.


## Previous addition — inspection result panel

Commit [8a25bc8](../commit/8a25bc8) replaces the result area as the first thing users see after decode:
- Parses the wasm JSON output client-side into a compact inspection model.
- Shows metric cards for fee, inputs, reference inputs, outputs, output assets, mint policies/assets, certs, withdrawals, required signers, and validity slots.
- The earlier focused sections for outputs, mint policies, spending inputs, and reference inputs are now superseded by the recursive browser below, so the summary stays compact while the full decoded transaction remains navigable.
- Keeps the full pretty raw JSON under a `Raw JSON` disclosure and leaves `Copy JSON` unchanged.
- Corrects the Blockfrost project link from the dead `/auth/signup` URL to `https://blockfrost.io/dashboard`.

Extra verification for this addition:
- Confirmed `https://blockfrost.io/auth/signup` returns 404 and `https://blockfrost.io/dashboard` returns 200.
- Decoded tx `62e842c2b864776b2aec846fed1c1ad5810fa4dc12e12d44e8a53b18fdc828f9` through the live deployed UI.
- Verified the live inspection panel renders metrics, raw JSON disclosure, no horizontal overflow, and the corrected Blockfrost dashboard link.

## Previous addition — recursive transaction browser

Commit [d4c1000](../commit/d4c1000) replaces the short result slices with a recursive browser over the decoded JSON:
- Every decoded field/value is represented as a row with a direct `Copy` action.
- Object and array rows get `Open`, including empty containers, so users can browse the full transaction structure instead of only the preview subset.
- Breadcrumb buttons keep navigation local to the transaction path (`tx`, `outputs`, `#4`, `assets`, policy IDs, asset names, etc.).
- `Copy current` copies the whole object/array at the current breadcrumb path; scalar rows copy the raw scalar value, while container rows copy pretty JSON.
- Long hashes and policy IDs are ellipsized visually but copied in full.

Extra verification for this addition:
- `nix shell 'github:paolino/purescript-overlay?ref=fix/remove-nodePackages#purs' 'github:paolino/purescript-overlay?ref=fix/remove-nodePackages#spago-unstable' -c spago build`
- `nix build .#packages.x86_64-linux.tx-inspector-ui`
- `git diff --check`
- Published to Surge: https://cardano-tx-inspector.surge.sh
- Playwright live preview decoded tx `62e842c2b864776b2aec846fed1c1ad5810fa4dc12e12d44e8a53b18fdc828f9` in CBOR mode.
- Verified the root has 14 browsable/copyable rows; `outputs -> #4 -> assets` has 77 policy rows, all 77 openable and copyable; `policy -> asset` scalar copy writes the value.
- Verified no horizontal overflow at 1440 px desktop or 390 px mobile, no console warnings/errors, `index.js?v=transaction-browser-1` is loaded, and the Blockfrost Dashboard link is `https://blockfrost.io/dashboard`.

## Latest correction — ledger RPC boundary

Commit [b00ce7e](../commit/b00ce7e) fixes the architectural problem in the first browser pass: the UI no longer navigates the already-returned JSON locally.

The WASM executable now accepts either legacy raw CBOR hex or a JSON RPC envelope:
```json
{
  "tx_cbor": "<hex>",
  "method": "inspect | browse",
  "path": ["outputs", "#4", "assets"]
}
```

Current methods:
- `inspect` decodes the CBOR with the Haskell ledger and returns the compact inspection JSON plus the root browser view.
- `browse` decodes the same CBOR with the Haskell ledger and returns the browser rows for the requested path.

Why this matters:
- Browser navigation now crosses the Haskell/WASM boundary every time with the original transaction CBOR and explicit arguments.
- The PureScript UI is no longer the authority for traversal; it only renders the JSON returned by the Haskell RPC.
- This is the right boundary for future ledger operations: validation, invariants/checks, patching, and balance attempts can be added as new RPC methods that return diagnostics and, for mutating methods, a new transaction CBOR.
- Balancing should fit this model for cases with enough slack: the UI sends `tx_cbor` plus balancing arguments, Haskell performs the ledger-side manipulation/checks, and the response can include both the patched CBOR and structured diagnostics.

Extra verification for this correction:
- `nix build .#packages.x86_64-linux.wasm-tx-inspector`
- `nix shell 'github:paolino/purescript-overlay?ref=fix/remove-nodePackages#purs' 'github:paolino/purescript-overlay?ref=fix/remove-nodePackages#spago-unstable' -c spago build`
- `nix build .#packages.x86_64-linux.tx-inspector-ui`
- `git diff --check`
- CLI RPC smoke: `inspect` returns `conway-tx-inspector/v1`, an `inspection`, and 14 root browser rows; `browse` for `["outputs","#4","assets"]` returns 77 rows.
- Live Playwright verification on https://cardano-tx-inspector.surge.sh confirms the loaded script is `index.js?v=ledger-rpc-1`.
- Live Playwright instrumentation observed one `inspect` RPC followed by `browse` RPCs for `["outputs"]`, `["outputs","#4"]`, `["outputs","#4","assets"]`, and a selected policy; every call included the full tx CBOR.
- Live desktop and 390 px mobile checks show 77 openable/copyable asset-policy rows and no horizontal overflow.

## Latest UX correction — in-place tree expansion

Commit [f907ea5](../commit/f907ea5) fixes the remaining navigation problem in the RPC browser:
- `Open` still calls the Haskell `browse` RPC with the full tx CBOR and the selected path.
- The returned rows are now inserted under the clicked row instead of replacing the whole browser panel.
- Parent/root context stays visible while drilling into `outputs -> #4 -> assets`.
- Expanded nodes are highlighted and can be closed in place.
- Closing a child subtree preserves the parent expansion and avoids losing the surrounding transaction view.

Extra verification for this correction:
- `nix shell 'github:paolino/purescript-overlay?ref=fix/remove-nodePackages#purs' 'github:paolino/purescript-overlay?ref=fix/remove-nodePackages#spago-unstable' -c spago build`
- `nix build .#packages.x86_64-linux.tx-inspector-ui`
- `git diff --check`
- Published to Surge: https://cardano-tx-inspector.surge.sh
- Live Playwright desktop decoded tx `62e842c2b864776b2aec846fed1c1ad5810fa4dc12e12d44e8a53b18fdc828f9`, expanded `outputs -> #4 -> assets`, and verified the visible tree grows from 14 rows to 100 rows without losing root fields such as `fee_lovelace`.
- Live Playwright verified RPC calls remain `inspect`, then `browse ["outputs"]`, `browse ["outputs","#4"]`, `browse ["outputs","#4","assets"]`.
- Live Playwright verified closing `#4` collapses back to 19 visible rows while keeping `outputs` expanded.
- Live desktop and 390 px mobile checks show no horizontal overflow with the nested tree.


## Latest constitution amendment - ledger functional layer

Commit [f7ca35e](../commit/f7ca35e) records the transaction-workspace boundary in `.specify/memory/constitution.md`:
- The browser/application workspace owns explicit transaction documents and their canonical CBOR bytes.
- Haskell/WASM components act as a ledger functional layer: operations receive `tx_cbor`, explicit args, and any required external context, then return JSON results and patched CBOR for mutations.
- JSON is the control plane for operation names, paths, diagnostics, summaries, and simple args; CBOR remains the data plane for transactions and fidelity-sensitive ledger values.
- WASM-side caches or handles are allowed only as performance aids, not as hidden authoritative state.

Verification for this amendment:
- `git diff --check`
