### PR TITLE
feat: introduce ledger functional API envelope

### DIFF
--- a/docs/inspector/dist/index.html
+++ b/docs/inspector/dist/index.html
@@ -788,6 +788,6 @@
         >.
       </div>
     </footer>
-    <script src="index.js?v=ledger-rpc-tree-1"></script>
+    <script src="index.js?v=ledger-functional-api-1"></script>
   </body>
 </html>

--- a/docs/inspector/src/FFI/Inspector.js
+++ b/docs/inspector/src/FFI/Inspector.js
@@ -3,7 +3,7 @@
 export const runInspectorImpl = (stdinText) => () =>
   globalThis.runInspector(stdinText);
 
-export const runInspectorRpcImpl = (txCbor) => (method) => (pathText) => () => {
+export const runLedgerOperationImpl = (txCbor) => (op) => (pathText) => () => {
   let path = [];
   try {
     const parsed = JSON.parse(pathText);
@@ -15,8 +15,8 @@ export const runInspectorRpcImpl = (txCbor) => (method) => (pathText) => () => {
   return globalThis.runInspector(
     JSON.stringify({
       tx_cbor: txCbor,
-      method,
-      path,
+      op,
+      args: { path },
     })
   );
 };

--- a/docs/inspector/src/FFI/Inspector.purs
+++ b/docs/inspector/src/FFI/Inspector.purs
@@ -1,7 +1,7 @@
 module FFI.Inspector
   ( InspectorResult
   , runInspector
-  , runInspectorRpc
+  , runLedgerOperation
   ) where
 
 import Prelude
@@ -17,10 +17,10 @@ type InspectorResult =
   }
 
 foreign import runInspectorImpl :: String -> Effect (Promise InspectorResult)
-foreign import runInspectorRpcImpl :: String -> String -> String -> Effect (Promise InspectorResult)
+foreign import runLedgerOperationImpl :: String -> String -> String -> Effect (Promise InspectorResult)
 
 runInspector :: String -> Aff InspectorResult
 runInspector = toAffE <<< runInspectorImpl
 
-runInspectorRpc :: String -> String -> String -> Aff InspectorResult
-runInspectorRpc txCbor method path = toAffE (runInspectorRpcImpl txCbor method path)
+runLedgerOperation :: String -> String -> String -> Aff InspectorResult
+runLedgerOperation txCbor op path = toAffE (runLedgerOperationImpl txCbor op path)

--- a/docs/inspector/src/FFI/Json.js
+++ b/docs/inspector/src/FFI/Json.js
@@ -193,7 +193,7 @@ const invalidBrowser = (title, subtitle, currentJson = "") => ({
 
 const normalizeBrowser = (browser) => {
   if (!browser || typeof browser !== "object") {
-    return invalidBrowser("Transaction browser", "RPC response missing browser.");
+    return invalidBrowser("Transaction browser", "Ledger operation response missing browser.");
   }
 
   return {
@@ -221,11 +221,14 @@ const normalizeBrowser = (browser) => {
   };
 };
 
-export const rpcInspectionImpl = (raw) => {
+const operationResult = (parsed) => parsed?.result ?? parsed;
+
+export const operationInspectionImpl = (raw) => {
   try {
     const parsed = JSON.parse(raw);
-    if (parsed && Object.prototype.hasOwnProperty.call(parsed, "inspection")) {
-      return JSON.stringify(parsed.inspection);
+    const result = operationResult(parsed);
+    if (result && Object.prototype.hasOwnProperty.call(result, "inspection")) {
+      return JSON.stringify(result.inspection);
     }
   } catch (_err) {
     return raw;
@@ -233,11 +236,11 @@ export const rpcInspectionImpl = (raw) => {
   return raw;
 };
 
-export const rpcBrowserImpl = (raw) => {
+export const operationBrowserImpl = (raw) => {
   try {
     const parsed = JSON.parse(raw);
-    return normalizeBrowser(parsed?.browser);
+    return normalizeBrowser(operationResult(parsed)?.browser);
   } catch (_err) {
-    return invalidBrowser("Transaction browser", "RPC response was not JSON.", raw);
+    return invalidBrowser("Transaction browser", "Ledger operation response was not JSON.", raw);
   }
 };

--- a/docs/inspector/src/FFI/Json.purs
+++ b/docs/inspector/src/FFI/Json.purs
@@ -7,15 +7,15 @@ module FFI.Json
   , MintRow
   , OutputRow
   , inspect
+  , operationBrowser
+  , operationInspection
   , pretty
-  , rpcBrowser
-  , rpcInspection
   ) where
 
 foreign import prettyImpl :: String -> String
 foreign import inspectImpl :: String -> Inspection
-foreign import rpcInspectionImpl :: String -> String
-foreign import rpcBrowserImpl :: String -> Browser
+foreign import operationInspectionImpl :: String -> String
+foreign import operationBrowserImpl :: String -> Browser
 
 type Metric =
   { label :: String
@@ -79,8 +79,8 @@ pretty = prettyImpl
 inspect :: String -> Inspection
 inspect = inspectImpl
 
-rpcInspection :: String -> String
-rpcInspection = rpcInspectionImpl
+operationInspection :: String -> String
+operationInspection = operationInspectionImpl
 
-rpcBrowser :: String -> Browser
-rpcBrowser = rpcBrowserImpl
+operationBrowser :: String -> Browser
+operationBrowser = operationBrowserImpl

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -13,8 +13,8 @@ import Effect.Class (liftEffect)
 import Effect.Exception (message)
 import FFI.Blockfrost (Network(..))
 import FFI.Clipboard (copy) as Clipboard
-import FFI.Inspector (InspectorResult, runInspectorRpc)
-import FFI.Json (Browser, inspect, pretty, rpcBrowser, rpcInspection) as Json
+import FFI.Inspector (InspectorResult, runLedgerOperation)
+import FFI.Json (Browser, inspect, operationBrowser, operationInspection, pretty) as Json
 import FFI.Storage as Storage
 import Provider (Provider(..))
 import Provider as Provider
@@ -676,18 +676,18 @@ inspectorComponent initial =
       case hexE of
         Left err -> H.modify_ _ { running = false, fetchError = Just err, browserPath = "[]" }
         Right h -> do
-          rpcResult <- H.liftAff (runInspectorRpc h "inspect" "[]")
+          operationResult <- H.liftAff (runLedgerOperation h "tx.inspect" "[]")
           let
-            inspectionResult = rpcResult { stdout = Json.rpcInspection rpcResult.stdout }
-            browser = Json.rpcBrowser rpcResult.stdout
+            inspectionResult = operationResult { stdout = Json.operationInspection operationResult.stdout }
+            browser = Json.operationBrowser operationResult.stdout
           H.modify_
             _
               { running = false
               , result = Just inspectionResult
               , txCbor = Just h
-              , browser = if rpcResult.exitOk && browser.valid then Just browser else Nothing
+              , browser = if operationResult.exitOk && browser.valid then Just browser else Nothing
               , browserNodes =
-                  if rpcResult.exitOk && browser.valid then rootBrowserNodes browser
+                  if operationResult.exitOk && browser.valid then rootBrowserNodes browser
                   else []
               , expandedPaths = []
               , browserPath = browser.currentPath
@@ -712,22 +712,22 @@ inspectorComponent initial =
             H.modify_ _ { browserPath = path, copiedPath = Nothing }
           Just txCbor -> do
             H.modify_ _ { browserPath = path, copiedPath = Nothing }
-            rpcResult <- H.liftAff (runInspectorRpc txCbor "browse" path)
-            let browser = Json.rpcBrowser rpcResult.stdout
+            operationResult <- H.liftAff (runLedgerOperation txCbor "tx.browse" path)
+            let browser = Json.operationBrowser operationResult.stdout
             H.modify_
               _
                 { browserNodes =
-                    if rpcResult.exitOk && browser.valid then
+                    if operationResult.exitOk && browser.valid then
                       upsertBrowserNode path browser st.browserNodes
                     else
                       st.browserNodes
                 , expandedPaths =
-                    if rpcResult.exitOk && browser.valid then
+                    if operationResult.exitOk && browser.valid then
                       expandPath path st.expandedPaths
                     else
                       st.expandedPaths
                 , browserPath = browser.currentPath
                 , fetchError =
-                    if rpcResult.exitOk && browser.valid then Nothing
-                    else Just (if rpcResult.stderr == "" then "Haskell RPC browse failed." else rpcResult.stderr)
+                    if operationResult.exitOk && browser.valid then Nothing
+                    else Just (if operationResult.stderr == "" then "Haskell ledger operation browse failed." else operationResult.stderr)
                 }

--- a/nix/wasm/tx-inspector/wasm-tx-inspector/app/Main.hs
+++ b/nix/wasm/tx-inspector/wasm-tx-inspector/app/Main.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-{- | WASI reactor entry: read either raw Conway tx hex or a JSON RPC envelope
-  on stdin, write JSON on stdout. Error category on stderr, non-zero exit,
-  no partial JSON on stdout.
+{- | WASI reactor entry: read either raw Conway tx hex or a JSON ledger-operation
+  envelope on stdin, write JSON on stdout. Error category on stderr, non-zero
+  exit, no partial JSON on stdout.
 -}
 module Main (main) where
 
@@ -17,12 +17,13 @@ import System.IO (hPutStrLn, stderr, stdout)
 main :: IO ()
 main = do
     input <- BS.getContents
-    case Inspector.rpc input of
+    case Inspector.runLedgerOperationInput input of
         Left (Inspector.MalformedHex err) -> die "malformed_hex" err
         Left (Inspector.MalformedCbor err) -> die "malformed_cbor" err
-        Left (Inspector.MalformedRpc err) -> die "malformed_rpc" err
-        Left (Inspector.UnknownRpcMethod method) ->
-            die "unknown_rpc_method" (T.unpack method)
+        Left (Inspector.MalformedLedgerOperation err) ->
+            die "malformed_ledger_operation" err
+        Left (Inspector.UnknownLedgerOperation operation) ->
+            die "unknown_ledger_operation" (T.unpack operation)
         Right value -> do
             BSL.hPut stdout (Aeson.encode value)
             BSL.hPut stdout "\n"

--- a/nix/wasm/tx-inspector/wasm-tx-inspector/src/Conway/Inspector.hs
+++ b/nix/wasm/tx-inspector/wasm-tx-inspector/src/Conway/Inspector.hs
@@ -6,13 +6,14 @@
 
   Decoder-only: no signature checking, no script evaluation, no fee
   validation. The hard work (CBOR → Conway `Tx`) is delegated to the
-  upstream Haskell ledger packages. Browser-facing calls use a small RPC
-  envelope so each UI interaction can go back through the ledger value
-  instead of navigating a stale client-side JSON projection.
+  upstream Haskell ledger packages. Browser-facing calls use a small
+  ledger-operation envelope so each UI interaction can go back through
+  the ledger value instead of navigating a stale client-side JSON
+  projection.
 -}
 module Conway.Inspector (
     inspect,
-    rpc,
+    runLedgerOperationInput,
     InspectError (..),
 ) where
 
@@ -49,22 +50,51 @@ import Text.Read (readMaybe)
 data InspectError
     = MalformedHex String
     | MalformedCbor String
-    | MalformedRpc String
-    | UnknownRpcMethod T.Text
+    | MalformedLedgerOperation String
+    | UnknownLedgerOperation T.Text
     deriving (Show)
 
-data RpcRequest = RpcRequest
-    { rrTxCbor :: T.Text
-    , rrMethod :: T.Text
-    , rrPath :: [T.Text]
+data LedgerOperationRequest = LedgerOperationRequest
+    { lorTxCbor :: T.Text
+    , lorOperation :: T.Text
+    , lorPath :: [T.Text]
     }
 
-instance Aeson.FromJSON RpcRequest where
-    parseJSON = Aeson.withObject "RpcRequest" $ \o ->
-        RpcRequest
-            <$> o Aeson..: "tx_cbor"
-            <*> o Aeson..: "method"
-            <*> o Aeson..:? "path" Aeson..!= []
+instance Aeson.FromJSON LedgerOperationRequest where
+    parseJSON = Aeson.withObject "LedgerOperationRequest" $ \o -> do
+        txCbor <- o Aeson..: "tx_cbor"
+        operation <- parseOperation o
+        legacyPath <- o Aeson..:? "path" Aeson..!= []
+        args <- o Aeson..:? "args" Aeson..!= Aeson.object []
+        path <- parsePathArg args legacyPath
+        pure
+            LedgerOperationRequest
+                { lorTxCbor = txCbor
+                , lorOperation = normalizeOperation operation
+                , lorPath = path
+                }
+      where
+        parseOperation o = do
+            maybeOp <- o Aeson..:? "op"
+            case maybeOp of
+                Just op -> pure op
+                Nothing -> do
+                    maybeMethod <- o Aeson..:? "method"
+                    case maybeMethod of
+                        Just method -> pure method
+                        Nothing -> fail "missing required field: op"
+
+        parsePathArg args legacyPath =
+            case args of
+                Aeson.Object obj ->
+                    case KeyMap.lookup "path" obj of
+                        Just pathValue -> Aeson.parseJSON pathValue
+                        Nothing -> pure legacyPath
+                _ -> pure legacyPath
+
+        normalizeOperation "inspect" = "tx.inspect"
+        normalizeOperation "browse" = "tx.browse"
+        normalizeOperation op = op
 
 -- | Hex → bytes → Conway tx → JSON.
 inspect :: BS.ByteString -> Either InspectError Aeson.Value
@@ -72,45 +102,51 @@ inspect hexBytes = do
     tx <- decodeTx hexBytes
     pure (renderTx tx)
 
-{- | Browser/runtime RPC. If stdin is not a JSON RPC request, fall back to the
-  legacy raw-CBOR inspection path used by CLI recipes.
+{- | Browser/runtime ledger operation. If stdin is not a JSON operation request,
+  fall back to the legacy raw-CBOR inspection path used by CLI recipes.
 -}
-rpc :: BS.ByteString -> Either InspectError Aeson.Value
-rpc input =
+runLedgerOperationInput :: BS.ByteString -> Either InspectError Aeson.Value
+runLedgerOperationInput input =
     case Aeson.eitherDecodeStrict' input of
-        Right request -> runRpc request
+        Right request -> runLedgerOperation request
         Left err
-            | looksLikeRpc input -> Left (MalformedRpc err)
+            | looksLikeJsonRequest input -> Left (MalformedLedgerOperation err)
             | otherwise -> inspect input
 
-looksLikeRpc :: BS.ByteString -> Bool
-looksLikeRpc input =
+looksLikeJsonRequest :: BS.ByteString -> Bool
+looksLikeJsonRequest input =
     case BS.dropWhile isJsonWhitespace input of
         bs | BS.null bs -> False
         bs -> BS.head bs == 0x7b
   where
     isJsonWhitespace c = c == 0x20 || c == 0x09 || c == 0x0a || c == 0x0d
 
-runRpc :: RpcRequest -> Either InspectError Aeson.Value
-runRpc request = do
-    tx <- decodeTx (T.encodeUtf8 (rrTxCbor request))
-    case rrMethod request of
-        "inspect" ->
+runLedgerOperation :: LedgerOperationRequest -> Either InspectError Aeson.Value
+runLedgerOperation request = do
+    tx <- decodeTx (T.encodeUtf8 (lorTxCbor request))
+    case lorOperation request of
+        "tx.inspect" ->
             pure $
-                Aeson.object
-                    [ "rpc" .= ("conway-tx-inspector/v1" :: T.Text)
-                    , "method" .= rrMethod request
-                    , "inspection" .= renderTx tx
-                    , "browser" .= browserJson tx (rrPath request)
+                ledgerOperationResponse
+                    (lorOperation request)
+                    [ "inspection" .= renderTx tx
+                    , "browser" .= browserJson tx (lorPath request)
                     ]
-        "browse" ->
+        "tx.browse" ->
             pure $
-                Aeson.object
-                    [ "rpc" .= ("conway-tx-inspector/v1" :: T.Text)
-                    , "method" .= rrMethod request
-                    , "browser" .= browserJson tx (rrPath request)
+                ledgerOperationResponse
+                    (lorOperation request)
+                    [ "browser" .= browserJson tx (lorPath request)
                     ]
-        other -> Left (UnknownRpcMethod other)
+        other -> Left (UnknownLedgerOperation other)
+
+ledgerOperationResponse :: T.Text -> [(AesonKey.Key, Aeson.Value)] -> Aeson.Value
+ledgerOperationResponse operation resultFields =
+    Aeson.object
+        [ "ledger_functional_layer" .= ("cardano-ledger-functional/v1" :: T.Text)
+        , "op" .= operation
+        , "result" .= Aeson.object resultFields
+        ]
 
 decodeTx ::
     BS.ByteString ->
@@ -256,9 +292,9 @@ breadcrumbsFor path =
         , "path" .= encodePath []
         ]
         : [ Aeson.object
-                [ "label" .= label
-                , "path" .= encodePath (take n path)
-                ]
+            [ "label" .= label
+            , "path" .= encodePath (take n path)
+            ]
           | (n, label) <- zip [1 :: Int ..] path
           ]
 

--- a/specs/033-wasm-ledger-inspector/contracts/ledger-functional-api.md
+++ b/specs/033-wasm-ledger-inspector/contracts/ledger-functional-api.md
@@ -1,0 +1,88 @@
+# Ledger Functional Layer API
+
+The browser and any downstream application own transaction workspace state.
+The ledger layer receives explicit inputs and returns explicit results.
+
+## Request
+
+Ledger operation requests are JSON:
+
+```json
+{
+  "tx_cbor": "<hex-encoded Conway transaction>",
+  "op": "tx.inspect",
+  "args": {}
+}
+```
+
+- `tx_cbor` is required and is the canonical transaction document for the
+  operation.
+- `op` names the pure ledger operation.
+- `args` contains operation-specific JSON control-plane arguments.
+- Fidelity-sensitive ledger values remain CBOR hex inside JSON fields.
+
+For browser navigation:
+
+```json
+{
+  "tx_cbor": "<hex>",
+  "op": "tx.browse",
+  "args": {
+    "path": ["outputs", "#4", "assets"]
+  }
+}
+```
+
+## Response
+
+Successful ledger operations return JSON:
+
+```json
+{
+  "ledger_functional_layer": "cardano-ledger-functional/v1",
+  "op": "tx.inspect",
+  "result": {}
+}
+```
+
+- `ledger_functional_layer` identifies the envelope version.
+- `op` echoes the operation that ran.
+- `result` is operation-specific JSON.
+- Mutating operations MUST include the resulting transaction CBOR in
+  `result.tx_cbor`.
+
+## Initial Operations
+
+### `tx.inspect`
+
+Decode the supplied transaction CBOR with the Haskell ledger and return:
+
+```json
+{
+  "inspection": {},
+  "browser": {}
+}
+```
+
+`inspection` is the compact transaction summary. `browser` is the root browser
+view used by the UI tree.
+
+### `tx.browse`
+
+Decode the supplied transaction CBOR with the Haskell ledger and return the
+browser view at `args.path`:
+
+```json
+{
+  "browser": {}
+}
+```
+
+The browser MUST send the full current `tx_cbor` on every browse operation.
+The ledger layer MAY cache decoded values, but cache state is not authoritative.
+
+## Compatibility
+
+During the transition from the earlier browser prototype, the WASM executable
+MAY accept legacy requests containing `method` and top-level `path`. New callers
+MUST use `op` and `args.path`.


### PR DESCRIPTION
## Summary

This starts the functional-layer API work on top of the merged WASM DevX branch.

The browser/WASM boundary is no longer described or shaped as RPC. The initial envelope is now a ledger operation request:

```json
{
  "tx_cbor": "<hex>",
  "op": "tx.inspect",
  "args": {}
}
```

Responses now identify the functional layer and wrap operation-specific data under `result`:

```json
{
  "ledger_functional_layer": "cardano-ledger-functional/v1",
  "op": "tx.inspect",
  "result": {}
}
```

## What changed

- Added `specs/033-wasm-ledger-inspector/contracts/ledger-functional-api.md` as the first explicit contract for the JSON-control / CBOR-data boundary.
- Renamed the Haskell runtime entry from `rpc` to `runLedgerOperationInput`.
- Replaced `RpcRequest` with `LedgerOperationRequest`.
- Added namespaced operations `tx.inspect` and `tx.browse`.
- Moved browser path input under `args.path`.
- Updated PureScript/JS FFI names from `runInspectorRpc` to `runLedgerOperation`.
- Updated JSON response parsing to consume the new `result.inspection` and `result.browser` shape.
- Bumped the inspector script cache key to `ledger-functional-api-1`.

## Compatibility

The WASM executable still accepts the old prototype shape during transition:

```json
{
  "tx_cbor": "<hex>",
  "method": "browse",
  "path": ["outputs"]
}
```

That legacy input is normalized to `op: "tx.browse"` internally. New callers should use `op` and `args.path` only.

## Verification

- `nix build .#packages.x86_64-linux.wasm-tx-inspector`
- `nix shell 'github:paolino/purescript-overlay?ref=fix/remove-nodePackages#purs' 'github:paolino/purescript-overlay?ref=fix/remove-nodePackages#spago-unstable' -c spago build`
- `nix build .#packages.x86_64-linux.tx-inspector-ui`
- `nix develop -c fourmolu -m check nix/wasm/tx-inspector/wasm-tx-inspector/app/Main.hs nix/wasm/tx-inspector/wasm-tx-inspector/src/Conway/Inspector.hs`
- `git diff --check`
- WASM CLI smoke: `tx.inspect` returns `cardano-ledger-functional/v1`, an inspection result, and 14 root browser rows.
- WASM CLI smoke: `tx.browse` on `args.path=["outputs"]` returns title `outputs` and 3 rows.
- Legacy input smoke: old `method: "browse"` + top-level `path` still normalizes to `tx.browse`.
- Local Playwright smoke against the built UI confirmed the browser sends `tx.inspect` / `tx.browse` with `args.path`, and does not send `method` or top-level `path`.

## Stack

Base branch: `033-wasm-ledger-inspector` / PR #69.

This PR should be reviewed as the first API slice after #71 was merged.

## Deployment

Published to Surge after the UI package build: https://cardano-tx-inspector.surge.sh


Live verification:
- Playwright loaded https://cardano-tx-inspector.surge.sh and confirmed `index.js?v=ledger-functional-api-1`.
- Latest live console check: no errors or warnings after reload.
