### PR TITLE
feat: fold residual mint/multi-asset into change output

### DIFF
--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -183,19 +183,23 @@ test-suite e2e-tests
     Cardano.Node.Client.E2E.BalanceSpec
     Cardano.Node.Client.E2E.ChainPopulatorSpec
     Cardano.Node.Client.E2E.ChainSyncSpec
+    Cardano.Node.Client.E2E.MultiAssetChangeSpec
     Cardano.Node.Client.E2E.ProviderSpec
     Cardano.Node.Client.E2E.TxBuildSpec
 
   build-depends:
     , async
     , base
+    , base16-bytestring
     , bytestring
     , cardano-crypto-class
     , cardano-ledger-allegra
+    , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-byron
     , cardano-ledger-conway
     , cardano-ledger-core
+    , cardano-ledger-mary
     , cardano-ledger-read
     , cardano-node-clients
     , cardano-node-clients:devnet

--- a/lib/Cardano/Node/Client/Balance.hs
+++ b/lib/Cardano/Node/Client/Balance.hs
@@ -472,6 +472,14 @@ exceed the budget are terminated. This value is
 injected before 'evaluateTx' so scripts get
 enough room to run, then replaced by the real
 ExUnits from the evaluation result.
+
+Sized to mainnet's Conway-era @maxTxExUnits@
+(epoch 627+: 16_500_000 mem, 10_000_000_000
+steps), so heavy scripts that already run on
+mainnet — e.g. asteria's @add_new_ship@ — fit
+under the eval budget locally too. Submission
+fails the same way as it would on mainnet if a
+script's actual usage exceeds the cluster's pp.
 -}
 evalBudgetExUnits :: ExUnits
-evalBudgetExUnits = ExUnits 14_000_000 10_000_000_000
+evalBudgetExUnits = ExUnits 16_500_000 10_000_000_000

--- a/lib/Cardano/Node/Client/Balance.hs
+++ b/lib/Cardano/Node/Client/Balance.hs
@@ -12,10 +12,19 @@ estimated iteratively via 'estimateMinFeeTx' from
 (at most 10 rounds). The function internally injects
 dummy VKey witnesses for correct size estimation.
 
-This is a simplified balancer that only handles
-ADA-only fee inputs. Multi-asset coin selection is
-out of scope — callers construct the script inputs
-and this module adds the fee delta.
+The change output absorbs both the residual ADA
+(@input − fee − sum(existing output ADA)@) and any
+residual multi-assets (@sum(input MA) + mint −
+sum(existing output MA)@). This lets callers mint
+NFTs without emitting an explicit recipient output:
+the minted asset lands in the change output along
+with the ADA leftovers, matching the convention of
+mainnet off-chain code that returns the PILOT NFT in
+the same output as the player's ADA change.
+
+Multi-asset coin selection is still out of scope —
+callers construct the script inputs and this module
+only folds the leftover into a single change output.
 -}
 module Cardano.Node.Client.Balance (
     -- * Balancing
@@ -62,23 +71,29 @@ import Cardano.Ledger.Api.Tx (
 import Cardano.Ledger.Api.Tx.Body (
     feeTxBodyL,
     inputsTxBodyL,
+    mintTxBodyL,
     outputsTxBodyL,
     referenceInputsTxBodyL,
  )
 import Cardano.Ledger.Api.Tx.Out (
     TxOut,
-    coinTxOutL,
     mkBasicTxOut,
     referenceScriptTxOutL,
+    valueTxOutL,
  )
 import Cardano.Ledger.BaseTypes (
-    Inject (..),
     StrictMaybe (SJust, SNothing),
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core (PParams)
 import Cardano.Ledger.Hashes (originalBytes)
+import Cardano.Ledger.Mary.Value (
+    MaryValue (..),
+    MultiAsset (..),
+    filterMultiAsset,
+    mapMaybeMultiAsset,
+ )
 import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
 import Cardano.Ledger.Plutus.Language (Language)
 import Cardano.Ledger.TxIn (TxIn)
@@ -137,30 +152,56 @@ balanceTx pp inputUtxos refUtxos changeAddr tx =
             refScriptsSize
                 (body ^. referenceInputsTxBodyL)
                 refUtxos
-        inputCoin =
+        valueOf o = let MaryValue c m = o ^. valueTxOutL in (c, m)
+        sumValues ::
+            (Foldable t) =>
+            t (TxOut ConwayEra) ->
+            (Coin, MultiAsset)
+        sumValues =
             foldl'
-                ( \(Coin acc) (_, o) ->
-                    let Coin c = o ^. coinTxOutL
-                     in Coin (acc + c)
+                ( \(Coin a, ma) o ->
+                    let (Coin c, m) = valueOf o
+                     in (Coin (a + c), ma <> m)
                 )
-                (Coin 0)
-                inputUtxos
+                (Coin 0, mempty)
+        (inputCoin, inputMA) = sumValues (map snd inputUtxos)
         newInputs =
             foldl'
                 (\s (tin, _) -> Set.insert tin s)
                 (body ^. inputsTxBodyL)
                 inputUtxos
         origOutputs = body ^. outputsTxBodyL
-        -- Sum ADA already committed in existing
-        -- outputs (e.g. cage output with 2 ADA).
-        Coin origAda =
-            foldl'
-                ( \(Coin acc) o ->
-                    let Coin c = o ^. coinTxOutL
-                     in Coin (acc + c)
+        -- Sum ADA / multi-assets already committed
+        -- in existing outputs (e.g. asteria + ship
+        -- outputs in a spawn-ship tx).
+        (Coin origAda, origMA) = sumValues origOutputs
+        bodyMint :: MultiAsset
+        bodyMint = body ^. mintTxBodyL
+        -- Residual multi-assets that no existing
+        -- output absorbed: input + mint − output.
+        -- A positive residual indicates minted tokens
+        -- (e.g. a PILOT NFT) or unspent input assets
+        -- that must land in the change output to
+        -- satisfy the ledger's value-conservation
+        -- equation.
+        --
+        -- Negative entries — output references assets
+        -- the balancer wasn't told about — are
+        -- filtered out: the caller has already
+        -- balanced those via inputs not surfaced in
+        -- @inputUtxos@, and the ledger checks
+        -- conservation against the real UTxO state
+        -- at submission time.
+        changeMA :: MultiAsset
+        changeMA =
+            filterMultiAsset
+                (\_ _ q -> q > 0)
+                ( inputMA
+                    <> bodyMint
+                    <> mapMaybeMultiAsset
+                        (\_ _ q -> Just (negate q))
+                        origMA
                 )
-                (Coin 0)
-                origOutputs
         -- Build a candidate tx for a given fee.
         -- Change is clamped to 0 so fee estimation
         -- works even when funds are insufficient.
@@ -174,7 +215,7 @@ balanceTx pp inputUtxos refUtxos changeAddr tx =
                 changeOut =
                     mkBasicTxOut
                         changeAddr
-                        (inject (Coin change))
+                        (MaryValue (Coin change) changeMA)
                 finalBody =
                     body
                         & inputsTxBodyL

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -75,6 +75,9 @@ module Cardano.Node.Client.TxBuild (
     draft,
     draftWith,
     build,
+    buildWith,
+    BuildOptions (..),
+    defaultBuildOptions,
 
     -- * Errors
     BuildError (..),
@@ -866,6 +869,31 @@ the Tx body stabilizes:
 5. Balance (fee + change)
 6. If any Peek returned Iterate or Tx changed → 1
 -}
+{- | Knobs that influence 'buildWith'. New options
+will be added here without breaking 'build', whose
+default behaviour is preserved by 'defaultBuildOptions'.
+-}
+data BuildOptions = BuildOptions
+    { boExUnitsMargin :: !(ExUnits -> ExUnits)
+    -- ^ Transform each redeemer's evaluated 'ExUnits'
+    -- before the integrity hash is recomputed and the
+    -- tx is balanced. Defaults to 'id'.
+    --
+    -- Use a small overshoot (e.g. @1.20×@, mirroring
+    -- @cardano-cli@) when the client-side ledger
+    -- evaluator (the one running here, via
+    -- @evalTxExUnits@) is older than the cluster
+    -- node's: the same script can cost a few hundred
+    -- mem / a few hundred-thousand steps more on the
+    -- newer side, and that delta lands as
+    -- 'PlutusFailure' at submit time even though the
+    -- shape of the tx is correct.
+    }
+
+-- | All defaults preserve pre-'buildWith' behaviour.
+defaultBuildOptions :: BuildOptions
+defaultBuildOptions = BuildOptions{boExUnitsMargin = id}
+
 build ::
     PParams ConwayEra ->
     InterpretIO q ->
@@ -893,7 +921,29 @@ build ::
     Addr ->
     TxBuild q e a ->
     IO (Either (BuildError e) ConwayTx)
-build pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
+build = buildWith defaultBuildOptions
+
+-- | 'build' with explicit 'BuildOptions'.
+buildWith ::
+    BuildOptions ->
+    PParams ConwayEra ->
+    InterpretIO q ->
+    ( ConwayTx ->
+      IO
+        ( Map
+            ( ConwayPlutusPurpose
+                AsIx
+                ConwayEra
+            )
+            (Either String ExUnits)
+        )
+    ) ->
+    [(TxIn, TxOut ConwayEra)] ->
+    [(TxIn, TxOut ConwayEra)] ->
+    Addr ->
+    TxBuild q e a ->
+    IO (Either (BuildError e) ConwayTx)
+buildWith opts pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
     step Set.empty (Coin 0) 0 (mkBasicTx mkBasicTxBody)
   where
     -- Pre-compute the extra TxIns from inputUtxos
@@ -1303,10 +1353,14 @@ build pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
                                         ChecksFailed
                                             errs
 
-    -- \| Patch ExUnits from eval result.
+    -- \| Patch ExUnits from eval result, applying
+    -- the caller-supplied 'boExUnitsMargin'
+    -- transform. Default options leave the value
+    -- untouched (identity).
     patchExUnits tx evalResult =
         let Redeemers rdmrMap =
                 tx ^. witsTxL . rdmrsTxWitsL
+            margin = boExUnitsMargin opts
             patched =
                 Map.mapWithKey
                     ( \purpose (dat, eu) ->
@@ -1314,7 +1368,7 @@ build pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
                             purpose
                             evalResult of
                             Just (Right eu') ->
-                                (dat, eu')
+                                (dat, margin eu')
                             _ -> (dat, eu)
                     )
                     rdmrMap

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -869,12 +869,13 @@ the Tx body stabilizes:
 5. Balance (fee + change)
 6. If any Peek returned Iterate or Tx changed → 1
 -}
+
 {- | Knobs that influence 'buildWith'. New options
 will be added here without breaking 'build', whose
 default behaviour is preserved by 'defaultBuildOptions'.
 -}
-data BuildOptions = BuildOptions
-    { boExUnitsMargin :: !(ExUnits -> ExUnits)
+newtype BuildOptions = BuildOptions
+    { boExUnitsMargin :: ExUnits -> ExUnits
     -- ^ Transform each redeemer's evaluated 'ExUnits'
     -- before the integrity hash is recomputed and the
     -- tx is balanced. Defaults to 'id'.

--- a/test/Cardano/Node/Client/BalanceSpec.hs
+++ b/test/Cardano/Node/Client/BalanceSpec.hs
@@ -28,6 +28,7 @@ import Cardano.Ledger.Api.Tx (
  )
 import Cardano.Ledger.Api.Tx.Body (
     feeTxBodyL,
+    mintTxBodyL,
     mkBasicTxBody,
     outputsTxBodyL,
     referenceInputsTxBodyL,
@@ -36,6 +37,7 @@ import Cardano.Ledger.Api.Tx.Out (
     coinTxOutL,
     mkBasicTxOut,
     referenceScriptTxOutL,
+    valueTxOutL,
  )
 import Cardano.Ledger.BaseTypes (
     Inject (..),
@@ -66,10 +68,16 @@ import Cardano.Ledger.Credential (
     Credential (KeyHashObj),
     StakeReference (StakeRefNull),
  )
-import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
+import Cardano.Ledger.Hashes (ScriptHash (..), unsafeMakeSafeHash)
 import Cardano.Ledger.Keys (
     KeyHash (..),
     KeyRole (Payment),
+ )
+import Cardano.Ledger.Mary.Value (
+    AssetName (..),
+    MaryValue (..),
+    MultiAsset (..),
+    PolicyID (..),
  )
 import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
 import Cardano.Ledger.Plutus.Language (
@@ -99,6 +107,7 @@ spec = describe "Balance helpers" $ do
     computeScriptIntegritySpec
     placeholderExUnitsSpec
     balanceTxSpec
+    balanceTxMultiAssetSpec
     refScriptsSizeSpec
     balanceTxRefScriptFeeSpec
 
@@ -487,3 +496,177 @@ balanceTxRefScriptFeeSpec =
                 pure (Coin 0)
             Right BalanceResult{balancedTx = bal} ->
                 pure (bal ^. bodyTxL . feeTxBodyL)
+
+-- -----------------------------------------------------------
+-- balanceTx multi-asset change folding
+-- -----------------------------------------------------------
+
+-- | Deterministic policy ID from an Int.
+mkPolicy :: Int -> PolicyID
+mkPolicy n =
+    let hexStr =
+            replicate 52 '0'
+                ++ hexByte (n `div` 256)
+                ++ hexByte (n `mod` 256)
+        h = fromJust (hashFromStringAsHex hexStr)
+     in PolicyID (ScriptHash h)
+  where
+    hexByte b =
+        let (hi, lo) = b `divMod` 16
+         in [hexDigit hi, hexDigit lo]
+    hexDigit d
+        | d < 10 = toEnum (fromEnum '0' + d)
+        | otherwise = toEnum (fromEnum 'a' + d - 10)
+
+mkAssetName :: BS8.ByteString -> AssetName
+mkAssetName = AssetName . SBS.toShort
+
+singletonMA :: PolicyID -> AssetName -> Integer -> MultiAsset
+singletonMA p a q =
+    MultiAsset (Map.singleton p (Map.singleton a q))
+
+balanceTxMultiAssetSpec :: Spec
+balanceTxMultiAssetSpec =
+    describe "balanceTx multi-asset change folding" $ do
+        it "folds minted NFT into the change output" $ do
+            let pp =
+                    emptyPParams @ConwayEra
+                        & ppTxFeePerByteL
+                            .~ CoinPerByte
+                                (compactCoinOrError (Coin 44))
+                        & ppTxFeeFixedL .~ Coin 155381
+                policy = mkPolicy 7
+                pilot = mkAssetName "PILOT0"
+                mintMA = singletonMA policy pilot 1
+                inputUtxos =
+                    [
+                        ( mkTxIn 1
+                        , mkBasicTxOut
+                            (mkAddr 1)
+                            (inject (Coin 10_000_000))
+                        )
+                    ]
+                template =
+                    mkBasicTx $
+                        mkBasicTxBody
+                            & outputsTxBodyL
+                                .~ StrictSeq.singleton
+                                    ( mkBasicTxOut
+                                        (mkAddr 2)
+                                        (inject (Coin 3_000_000))
+                                    )
+                            & mintTxBodyL .~ mintMA
+            case balanceTx pp inputUtxos [] (mkAddr 3) template of
+                Left err -> expectationFailure (show err)
+                Right BalanceResult{balancedTx = tx} -> do
+                    let outs =
+                            foldr (:) [] (tx ^. bodyTxL . outputsTxBodyL)
+                        MaryValue _ changeMA =
+                            last outs ^. valueTxOutL
+                    changeMA `shouldBe` mintMA
+
+        it "non-minting tx still produces ADA-only change" $ do
+            let pp =
+                    emptyPParams @ConwayEra
+                        & ppTxFeePerByteL
+                            .~ CoinPerByte
+                                (compactCoinOrError (Coin 44))
+                        & ppTxFeeFixedL .~ Coin 155381
+                inputUtxos =
+                    [
+                        ( mkTxIn 1
+                        , mkBasicTxOut
+                            (mkAddr 1)
+                            (inject (Coin 10_000_000))
+                        )
+                    ]
+                template =
+                    mkBasicTx $
+                        mkBasicTxBody
+                            & outputsTxBodyL
+                                .~ StrictSeq.singleton
+                                    ( mkBasicTxOut
+                                        (mkAddr 2)
+                                        (inject (Coin 3_000_000))
+                                    )
+            case balanceTx pp inputUtxos [] (mkAddr 3) template of
+                Left err -> expectationFailure (show err)
+                Right BalanceResult{balancedTx = tx} -> do
+                    let outs =
+                            foldr (:) [] (tx ^. bodyTxL . outputsTxBodyL)
+                        MaryValue _ changeMA =
+                            last outs ^. valueTxOutL
+                    changeMA `shouldBe` mempty
+
+        it "passes through asset already present in input" $ do
+            let pp =
+                    emptyPParams @ConwayEra
+                        & ppTxFeePerByteL
+                            .~ CoinPerByte
+                                (compactCoinOrError (Coin 44))
+                        & ppTxFeeFixedL .~ Coin 155381
+                policy = mkPolicy 8
+                token = mkAssetName "TOKEN"
+                inputMA = singletonMA policy token 5
+                inputUtxos =
+                    [
+                        ( mkTxIn 1
+                        , mkBasicTxOut
+                            (mkAddr 1)
+                            (MaryValue (Coin 10_000_000) inputMA)
+                        )
+                    ]
+                template =
+                    mkBasicTx $
+                        mkBasicTxBody
+                            & outputsTxBodyL
+                                .~ StrictSeq.singleton
+                                    ( mkBasicTxOut
+                                        (mkAddr 2)
+                                        (inject (Coin 3_000_000))
+                                    )
+            case balanceTx pp inputUtxos [] (mkAddr 3) template of
+                Left err -> expectationFailure (show err)
+                Right BalanceResult{balancedTx = tx} -> do
+                    let outs =
+                            foldr (:) [] (tx ^. bodyTxL . outputsTxBodyL)
+                        MaryValue _ changeMA =
+                            last outs ^. valueTxOutL
+                    changeMA `shouldBe` inputMA
+
+        it "subtracts asset already absorbed by an existing output" $ do
+            let pp =
+                    emptyPParams @ConwayEra
+                        & ppTxFeePerByteL
+                            .~ CoinPerByte
+                                (compactCoinOrError (Coin 44))
+                        & ppTxFeeFixedL .~ Coin 155381
+                policy = mkPolicy 9
+                token = mkAssetName "TOKEN"
+                inputMA = singletonMA policy token 5
+                outputMA = singletonMA policy token 2
+                inputUtxos =
+                    [
+                        ( mkTxIn 1
+                        , mkBasicTxOut
+                            (mkAddr 1)
+                            (MaryValue (Coin 10_000_000) inputMA)
+                        )
+                    ]
+                template =
+                    mkBasicTx $
+                        mkBasicTxBody
+                            & outputsTxBodyL
+                                .~ StrictSeq.singleton
+                                    ( mkBasicTxOut
+                                        (mkAddr 2)
+                                        (MaryValue (Coin 3_000_000) outputMA)
+                                    )
+            case balanceTx pp inputUtxos [] (mkAddr 3) template of
+                Left err -> expectationFailure (show err)
+                Right BalanceResult{balancedTx = tx} -> do
+                    let outs =
+                            foldr (:) [] (tx ^. bodyTxL . outputsTxBodyL)
+                        MaryValue _ changeMA =
+                            last outs ^. valueTxOutL
+                    changeMA `shouldBe` singletonMA policy token 3

--- a/test/Cardano/Node/Client/E2E/MultiAssetChangeSpec.hs
+++ b/test/Cardano/Node/Client/E2E/MultiAssetChangeSpec.hs
@@ -1,0 +1,265 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Cardano.Node.Client.E2E.MultiAssetChangeSpec
+Description : E2E test: balanceTx folds minted NFT into change.
+
+Exercises the residual-multi-asset folding added to 'balanceTx'.
+A spawn-style transaction:
+
+  * spends a genesis UTxO,
+  * mints 1 unit of an always-true policy with no explicit
+    recipient output,
+  * pays a fixed-coin output to a third-party recipient.
+
+Without the folding patch, the balancer would emit an ADA-only
+change output and the ledger would reject the tx with
+'ValueNotConserved' (the minted token has no destination). With
+the patch, the change output absorbs the NFT and the tx is
+accepted on the devnet.
+-}
+module Cardano.Node.Client.E2E.MultiAssetChangeSpec (spec) where
+
+import Control.Concurrent (threadDelay)
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Char8 qualified as BS8
+import Data.ByteString.Short qualified as SBS
+import Data.Foldable (toList)
+import Data.Map.Strict qualified as Map
+import Data.Void (Void)
+import Lens.Micro ((^.))
+import Test.Hspec
+
+import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Alonzo.Scripts (
+    fromPlutusScript,
+    mkPlutusScript,
+ )
+import Cardano.Ledger.Api.Tx (bodyTxL)
+import Cardano.Ledger.Api.Tx.Body (outputsTxBodyL)
+import Cardano.Ledger.Api.Tx.Out (
+    TxOut,
+    coinTxOutL,
+    valueTxOutL,
+ )
+import Cardano.Ledger.BaseTypes (Inject (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core (PParams, Script, hashScript)
+import Cardano.Ledger.Hashes (ScriptHash)
+import Cardano.Ledger.Mary.Value (
+    AssetName (..),
+    MaryValue (..),
+    MultiAsset (..),
+    PolicyID (..),
+ )
+import Cardano.Ledger.Plutus.Language (
+    Language (PlutusV3),
+    Plutus (..),
+    PlutusBinary (..),
+ )
+import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Node.Client.E2E.Setup (
+    addKeyWitness,
+    enterpriseAddr,
+    genesisAddr,
+    genesisSignKey,
+    keyHashFromSignKey,
+    mkSignKey,
+    withDevnet,
+ )
+import Cardano.Node.Client.N2C.Provider (mkN2CProvider)
+import Cardano.Node.Client.N2C.Submitter (mkN2CSubmitter)
+import Cardano.Node.Client.Provider (Provider (..))
+import Cardano.Node.Client.Submitter (
+    SubmitResult (..),
+    Submitter (..),
+ )
+import Cardano.Node.Client.TxBuild (
+    InterpretIO (..),
+    TxBuild,
+    attachScript,
+    build,
+    collateral,
+    mint,
+    payTo,
+    spend,
+ )
+
+spec :: Spec
+spec =
+    around withEnv $
+        describe "balanceTx multi-asset change folding (E2E)" $
+            it
+                "folds minted NFT into change output and submits successfully"
+                mintsNftIntoChange
+
+type Env =
+    ( Provider IO
+    , Submitter IO
+    , PParams ConwayEra
+    , [(TxIn, TxOut ConwayEra)]
+    )
+
+withEnv :: (Env -> IO ()) -> IO ()
+withEnv action =
+    withDevnet $ \lsq ltxs -> do
+        let provider = mkN2CProvider lsq
+            submitter = mkN2CSubmitter ltxs
+        pp <- queryProtocolParams provider
+        utxos <- queryUTxOs provider genesisAddr
+        action (provider, submitter, pp, utxos)
+
+-- | A Plutus V3 always-true minting policy (215 bytes of CBOR).
+alwaysTrueScript :: Script ConwayEra
+alwaysTrueScript =
+    let bytes =
+            either error id $
+                Base16.decode (BS8.filter (/= '\n') alwaysTrueHex)
+        plutus =
+            Plutus @PlutusV3
+                (PlutusBinary (SBS.toShort bytes))
+     in maybe
+            (error "alwaysTrueScript: mkPlutusScript")
+            fromPlutusScript
+            (mkPlutusScript plutus)
+
+alwaysTrueHex :: BS8.ByteString
+alwaysTrueHex =
+    "58d501010029800aba2aba1aab9eaab9dab9a48888966002646465\
+    \300130053754003300700398038012444b30013370e9000001c4c\
+    \9289bae300a3009375400915980099b874800800e2646644944c0\
+    \2c004c02cc030004c024dd5002456600266e1d200400389925130\
+    \0a3009375400915980099b874801800e2646644944dd698058009\
+    \805980600098049baa0048acc004cdc3a40100071324a26014601\
+    \26ea80122646644944dd698058009805980600098049baa004401\
+    \c8039007200e401c3006300700130060013003375400d149a26ca\
+    \c8009"
+
+mintsNftIntoChange :: Env -> IO ()
+mintsNftIntoChange (provider, submitter, pp, utxos) = do
+    seed@(seedIn, _) <- case utxos of
+        u : _ -> pure u
+        [] -> fail "no genesis UTxOs"
+    let recipient =
+            enterpriseAddr $
+                keyHashFromSignKey $
+                    mkSignKey
+                        (BS8.pack (replicate 32 'r'))
+        policyHash :: ScriptHash
+        policyHash = hashScript alwaysTrueScript
+        policy = PolicyID policyHash
+        nftName =
+            AssetName (SBS.toShort (BS8.pack "PILOT0"))
+        recipientCoin = Coin 3_000_000
+        interpret :: InterpretIO NoQ
+        interpret = InterpretIO $ \case {}
+        eval tx =
+            fmap
+                (Map.map (either (Left . show) Right))
+                (evaluateTx provider tx)
+        prog :: TxBuild NoQ Void ()
+        prog = do
+            _ <- spend seedIn
+            collateral seedIn
+            attachScript alwaysTrueScript
+            -- Mint without an explicit recipient
+            -- output for the NFT — the balancer must
+            -- fold it into the change output.
+            mint policy (Map.singleton nftName 1) ()
+            _ <- payTo recipient (inject recipientCoin)
+            pure ()
+
+    build pp interpret eval [seed] [] genesisAddr prog
+        >>= \case
+            Left err -> expectationFailure (show err)
+            Right tx -> do
+                let outs =
+                        toList
+                            (tx ^. bodyTxL . outputsTxBodyL)
+                length outs `shouldBe` 2
+                case outs of
+                    [recipientOut, changeOut] -> do
+                        recipientOut ^. coinTxOutL
+                            `shouldBe` recipientCoin
+                        let MaryValue _ recipientMA =
+                                recipientOut ^. valueTxOutL
+                            MaryValue _ changeMA =
+                                changeOut ^. valueTxOutL
+                            expectedMA =
+                                MultiAsset $
+                                    Map.singleton
+                                        policy
+                                        (Map.singleton nftName 1)
+                        recipientMA `shouldBe` mempty
+                        changeMA `shouldBe` expectedMA
+                    _ ->
+                        expectationFailure
+                            "expected recipient + change outputs"
+
+                let signed = addKeyWitness genesisSignKey tx
+                submitTx submitter signed
+                    >>= \case
+                        Submitted _ -> pure ()
+                        Rejected reason ->
+                            expectationFailure $
+                                "submitTx rejected: "
+                                    <> show reason
+
+                changeUtxos <-
+                    waitForUtxoWithMA
+                        provider
+                        genesisAddr
+                        policy
+                        nftName
+                        30
+                case changeUtxos of
+                    [] ->
+                        expectationFailure
+                            "no change UTxO with the minted NFT \
+                            \appeared at genesisAddr"
+                    (_, out) : _ -> do
+                        let MaryValue _ ma =
+                                out ^. valueTxOutL
+                            MultiAsset entries = ma
+                        Map.lookup policy entries
+                            `shouldBe` Just
+                                (Map.singleton nftName 1)
+
+-- | Phantom query GADT — this test has no @ctx@ queries.
+data NoQ a
+
+waitForUtxoWithMA ::
+    Provider IO ->
+    Addr ->
+    PolicyID ->
+    AssetName ->
+    Int ->
+    IO [(TxIn, TxOut ConwayEra)]
+waitForUtxoWithMA provider addr policy name attempts
+    | attempts <= 0 = pure []
+    | otherwise = do
+        utxos <- queryUTxOs provider addr
+        let matching =
+                [ (i, o)
+                | (i, o) <- utxos
+                , let MaryValue _ (MultiAsset m) =
+                        o ^. valueTxOutL
+                , case Map.lookup policy m of
+                    Just inner ->
+                        Map.lookup name inner == Just 1
+                    Nothing -> False
+                ]
+        if null matching
+            then do
+                threadDelay 1_000_000
+                waitForUtxoWithMA
+                    provider
+                    addr
+                    policy
+                    name
+                    (attempts - 1)
+            else pure matching

--- a/test/main.hs
+++ b/test/main.hs
@@ -5,6 +5,7 @@ import Test.Hspec (hspec)
 import Cardano.Node.Client.E2E.BalanceSpec qualified as BalanceSpec
 import Cardano.Node.Client.E2E.ChainPopulatorSpec qualified as ChainPopulatorSpec
 import Cardano.Node.Client.E2E.ChainSyncSpec qualified as ChainSyncSpec
+import Cardano.Node.Client.E2E.MultiAssetChangeSpec qualified as MultiAssetChangeSpec
 import Cardano.Node.Client.E2E.ProviderSpec qualified as ProviderSpec
 import Cardano.Node.Client.E2E.TxBuildSpec qualified as TxBuildSpec
 
@@ -13,5 +14,6 @@ main = hspec $ do
     ProviderSpec.spec
     BalanceSpec.spec
     TxBuildSpec.spec
+    MultiAssetChangeSpec.spec
     ChainSyncSpec.spec
     ChainPopulatorSpec.spec


### PR DESCRIPTION
## Summary

Three orthogonal fixes that together unblock asteria-style transactions for downstream off-chain code:

1. **`balanceTx` folds residual mint / multi-assets into the change output** (was: ADA-only change). Mints land in the same UTxO as the ADA change, mirroring `cardano-cli`'s default and the shape mainnet asteria off-chain code produces.
2. **`evalBudgetExUnits` bumped from 14 M → 16.5 M memory** to match Conway mainnet `maxTxExUnits`. Heavy validators (asteria's `add_new_ship` is ~14 – 15 M memory after our local rebuild) no longer terminate mid-eval.
3. **Opt-in ExUnits safety margin via `BuildOptions` + `buildWith`**. Default behaviour (`build`) is unchanged — `defaultBuildOptions` uses `id`. Callers that face cardano-ledger version drift between client (here) and the cluster's node can pass e.g. a `1.20×` overshoot, mirroring `cardano-cli` defaults, so the patched per-redeemer ExUnits land above the cluster's submit-time evaluator's actual cost.

The drop in script-context output count *and* the ledger version drift surfaced together while wiring asteria into the antithesis cluster (`cardano-foundation/cardano-node-antithesis#56`). The two-line workaround there is `Game.hs` no longer emitting an explicit `payTo` for the PILOT NFT plus `PlayerMain.hs` calling `buildWith (defaultBuildOptions { boExUnitsMargin = 1.2× })`.

## Behavioural changes

- `balanceTx` change output: `MaryValue (Coin n) residualPositiveMA` (was: `MaryValue (Coin n) mempty`). Negative residuals are dropped — the caller already balanced those via inputs not surfaced in `inputUtxos`.
- `evalBudgetExUnits`: `ExUnits 16_500_000 10_000_000_000` (was: `ExUnits 14_000_000 10_000_000_000`).
- New API: `buildWith :: BuildOptions -> ...` and `BuildOptions { boExUnitsMargin :: ExUnits -> ExUnits }`. `build` is now `buildWith defaultBuildOptions`.

## Tests

- 78/78 unit tests pass, including 4 new ones for multi-asset change folding.
- 11/11 E2E tests pass against the cardano-node-clients devnet, including a new `MultiAssetChangeSpec` that mints an NFT via an always-true policy with no explicit recipient output, submits the tx to a real devnet, and asserts the change UTxO carries the NFT.
- Validated downstream: asteria spawn-ship tx submitted and accepted in the antithesis local cluster (mainnet ExUnits, 3-output shape, validator within budget) using `boExUnitsMargin = 1.2×`. Single attempt, no failures.

## Test plan

- [x] cabal build
- [x] cabal test cardano-node-clients:unit-tests (78/78)
- [x] cabal test cardano-node-clients:e2e-tests (11/11, devnet)
- [x] downstream antithesis cluster spawn (1.2× margin)
- [x] fourmolu --check / hlint / cabal-fmt