### PR TITLE
feat: utxo-indexer daemon (refs #78)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: nixos
     steps:
       - uses: actions/checkout@v6
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v17
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -28,7 +28,7 @@ jobs:
     runs-on: nixos
     steps:
       - uses: actions/checkout@v6
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v17
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
     runs-on: nixos
     steps:
       - uses: actions/checkout@v6
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v17
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -50,7 +50,7 @@ jobs:
     runs-on: nixos
     steps:
       - uses: actions/checkout@v6
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v17
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -62,7 +62,7 @@ jobs:
     needs: [build, e2e, lint]
     steps:
       - uses: actions/checkout@v6
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v17
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/app/utxo-indexer/Main.hs
+++ b/app/utxo-indexer/Main.hs
@@ -1,0 +1,116 @@
+{- |
+Module      : Main
+Description : utxo-indexer daemon entrypoint
+License     : Apache-2.0
+
+Minimal address->UTxO indexer daemon. Follows the chain
+via N2C ChainSync from one relay socket, maintains an
+in-memory address->UTxO index, exposes two read primitives
+(@utxos_at@, @await@) plus a @ready@ probe over a Unix
+domain socket using newline-delimited JSON.
+
+This Main is the scaffolding patch: parses CLI flags,
+prints the resolved config, exits 0. Subsequent patches
+wire the chain-sync follower, the STM index, and the
+NDJSON server.
+-}
+module Main (main) where
+
+import Data.Maybe (fromMaybe)
+import System.Environment (getArgs, getProgName)
+import System.Exit (exitFailure, exitSuccess)
+import System.IO (hPutStrLn, stderr)
+import Text.Read (readMaybe)
+
+-- | Resolved daemon configuration, populated from CLI flags.
+data Config = Config
+    { cfgRelaySocket :: FilePath
+    -- ^ Path to the Cardano relay's N2C Unix socket.
+    , cfgListenSocket :: FilePath
+    -- ^ Path the daemon will listen on.
+    , cfgNetworkMagic :: Word
+    -- ^ Network magic of the target network.
+    , cfgByronEpochSlots :: Word
+    -- ^ Byron epoch slot count (genesis configuration).
+    , cfgReadyThresholdSlots :: Word
+    -- ^ Maximum @slotsBehind@ for the daemon to report
+    -- @ready=true@ on the @ready@ request.
+    }
+    deriving stock (Show)
+
+-- | Default ready threshold (slots).
+defaultReadyThreshold :: Word
+defaultReadyThreshold = 60
+
+{- | Parse a single @--key value@ pair from the argument
+list. Returns the value and the remaining args.
+-}
+takeFlag :: String -> [String] -> Maybe (String, [String])
+takeFlag _ [] = Nothing
+takeFlag key args = go [] args
+  where
+    go _ [] = Nothing
+    go seen (k : v : rest)
+        | k == key = Just (v, reverse seen ++ rest)
+    go seen (x : rest) = go (x : seen) rest
+
+{- | Parse all CLI flags into a 'Config'. On error,
+print usage to stderr and exit non-zero.
+-}
+parseConfig :: [String] -> IO Config
+parseConfig args0 = do
+    (relay, args1) <- requireFlag "--relay-socket" args0
+    (listen, args2) <- requireFlag "--listen" args1
+    (magicS, args3) <- requireFlag "--network-magic" args2
+    (slotsS, args4) <- requireFlag "--byron-epoch-slots" args3
+    let (readyS, args5) =
+            fromMaybe (show defaultReadyThreshold, args4) $
+                takeFlag "--ready-threshold-slots" args4
+    case args5 of
+        [] -> pure ()
+        extra -> dieUsage $ "Unexpected args: " <> show extra
+    magic <- requireWord "--network-magic" magicS
+    slots <- requireWord "--byron-epoch-slots" slotsS
+    ready <- requireWord "--ready-threshold-slots" readyS
+    pure
+        Config
+            { cfgRelaySocket = relay
+            , cfgListenSocket = listen
+            , cfgNetworkMagic = magic
+            , cfgByronEpochSlots = slots
+            , cfgReadyThresholdSlots = ready
+            }
+  where
+    requireFlag key args =
+        maybe
+            (dieUsage $ "Missing required flag: " <> key)
+            pure
+            (takeFlag key args)
+    requireWord key s =
+        maybe
+            (dieUsage $ key <> " expects a non-negative integer, got: " <> s)
+            pure
+            (readMaybe s)
+
+-- | Print usage and exit 1.
+dieUsage :: String -> IO a
+dieUsage msg = do
+    prog <- getProgName
+    hPutStrLn stderr msg
+    hPutStrLn stderr ""
+    hPutStrLn stderr $ "Usage: " <> prog <> " \\"
+    hPutStrLn stderr "  --relay-socket PATH \\"
+    hPutStrLn stderr "  --listen PATH \\"
+    hPutStrLn stderr "  --network-magic INT \\"
+    hPutStrLn stderr "  --byron-epoch-slots INT \\"
+    hPutStrLn stderr "  [--ready-threshold-slots INT]"
+    exitFailure
+
+-- | Entry point. Phase 0: parse args, log config, exit 0.
+main :: IO ()
+main = do
+    args <- getArgs
+    cfg <- parseConfig args
+    putStrLn $ "utxo-indexer: " <> show cfg
+    putStrLn "utxo-indexer: scaffolding only — chain-sync, index, and server land in subsequent patches"
+    exitSuccess

--- a/app/utxo-indexer/Main.hs
+++ b/app/utxo-indexer/Main.hs
@@ -5,38 +5,24 @@ License     : Apache-2.0
 
 Minimal address->UTxO indexer daemon. Follows the chain
 via N2C ChainSync from one relay socket, maintains an
-in-memory address->UTxO index, exposes two read primitives
-(@utxos_at@, @await@) plus a @ready@ probe over a Unix
-domain socket using newline-delimited JSON.
+in-memory address->UTxO index, exposes two read
+primitives (@utxos_at@, @await@) plus a @ready@ probe
+over a Unix domain socket using newline-delimited JSON.
 
-This Main is the scaffolding patch: parses CLI flags,
-prints the resolved config, exits 0. Subsequent patches
-wire the chain-sync follower, the STM index, and the
-NDJSON server.
+This @Main@ is just CLI parsing; everything else lives
+in 'Cardano.Node.Client.UTxOIndexer.Daemon.runDaemon'.
 -}
 module Main (main) where
 
+import Cardano.Node.Client.UTxOIndexer.Daemon (
+    DaemonConfig (..),
+    runDaemon,
+ )
 import Data.Maybe (fromMaybe)
 import System.Environment (getArgs, getProgName)
-import System.Exit (exitFailure, exitSuccess)
+import System.Exit (exitFailure)
 import System.IO (hPutStrLn, stderr)
 import Text.Read (readMaybe)
-
--- | Resolved daemon configuration, populated from CLI flags.
-data Config = Config
-    { cfgRelaySocket :: FilePath
-    -- ^ Path to the Cardano relay's N2C Unix socket.
-    , cfgListenSocket :: FilePath
-    -- ^ Path the daemon will listen on.
-    , cfgNetworkMagic :: Word
-    -- ^ Network magic of the target network.
-    , cfgByronEpochSlots :: Word
-    -- ^ Byron epoch slot count (genesis configuration).
-    , cfgReadyThresholdSlots :: Word
-    -- ^ Maximum @slotsBehind@ for the daemon to report
-    -- @ready=true@ on the @ready@ request.
-    }
-    deriving stock (Show)
 
 -- | Default ready threshold (slots).
 defaultReadyThreshold :: Word
@@ -54,10 +40,10 @@ takeFlag key args = go [] args
         | k == key = Just (v, reverse seen ++ rest)
     go seen (x : rest) = go (x : seen) rest
 
-{- | Parse all CLI flags into a 'Config'. On error,
-print usage to stderr and exit non-zero.
+{- | Parse all CLI flags into a 'DaemonConfig'. On
+error, print usage to stderr and exit non-zero.
 -}
-parseConfig :: [String] -> IO Config
+parseConfig :: [String] -> IO DaemonConfig
 parseConfig args0 = do
     (relay, args1) <- requireFlag "--relay-socket" args0
     (listen, args2) <- requireFlag "--listen" args1
@@ -73,12 +59,12 @@ parseConfig args0 = do
     slots <- requireWord "--byron-epoch-slots" slotsS
     ready <- requireWord "--ready-threshold-slots" readyS
     pure
-        Config
-            { cfgRelaySocket = relay
-            , cfgListenSocket = listen
-            , cfgNetworkMagic = magic
-            , cfgByronEpochSlots = slots
-            , cfgReadyThresholdSlots = ready
+        DaemonConfig
+            { dcRelaySocket = relay
+            , dcListenSocket = listen
+            , dcNetworkMagic = fromIntegral (magic :: Word)
+            , dcByronEpochSlots = fromIntegral (slots :: Word)
+            , dcReadyThresholdSlots = fromIntegral (ready :: Word)
             }
   where
     requireFlag key args =
@@ -106,11 +92,10 @@ dieUsage msg = do
     hPutStrLn stderr "  [--ready-threshold-slots INT]"
     exitFailure
 
--- | Entry point. Phase 0: parse args, log config, exit 0.
+-- | Entry point. Parse args, log config, run the daemon.
 main :: IO ()
 main = do
     args <- getArgs
     cfg <- parseConfig args
-    putStrLn $ "utxo-indexer: " <> show cfg
-    putStrLn "utxo-indexer: scaffolding only — chain-sync, index, and server land in subsequent patches"
-    exitSuccess
+    hPutStrLn stderr $ "utxo-indexer: " <> show cfg
+    runDaemon cfg

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -145,11 +145,14 @@ library utxo-indexer-lib
   default-language: GHC2021
   exposed-modules:
     Cardano.Node.Client.UTxOIndexer.Columns
+    Cardano.Node.Client.UTxOIndexer.Indexer
     Cardano.Node.Client.UTxOIndexer.Types
 
   build-depends:
     , base
     , bytestring
+    , dependent-map
+    , dependent-sum
     , lens
     , rocksdb-kv-transactions:kv-transactions
     , some
@@ -174,6 +177,7 @@ test-suite unit-tests
     Cardano.Node.Client.BalanceSpec
     Cardano.Node.Client.TxBuildGoldenSpec
     Cardano.Node.Client.TxBuildSpec
+    Cardano.Node.Client.UTxOIndexer.IndexerSpec
     Cardano.Node.Client.UTxOIndexer.TypesSpec
     Data.List.SampleFibonacciSpec
 

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -57,6 +57,7 @@ library
     Cardano.Node.Client.Submitter
     Cardano.Node.Client.TxBuild
     Cardano.Node.Client.Types
+    Cardano.Node.Client.UTxOIndexer.BlockExtract
     Data.List.SampleFibonacci
 
   build-depends:
@@ -64,15 +65,19 @@ library
     , base
     , bytestring
     , cardano-binary
+    , cardano-crypto-class
     , cardano-diffusion
     , cardano-diffusion:protocols
     , cardano-ledger-allegra
     , cardano-ledger-alonzo
     , cardano-ledger-api
+    , cardano-ledger-binary
     , cardano-ledger-byron
     , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-mary
+    , cardano-ledger-read
+    , cardano-node-clients:utxo-indexer-lib
     , cardano-prelude
     , cardano-slotting
     , cardano-strict-containers

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -58,11 +58,13 @@ library
     Cardano.Node.Client.TxBuild
     Cardano.Node.Client.Types
     Cardano.Node.Client.UTxOIndexer.BlockExtract
+    Cardano.Node.Client.UTxOIndexer.Daemon
     Cardano.Node.Client.UTxOIndexer.Server
     Data.List.SampleFibonacci
 
   build-depends:
     , aeson
+    , async
     , base
     , base16-bytestring
     , bytestring
@@ -176,6 +178,7 @@ executable utxo-indexer
   ghc-options:      -threaded -rtsopts -with-rtsopts=-N
   build-depends:
     , base
+    , cardano-node-clients
     , cardano-node-clients:utxo-indexer-lib
 
 test-suite unit-tests

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -157,13 +157,16 @@ library utxo-indexer-lib
     Cardano.Node.Client.UTxOIndexer.Types
 
   build-depends:
+    , async
     , base
     , bytestring
+    , containers
     , dependent-map
     , dependent-sum
     , lens
     , rocksdb-kv-transactions:kv-transactions
     , some
+    , stm
 
 executable utxo-indexer
   import:           warnings

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -237,8 +237,10 @@ test-suite e2e-tests
     Cardano.Node.Client.E2E.MultiAssetChangeSpec
     Cardano.Node.Client.E2E.ProviderSpec
     Cardano.Node.Client.E2E.TxBuildSpec
+    Cardano.Node.Client.E2E.UTxOIndexerSpec
 
   build-depends:
+    , aeson
     , async
     , base
     , base16-bytestring
@@ -259,9 +261,14 @@ test-suite e2e-tests
     , chain-follower
     , containers
     , contra-tracer
+    , directory
+    , filepath
     , hspec
     , lens
     , microlens
+    , network
     , ouroboros-network:api
     , rocksdb-kv-transactions:kv-transactions
     , stm
+    , temporary
+    , text

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -146,6 +146,7 @@ library utxo-indexer-lib
   exposed-modules:
     Cardano.Node.Client.UTxOIndexer.Columns
     Cardano.Node.Client.UTxOIndexer.Indexer
+    Cardano.Node.Client.UTxOIndexer.IndexerOp
     Cardano.Node.Client.UTxOIndexer.Types
 
   build-depends:

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -58,11 +58,13 @@ library
     Cardano.Node.Client.TxBuild
     Cardano.Node.Client.Types
     Cardano.Node.Client.UTxOIndexer.BlockExtract
+    Cardano.Node.Client.UTxOIndexer.Server
     Data.List.SampleFibonacci
 
   build-depends:
     , aeson
     , base
+    , base16-bytestring
     , bytestring
     , cardano-binary
     , cardano-crypto-class
@@ -184,10 +186,12 @@ test-suite unit-tests
     Cardano.Node.Client.TxBuildGoldenSpec
     Cardano.Node.Client.TxBuildSpec
     Cardano.Node.Client.UTxOIndexer.IndexerSpec
+    Cardano.Node.Client.UTxOIndexer.ServerSpec
     Cardano.Node.Client.UTxOIndexer.TypesSpec
     Data.List.SampleFibonacciSpec
 
   build-depends:
+    , aeson
     , base
     , base16-bytestring
     , bytestring
@@ -204,11 +208,14 @@ test-suite unit-tests
     , cardano-slotting
     , cardano-strict-containers
     , containers
+    , directory
     , hspec
     , microlens
+    , network
     , plutus-core
     , plutus-tx
     , QuickCheck
+    , temporary
     , text
 
 test-suite e2e-tests

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -138,6 +138,14 @@ library devnet
     , time
     , unix
 
+executable utxo-indexer
+  import:           warnings
+  hs-source-dirs:   app/utxo-indexer
+  main-is:          Main.hs
+  default-language: GHC2021
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+  build-depends:    base
+
 test-suite unit-tests
   import:           warnings
   type:             exitcode-stdio-1.0

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -138,13 +138,31 @@ library devnet
     , time
     , unix
 
+library utxo-indexer-lib
+  import:           warnings
+  visibility:       public
+  hs-source-dirs:   lib-utxo-indexer
+  default-language: GHC2021
+  exposed-modules:
+    Cardano.Node.Client.UTxOIndexer.Columns
+    Cardano.Node.Client.UTxOIndexer.Types
+
+  build-depends:
+    , base
+    , bytestring
+    , lens
+    , rocksdb-kv-transactions:kv-transactions
+    , some
+
 executable utxo-indexer
   import:           warnings
   hs-source-dirs:   app/utxo-indexer
   main-is:          Main.hs
   default-language: GHC2021
   ghc-options:      -threaded -rtsopts -with-rtsopts=-N
-  build-depends:    base
+  build-depends:
+    , base
+    , cardano-node-clients:utxo-indexer-lib
 
 test-suite unit-tests
   import:           warnings
@@ -156,6 +174,7 @@ test-suite unit-tests
     Cardano.Node.Client.BalanceSpec
     Cardano.Node.Client.TxBuildGoldenSpec
     Cardano.Node.Client.TxBuildSpec
+    Cardano.Node.Client.UTxOIndexer.TypesSpec
     Data.List.SampleFibonacciSpec
 
   build-depends:
@@ -171,6 +190,7 @@ test-suite unit-tests
     , cardano-ledger-core
     , cardano-ledger-mary
     , cardano-node-clients
+    , cardano-node-clients:utxo-indexer-lib
     , cardano-slotting
     , cardano-strict-containers
     , containers

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Columns.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Columns.hs
@@ -7,7 +7,7 @@ Database layout for the address->UTxO indexer expressed
 against the 'Database.KV.Transaction' abstraction from
 @kv-transactions@.
 
-Two live-state columns:
+Three columns:
 
 * 'TxInCol' :: @KV TxIn Address@ — primary table keyed
   by the 'TxIn' alone. The chain block consuming an
@@ -19,6 +19,10 @@ Two live-state columns:
   @lenByte || address || txId || ix@ so a cursor seek to
   @lenByte || address@ yields every UTxO at that address
   with its full 'TxOut' inline (no second-stage lookup).
+* 'RollbackCol' :: @KV SlotNo [UtxoOp]@ — slot-tagged
+  inverse-op log used to undo apply-block writes on a
+  chain-sync rollback. Keyed by 'SlotNo' (8-byte BE) so
+  cursor ordering matches numeric slot ordering.
 
 A future RocksDB swap is a one-line backend choice via
 @mkInMemoryDatabase@ → @mkRocksDBDatabase@; nothing in
@@ -31,32 +35,41 @@ module Cardano.Node.Client.UTxOIndexer.Columns (
     -- * Codecs
     txInColCodecs,
     addressIndexCodecs,
+    rollbackCodecs,
+
+    -- * Inverse-op list encoding
+    encodeOps,
+    decodeOps,
 ) where
 
+import Cardano.Node.Client.UTxOIndexer.IndexerOp (UtxoOp (..))
 import Cardano.Node.Client.UTxOIndexer.Types (
     AddrKey,
     Address (..),
+    SlotNo,
     TxIn,
     TxOut (..),
     addrKeyFromBytes,
     addrKeyToBytes,
+    slotFromBytes,
+    slotToBytes,
     txInFromBytes,
     txInToBytes,
  )
 import Control.Lens (Prism', prism')
+import Data.Bits (shiftL, shiftR, (.&.), (.|.))
 import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
 import Data.GADT.Compare (
     GCompare (..),
     GEq (..),
     GOrdering (..),
  )
 import Data.Type.Equality (type (:~:) (Refl))
+import Data.Word (Word32)
 import Database.KV.Transaction (Codecs (..), KV)
 
-{- | The indexer database's column families. Two live
-columns; rollback support lands in a follow-up patch and
-adds a third.
--}
+-- | The indexer database's column families.
 data Cols c where
     -- | Primary table: @TxIn → Address@. Lets the
     -- spend-by-TxIn path resolve the consumed UTxO's
@@ -68,23 +81,28 @@ data Cols c where
     -- prefix-scan by address yields @(TxIn, TxOut)@
     -- pairs directly.
     AddressIndex :: Cols (KV AddrKey TxOut)
+    -- | Rollback log: 'SlotNo' → list of inverse ops to
+    -- undo writes applied at that slot. The list is in
+    -- the order to apply on rollback (i.e. already
+    -- reversed relative to the original apply order).
+    RollbackCol :: Cols (KV SlotNo [UtxoOp])
 
 instance GEq Cols where
     geq TxInCol TxInCol = Just Refl
     geq AddressIndex AddressIndex = Just Refl
+    geq RollbackCol RollbackCol = Just Refl
     geq _ _ = Nothing
 
 instance GCompare Cols where
     gcompare TxInCol TxInCol = GEQ
-    gcompare TxInCol AddressIndex = GLT
-    gcompare AddressIndex TxInCol = GGT
+    gcompare TxInCol _ = GLT
+    gcompare _ TxInCol = GGT
     gcompare AddressIndex AddressIndex = GEQ
+    gcompare AddressIndex RollbackCol = GLT
+    gcompare RollbackCol AddressIndex = GGT
+    gcompare RollbackCol RollbackCol = GEQ
 
-{- | Codecs for 'TxInCol'. Both key (34 bytes fixed) and
-value (raw address bytes) are length-determined; the
-prism is total on encode, partial only on shape on
-decode.
--}
+-- | Codecs for 'TxInCol'.
 txInColCodecs :: Codecs (KV TxIn Address)
 txInColCodecs =
     Codecs
@@ -92,22 +110,24 @@ txInColCodecs =
         , valueCodec = addressPrism
         }
 
-{- | Codecs for 'AddressIndex'. The key codec is total
-on the encode side modulo the @maxAddressLength@
-invariant baked into 'addrKeyToBytes'; on the decode
-side it returns 'Nothing' for any byte string that
-does not match the
-@lenByte || address(lenByte) || txId(32) || ix(2)@
-shape.
-
-The value side is the raw CBOR 'TxOut' as observed on
-chain; the indexer never decodes it.
--}
+-- | Codecs for 'AddressIndex'.
 addressIndexCodecs :: Codecs (KV AddrKey TxOut)
 addressIndexCodecs =
     Codecs
         { keyCodec = addrKeyPrism
         , valueCodec = txOutPrism
+        }
+
+{- | Codecs for the rollback-log column. The op list uses
+a stable hand-rolled binary form (see 'encodeOps') so a
+future RocksDB swap can read entries written by the
+in-memory backend.
+-}
+rollbackCodecs :: Codecs (KV SlotNo [UtxoOp])
+rollbackCodecs =
+    Codecs
+        { keyCodec = slotPrism
+        , valueCodec = opsPrism
         }
 
 -- Internal --------------------------------------------------------
@@ -136,3 +156,116 @@ addrKeyPrism =
 
 txOutPrism :: Prism' ByteString TxOut
 txOutPrism = prism' unTxOut (Just . TxOut)
+
+slotPrism :: Prism' ByteString SlotNo
+slotPrism = prism' slotToBytes slotFromBytes
+
+opsPrism :: Prism' ByteString [UtxoOp]
+opsPrism = prism' encodeOps decodeOps
+
+-- Inverse-op list binary encoding ---------------------------------
+--
+-- @
+-- list   = listLen ++ encodedOps
+-- create = 0 ++ txIn(34) ++ addrLen(4 BE) ++ addr ++ txOutLen(4 BE) ++ txOut
+-- spend  = 1 ++ txIn(34)
+-- @
+
+{- | Encode a list of 'UtxoOp' into the rollback-column's
+on-disk byte form.
+-}
+encodeOps :: [UtxoOp] -> ByteString
+encodeOps ops =
+    word32BE (fromIntegral (length ops))
+        <> mconcat (map encodeOp ops)
+
+encodeOp :: UtxoOp -> ByteString
+encodeOp (UtxoCreate txIn (Address addr) (TxOut txOut)) =
+    BS.singleton 0
+        <> txInToBytes txIn
+        <> lenPrefixed addr
+        <> lenPrefixed txOut
+encodeOp (UtxoSpend txIn) =
+    BS.singleton 1 <> txInToBytes txIn
+
+lenPrefixed :: ByteString -> ByteString
+lenPrefixed bs = word32BE (fromIntegral (BS.length bs)) <> bs
+
+{- | Inverse of 'encodeOps'. Returns 'Nothing' if the
+byte string is malformed.
+-}
+decodeOps :: ByteString -> Maybe [UtxoOp]
+decodeOps bs0 = do
+    (n, rest0) <- readWord32 bs0
+    (ops, rest1) <- readN (fromIntegral n) decodeOp rest0
+    if BS.null rest1
+        then Just ops
+        else Nothing
+
+decodeOp :: ByteString -> Maybe (UtxoOp, ByteString)
+decodeOp bs0 = do
+    (tag, rest0) <- BS.uncons bs0
+    case tag of
+        0 -> do
+            (txInBs, rest1) <- splitFixed 34 rest0
+            txIn <- txInFromBytes txInBs
+            (addrBs, rest2) <- readLenPrefixed rest1
+            (txOutBs, rest3) <- readLenPrefixed rest2
+            Just
+                ( UtxoCreate
+                    txIn
+                    (Address addrBs)
+                    (TxOut txOutBs)
+                , rest3
+                )
+        1 -> do
+            (txInBs, rest1) <- splitFixed 34 rest0
+            txIn <- txInFromBytes txInBs
+            Just (UtxoSpend txIn, rest1)
+        _ -> Nothing
+
+splitFixed :: Int -> ByteString -> Maybe (ByteString, ByteString)
+splitFixed n bs
+    | BS.length bs < n = Nothing
+    | otherwise = Just (BS.splitAt n bs)
+
+readLenPrefixed :: ByteString -> Maybe (ByteString, ByteString)
+readLenPrefixed bs0 = do
+    (n, rest0) <- readWord32 bs0
+    let len = fromIntegral n
+    if BS.length rest0 < len
+        then Nothing
+        else Just (BS.splitAt len rest0)
+
+readWord32 :: ByteString -> Maybe (Word32, ByteString)
+readWord32 bs
+    | BS.length bs < 4 = Nothing
+    | otherwise =
+        let (hd, tl) = BS.splitAt 4 bs
+            w =
+                foldr (.|.) 0 $
+                    zipWith
+                        (\s b -> fromIntegral b `shiftL` s)
+                        [24 :: Int, 16, 8, 0]
+                        (BS.unpack hd)
+         in Just (w, tl)
+
+readN ::
+    Int ->
+    (ByteString -> Maybe (a, ByteString)) ->
+    ByteString ->
+    Maybe ([a], ByteString)
+readN 0 _ bs = Just ([], bs)
+readN n step bs = do
+    (a, bs') <- step bs
+    (as, bs'') <- readN (n - 1) step bs'
+    Just (a : as, bs'')
+
+word32BE :: Word32 -> ByteString
+word32BE w =
+    BS.pack
+        [ fromIntegral (w `shiftR` 24) .&. 0xFF
+        , fromIntegral (w `shiftR` 16) .&. 0xFF
+        , fromIntegral (w `shiftR` 8) .&. 0xFF
+        , fromIntegral w .&. 0xFF
+        ]

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Columns.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Columns.hs
@@ -1,0 +1,138 @@
+{- |
+Module      : Cardano.Node.Client.UTxOIndexer.Columns
+Description : Typed-column GADT for the indexer database
+License     : Apache-2.0
+
+Database layout for the address->UTxO indexer expressed
+against the 'Database.KV.Transaction' abstraction from
+@kv-transactions@.
+
+Two live-state columns:
+
+* 'TxInCol' :: @KV TxIn Address@ — primary table keyed
+  by the 'TxIn' alone. The chain block consuming an
+  input gives us only its 'TxIn'; this column lets us
+  resolve the input's address (needed to delete the
+  matching 'AddressIndex' row) without scanning.
+* 'AddressIndex' :: @KV AddrKey TxOut@ — secondary index
+  for address-prefix snapshot queries. Composite key
+  @lenByte || address || txId || ix@ so a cursor seek to
+  @lenByte || address@ yields every UTxO at that address
+  with its full 'TxOut' inline (no second-stage lookup).
+
+A future RocksDB swap is a one-line backend choice via
+@mkInMemoryDatabase@ → @mkRocksDBDatabase@; nothing in
+this module changes.
+-}
+module Cardano.Node.Client.UTxOIndexer.Columns (
+    -- * Column GADT
+    Cols (..),
+
+    -- * Codecs
+    txInColCodecs,
+    addressIndexCodecs,
+) where
+
+import Cardano.Node.Client.UTxOIndexer.Types (
+    AddrKey,
+    Address (..),
+    TxIn,
+    TxOut (..),
+    addrKeyFromBytes,
+    addrKeyToBytes,
+    txInFromBytes,
+    txInToBytes,
+ )
+import Control.Lens (Prism', prism')
+import Data.ByteString (ByteString)
+import Data.GADT.Compare (
+    GCompare (..),
+    GEq (..),
+    GOrdering (..),
+ )
+import Data.Type.Equality (type (:~:) (Refl))
+import Database.KV.Transaction (Codecs (..), KV)
+
+{- | The indexer database's column families. Two live
+columns; rollback support lands in a follow-up patch and
+adds a third.
+-}
+data Cols c where
+    -- | Primary table: @TxIn → Address@. Lets the
+    -- spend-by-TxIn path resolve the consumed UTxO's
+    -- address without scanning. Key is 34 bytes fixed.
+    TxInCol :: Cols (KV TxIn Address)
+    -- | Secondary index: @AddrKey → TxOut@ where
+    -- @AddrKey = (Address, TxIn)@ is encoded as
+    -- @lenByte || address || txId || ix@. Cursor
+    -- prefix-scan by address yields @(TxIn, TxOut)@
+    -- pairs directly.
+    AddressIndex :: Cols (KV AddrKey TxOut)
+
+instance GEq Cols where
+    geq TxInCol TxInCol = Just Refl
+    geq AddressIndex AddressIndex = Just Refl
+    geq _ _ = Nothing
+
+instance GCompare Cols where
+    gcompare TxInCol TxInCol = GEQ
+    gcompare TxInCol AddressIndex = GLT
+    gcompare AddressIndex TxInCol = GGT
+    gcompare AddressIndex AddressIndex = GEQ
+
+{- | Codecs for 'TxInCol'. Both key (34 bytes fixed) and
+value (raw address bytes) are length-determined; the
+prism is total on encode, partial only on shape on
+decode.
+-}
+txInColCodecs :: Codecs (KV TxIn Address)
+txInColCodecs =
+    Codecs
+        { keyCodec = txInPrism
+        , valueCodec = addressPrism
+        }
+
+{- | Codecs for 'AddressIndex'. The key codec is total
+on the encode side modulo the @maxAddressLength@
+invariant baked into 'addrKeyToBytes'; on the decode
+side it returns 'Nothing' for any byte string that
+does not match the
+@lenByte || address(lenByte) || txId(32) || ix(2)@
+shape.
+
+The value side is the raw CBOR 'TxOut' as observed on
+chain; the indexer never decodes it.
+-}
+addressIndexCodecs :: Codecs (KV AddrKey TxOut)
+addressIndexCodecs =
+    Codecs
+        { keyCodec = addrKeyPrism
+        , valueCodec = txOutPrism
+        }
+
+-- Internal --------------------------------------------------------
+
+txInPrism :: Prism' ByteString TxIn
+txInPrism = prism' txInToBytes txInFromBytes
+
+addressPrism :: Prism' ByteString Address
+addressPrism = prism' unAddress (Just . Address)
+
+addrKeyPrism :: Prism' ByteString AddrKey
+addrKeyPrism =
+    -- Encoding any address shorter than 256 bytes always
+    -- succeeds; we 'error' on the impossible case rather
+    -- than thread 'Maybe' through every caller (real
+    -- ledger never produces such addresses).
+    prism' encode addrKeyFromBytes
+  where
+    encode k = case addrKeyToBytes k of
+        Just bs -> bs
+        Nothing ->
+            error
+                "addrKeyPrism: address exceeds 255 bytes — \
+                \invariant violation, ledger never produces \
+                \such addresses"
+
+txOutPrism :: Prism' ByteString TxOut
+txOutPrism = prism' unTxOut (Just . TxOut)

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
@@ -1,0 +1,175 @@
+{- |
+Module      : Cardano.Node.Client.UTxOIndexer.Indexer
+Description : Address->UTxO indexer state and read API
+License     : Apache-2.0
+
+Holds the indexer's in-process state — a 'kv-transactions'
+'Database' (in-memory backend in v1) keyed by the 'Cols'
+GADT — and exposes the operations the rest of the daemon
+needs:
+
+* 'applyOps' commits a batch of create/spend operations
+  in one transaction. Apply-block expands a chain block
+  into one 'UtxoCreate' per new output and one 'UtxoSpend'
+  per consumed input.
+* 'snapshotAt' prefix-scans every UTxO at a given address
+  using a 'Cursor'.
+
+The op shape is asymmetric:
+
+* 'UtxoCreate' carries the full @(TxIn, Address, TxOut)@
+  triple — the producing block has all three.
+* 'UtxoSpend' carries only a 'TxIn' — the consuming block
+  has nothing else. The indexer's apply path resolves the
+  consumed UTxO's address via 'TxInCol' before deleting
+  the matching 'AddressIndex' row.
+
+A future RocksDB swap is a one-line change:
+'mkInMemoryDatabase' becomes 'mkRocksDBDatabase' from
+@rocksdb-kv-transactions@; nothing else in this module
+moves.
+
+Rollback support and the @await@ STM-wakeup primitive
+land in subsequent patches.
+-}
+module Cardano.Node.Client.UTxOIndexer.Indexer (
+    -- * Indexer handle
+    IndexerHandle (..),
+    withInMemoryIndexer,
+
+    -- * Operations
+    UtxoOp (..),
+) where
+
+import Cardano.Node.Client.UTxOIndexer.Columns (
+    Cols (..),
+    addressIndexCodecs,
+    txInColCodecs,
+ )
+import Cardano.Node.Client.UTxOIndexer.Types (
+    AddrKey (..),
+    Address (..),
+    TxIn (..),
+    TxOut,
+ )
+import Data.ByteString qualified as BS
+import Data.Foldable (traverse_)
+import Database.KV.Cursor (
+    Cursor,
+    Entry (..),
+    nextEntry,
+    seekKey,
+ )
+import Database.KV.Database (KV, mkColumns)
+import Database.KV.InMemory (mkInMemoryDatabase)
+import Database.KV.Transaction (
+    DSum ((:=>)),
+    RunTransaction (..),
+    Transaction,
+    delete,
+    fromList,
+    insert,
+    iterating,
+    newRunTransaction,
+    query,
+ )
+
+{- | A single mutation against the indexer's live state.
+Apply-block expands a chain block into a list of these.
+-}
+data UtxoOp
+    = -- | Create the UTxO @(txIn, addr, txOut)@:
+      -- insert into both 'TxInCol' (txIn → addr) and
+      -- 'AddressIndex' ((addr, txIn) → txOut).
+      UtxoCreate !TxIn !Address !TxOut
+    | -- | Spend the UTxO at @txIn@: look up its address
+      -- via 'TxInCol', delete from both columns. No-op if
+      -- the TxIn is not in the index.
+      UtxoSpend !TxIn
+    deriving stock (Eq, Show)
+
+{- | Operations the rest of the daemon performs against
+the indexer state.
+-}
+data IndexerHandle = IndexerHandle
+    { applyOps :: [UtxoOp] -> IO ()
+    -- ^ Atomically apply a batch of create/spend
+    -- operations against the index.
+    , snapshotAt :: Address -> IO [(TxIn, TxOut)]
+    -- ^ Snapshot every UTxO currently at the given
+    -- address, in ascending @TxIn@ order. Used by
+    -- the @utxos_at@ NDJSON request.
+    }
+
+{- | Open an in-memory indexer, run the action with the
+handle, and clean up on exit.
+
+In v1 this is the only constructor; a
+'withRocksDBIndexer' variant lands when persistence is
+needed without changing the @IndexerHandle@ contract or
+any consumer.
+-}
+withInMemoryIndexer :: (IndexerHandle -> IO a) -> IO a
+withInMemoryIndexer action = do
+    let codecs =
+            fromList
+                [ TxInCol :=> txInColCodecs
+                , AddressIndex :=> addressIndexCodecs
+                ]
+        columns = mkColumns [0 :: Int ..] codecs
+    db <- mkInMemoryDatabase columns
+    runner <- newRunTransaction db
+    action (mkHandle runner)
+
+-- Internal -------------------------------------------------------
+
+type Op = (Int, BS.ByteString, Maybe BS.ByteString)
+
+mkHandle ::
+    RunTransaction IO Int Cols Op ->
+    IndexerHandle
+mkHandle RunTransaction{runTransaction} =
+    IndexerHandle
+        { applyOps = runTransaction . traverse_ applyOne
+        , snapshotAt =
+            runTransaction . iterating AddressIndex . scanAddress
+        }
+
+applyOne ::
+    UtxoOp ->
+    Transaction IO Int Cols Op ()
+applyOne (UtxoCreate txIn addr txOut) = do
+    insert TxInCol txIn addr
+    insert AddressIndex (AddrKey addr txIn) txOut
+applyOne (UtxoSpend txIn) = do
+    mAddr <- query TxInCol txIn
+    case mAddr of
+        Nothing -> pure ()
+        Just addr -> do
+            delete AddressIndex (AddrKey addr txIn)
+            delete TxInCol txIn
+
+{- | Cursor program: seek to the synthetic minimum key
+under @addr@ and walk forward, collecting every entry
+whose key still lives under @addr@. Stops at the first
+entry whose address differs (or end of column).
+
+Each entry of 'AddressIndex' carries the 'TxOut'
+inline, so no second-stage lookup is required.
+-}
+scanAddress ::
+    (Monad m) =>
+    Address ->
+    Cursor m (KV AddrKey TxOut) [(TxIn, TxOut)]
+scanAddress addr =
+    let seekTo =
+            AddrKey
+                addr
+                (TxIn (BS.replicate 32 0) 0)
+     in seekKey seekTo >>= go []
+  where
+    go acc Nothing = pure (reverse acc)
+    go acc (Just Entry{entryKey = k, entryValue = v})
+        | addrKeyAddress k == addr =
+            nextEntry >>= go ((addrKeyTxIn k, v) : acc)
+        | otherwise = pure (reverse acc)

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
@@ -8,10 +8,12 @@ Holds the indexer's in-process state — a 'kv-transactions'
 GADT — and exposes the operations the rest of the daemon
 needs:
 
-* 'applyOps' commits a batch of create/spend operations
-  in one transaction. Apply-block expands a chain block
-  into one 'UtxoCreate' per new output and one 'UtxoSpend'
-  per consumed input.
+* 'applyAtSlot' commits a batch of create/spend operations
+  in one transaction, and atomically records the inverse
+  list under that slot in the rollback column.
+* 'rollbackTo' replays the inverse-op log for every slot
+  strictly greater than the target, in descending slot
+  order, then deletes those entries.
 * 'snapshotAt' prefix-scans every UTxO at a given address
   using a 'Cursor'.
 
@@ -29,8 +31,8 @@ A future RocksDB swap is a one-line change:
 @rocksdb-kv-transactions@; nothing else in this module
 moves.
 
-Rollback support and the @await@ STM-wakeup primitive
-land in subsequent patches.
+The @await@ STM-wakeup primitive lands in a subsequent
+patch.
 -}
 module Cardano.Node.Client.UTxOIndexer.Indexer (
     -- * Indexer handle
@@ -44,11 +46,14 @@ module Cardano.Node.Client.UTxOIndexer.Indexer (
 import Cardano.Node.Client.UTxOIndexer.Columns (
     Cols (..),
     addressIndexCodecs,
+    rollbackCodecs,
     txInColCodecs,
  )
+import Cardano.Node.Client.UTxOIndexer.IndexerOp (UtxoOp (..))
 import Cardano.Node.Client.UTxOIndexer.Types (
     AddrKey (..),
     Address (..),
+    SlotNo,
     TxIn (..),
     TxOut,
  )
@@ -57,7 +62,9 @@ import Data.Foldable (traverse_)
 import Database.KV.Cursor (
     Cursor,
     Entry (..),
+    lastEntry,
     nextEntry,
+    prevEntry,
     seekKey,
  )
 import Database.KV.Database (KV, mkColumns)
@@ -74,27 +81,21 @@ import Database.KV.Transaction (
     query,
  )
 
-{- | A single mutation against the indexer's live state.
-Apply-block expands a chain block into a list of these.
--}
-data UtxoOp
-    = -- | Create the UTxO @(txIn, addr, txOut)@:
-      -- insert into both 'TxInCol' (txIn → addr) and
-      -- 'AddressIndex' ((addr, txIn) → txOut).
-      UtxoCreate !TxIn !Address !TxOut
-    | -- | Spend the UTxO at @txIn@: look up its address
-      -- via 'TxInCol', delete from both columns. No-op if
-      -- the TxIn is not in the index.
-      UtxoSpend !TxIn
-    deriving stock (Eq, Show)
-
 {- | Operations the rest of the daemon performs against
 the indexer state.
 -}
 data IndexerHandle = IndexerHandle
-    { applyOps :: [UtxoOp] -> IO ()
+    { applyAtSlot :: SlotNo -> [UtxoOp] -> IO ()
     -- ^ Atomically apply a batch of create/spend
-    -- operations against the index.
+    -- operations and store the inverse list under the
+    -- given slot in 'RollbackCol'. Used by the
+    -- chain-sync follower's apply-block path.
+    , rollbackTo :: SlotNo -> IO ()
+    -- ^ Roll the index back to the given slot by
+    -- replaying inverse-op lists for every slot
+    -- @> target@, in descending slot order, then
+    -- deleting those rollback entries. Used by the
+    -- chain-sync follower's roll-backward path.
     , snapshotAt :: Address -> IO [(TxIn, TxOut)]
     -- ^ Snapshot every UTxO currently at the given
     -- address, in ascending @TxIn@ order. Used by
@@ -103,11 +104,6 @@ data IndexerHandle = IndexerHandle
 
 {- | Open an in-memory indexer, run the action with the
 handle, and clean up on exit.
-
-In v1 this is the only constructor; a
-'withRocksDBIndexer' variant lands when persistence is
-needed without changing the @IndexerHandle@ contract or
-any consumer.
 -}
 withInMemoryIndexer :: (IndexerHandle -> IO a) -> IO a
 withInMemoryIndexer action = do
@@ -115,6 +111,7 @@ withInMemoryIndexer action = do
             fromList
                 [ TxInCol :=> txInColCodecs
                 , AddressIndex :=> addressIndexCodecs
+                , RollbackCol :=> rollbackCodecs
                 ]
         columns = mkColumns [0 :: Int ..] codecs
     db <- mkInMemoryDatabase columns
@@ -130,10 +127,108 @@ mkHandle ::
     IndexerHandle
 mkHandle RunTransaction{runTransaction} =
     IndexerHandle
-        { applyOps = runTransaction . traverse_ applyOne
+        { applyAtSlot = \slot ops ->
+            runTransaction (applyAndLog slot ops)
+        , rollbackTo = runTransaction . rollbackToSlot
         , snapshotAt =
             runTransaction . iterating AddressIndex . scanAddress
         }
+
+{- | Within one transaction: for each op compute its
+inverse against the current state, apply the op, and
+finally store the reversed list of inverses under
+@slot@ in 'RollbackCol'.
+
+Computing the inverse before applying is essential —
+@query@ inside the same transaction sees buffered
+writes (read-your-writes), so once an op is applied,
+its inverse cannot be recovered from a later @query@.
+-}
+applyAndLog ::
+    SlotNo ->
+    [UtxoOp] ->
+    Transaction IO Int Cols Op ()
+applyAndLog slot ops = do
+    inverses <- traverse step ops
+    insert RollbackCol slot (reverse inverses)
+  where
+    step op = do
+        inv <- inverseOf op
+        applyOne op
+        pure inv
+
+{- | Roll back every slot strictly greater than
+@target@. Walks 'RollbackCol' from the highest slot
+down via 'lastEntry'/'prevEntry', collecting entries
+@> target@, then in a second pass replays each
+inverse-op list and deletes the corresponding rollback
+entry — both inside the same transaction.
+
+Two passes are needed because applying inverses (which
+@insert@/@delete@ into the workspace) does not affect
+the live cursor: the cursor reads from a snapshot of
+the underlying column. Collecting first guarantees we
+do not skip entries when later steps mutate the
+column.
+-}
+rollbackToSlot ::
+    SlotNo ->
+    Transaction IO Int Cols Op ()
+rollbackToSlot target = do
+    entries <-
+        iterating RollbackCol $
+            collectGreaterThan target
+    traverse_ undoSlot entries
+  where
+    undoSlot (slot, invs) = do
+        traverse_ applyOne invs
+        delete RollbackCol slot
+
+{- | Cursor program: from 'lastEntry' walk backwards,
+collecting @(slot, invs)@ pairs while @slot > target@.
+Returns them in descending-slot order.
+-}
+collectGreaterThan ::
+    (Monad m) =>
+    SlotNo ->
+    Cursor m (KV SlotNo [UtxoOp]) [(SlotNo, [UtxoOp])]
+collectGreaterThan target =
+    lastEntry >>= go []
+  where
+    go acc Nothing = pure (reverse acc)
+    go acc (Just Entry{entryKey = slot, entryValue = invs})
+        | slot > target =
+            prevEntry >>= go ((slot, invs) : acc)
+        | otherwise = pure (reverse acc)
+
+{- | Inverse of a single op against current state.
+
+* @inv (UtxoCreate txIn _a _v)@: query 'TxInCol' for
+  @txIn@. If present (with @a_old@), query
+  'AddressIndex' for @(a_old, txIn)@'s @v_old@; the
+  inverse is @UtxoCreate txIn a_old v_old@. If absent,
+  the inverse is @UtxoSpend txIn@.
+* @inv (UtxoSpend txIn)@: same shape — query current
+  state, restore via @UtxoCreate@; if absent the spend
+  was a no-op so the inverse is too.
+-}
+inverseOf ::
+    UtxoOp ->
+    Transaction IO Int Cols Op UtxoOp
+inverseOf op = do
+    let txIn = opTxIn op
+    mAddr <- query TxInCol txIn
+    case mAddr of
+        Nothing -> pure (UtxoSpend txIn)
+        Just addr -> do
+            mTxOut <- query AddressIndex (AddrKey addr txIn)
+            case mTxOut of
+                Just txOut -> pure (UtxoCreate txIn addr txOut)
+                Nothing -> pure (UtxoSpend txIn)
+
+opTxIn :: UtxoOp -> TxIn
+opTxIn (UtxoCreate t _ _) = t
+opTxIn (UtxoSpend t) = t
 
 applyOne ::
     UtxoOp ->

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
@@ -5,34 +5,27 @@ License     : Apache-2.0
 
 Holds the indexer's in-process state — a 'kv-transactions'
 'Database' (in-memory backend in v1) keyed by the 'Cols'
-GADT — and exposes the operations the rest of the daemon
-needs:
+GADT, plus an STM-held map of 'awaitTxIn' waiters — and
+exposes the operations the rest of the daemon needs:
 
 * 'applyAtSlot' commits a batch of create/spend operations
-  in one transaction, and atomically records the inverse
-  list under that slot in the rollback column.
+  in one transaction, atomically records the inverse list
+  in the rollback column, and wakes up any registered
+  waiters whose 'TxIn' was just created.
 * 'rollbackTo' replays the inverse-op log for every slot
-  strictly greater than the target, in descending slot
-  order, then deletes those entries.
+  strictly greater than the target. Awaiters whose
+  observed 'TxIn' gets rolled back stay closed (the
+  observation has already been reported); awaiters still
+  pending stay pending.
 * 'snapshotAt' prefix-scans every UTxO at a given address
   using a 'Cursor'.
-
-The op shape is asymmetric:
-
-* 'UtxoCreate' carries the full @(TxIn, Address, TxOut)@
-  triple — the producing block has all three.
-* 'UtxoSpend' carries only a 'TxIn' — the consuming block
-  has nothing else. The indexer's apply path resolves the
-  consumed UTxO's address via 'TxInCol' before deleting
-  the matching 'AddressIndex' row.
+* 'awaitTxIn' blocks until a given 'TxIn' is observed in
+  the index (or the optional timeout fires).
 
 A future RocksDB swap is a one-line change:
 'mkInMemoryDatabase' becomes 'mkRocksDBDatabase' from
 @rocksdb-kv-transactions@; nothing else in this module
 moves.
-
-The @await@ STM-wakeup primitive lands in a subsequent
-patch.
 -}
 module Cardano.Node.Client.UTxOIndexer.Indexer (
     -- * Indexer handle
@@ -41,6 +34,9 @@ module Cardano.Node.Client.UTxOIndexer.Indexer (
 
     -- * Operations
     UtxoOp (..),
+
+    -- * Await observations
+    AwaitObservation (..),
 ) where
 
 import Cardano.Node.Client.UTxOIndexer.Columns (
@@ -53,12 +49,31 @@ import Cardano.Node.Client.UTxOIndexer.IndexerOp (UtxoOp (..))
 import Cardano.Node.Client.UTxOIndexer.Types (
     AddrKey (..),
     Address (..),
+    BlockHash (..),
     SlotNo,
     TxIn (..),
     TxOut,
  )
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (race)
+import Control.Concurrent.STM (
+    STM,
+    TMVar,
+    TVar,
+    atomically,
+    modifyTVar',
+    newEmptyTMVar,
+    newTVarIO,
+    putTMVar,
+    readTMVar,
+    readTVar,
+    readTVarIO,
+    writeTVar,
+ )
 import Data.ByteString qualified as BS
 import Data.Foldable (traverse_)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
 import Database.KV.Cursor (
     Cursor,
     Entry (..),
@@ -81,25 +96,41 @@ import Database.KV.Transaction (
     query,
  )
 
+{- | An observed @TxIn@ apparition: the slot and block
+hash the daemon was at when it processed the
+creating block, plus the @TxOut@ inserted.
+-}
+data AwaitObservation = AwaitObservation
+    { aoSlot :: !SlotNo
+    , aoBlockHash :: !BlockHash
+    , aoTxOut :: !TxOut
+    }
+    deriving stock (Eq, Show)
+
 {- | Operations the rest of the daemon performs against
 the indexer state.
 -}
 data IndexerHandle = IndexerHandle
-    { applyAtSlot :: SlotNo -> [UtxoOp] -> IO ()
+    { applyAtSlot :: SlotNo -> BlockHash -> [UtxoOp] -> IO ()
     -- ^ Atomically apply a batch of create/spend
     -- operations and store the inverse list under the
-    -- given slot in 'RollbackCol'. Used by the
-    -- chain-sync follower's apply-block path.
+    -- given slot in 'RollbackCol'. After the
+    -- transaction commits, fire any 'awaitTxIn'
+    -- waiters whose 'TxIn' was just created.
     , rollbackTo :: SlotNo -> IO ()
     -- ^ Roll the index back to the given slot by
     -- replaying inverse-op lists for every slot
-    -- @> target@, in descending slot order, then
-    -- deleting those rollback entries. Used by the
-    -- chain-sync follower's roll-backward path.
+    -- @> target@, in descending slot order.
     , snapshotAt :: Address -> IO [(TxIn, TxOut)]
     -- ^ Snapshot every UTxO currently at the given
-    -- address, in ascending @TxIn@ order. Used by
-    -- the @utxos_at@ NDJSON request.
+    -- address, in ascending @TxIn@ order.
+    , awaitTxIn :: TxIn -> Maybe Int -> IO (Maybe AwaitObservation)
+    -- ^ Block until @txIn@ is observed in the index,
+    -- or until the timeout (seconds) fires. Returns
+    -- 'Just' with the observation, or 'Nothing' on
+    -- timeout. If @txIn@ is already in the index when
+    -- called, returns immediately with the
+    -- last-observed observation.
     }
 
 {- | Open an in-memory indexer, run the action with the
@@ -116,22 +147,50 @@ withInMemoryIndexer action = do
         columns = mkColumns [0 :: Int ..] codecs
     db <- mkInMemoryDatabase columns
     runner <- newRunTransaction db
-    action (mkHandle runner)
+    waitersVar <- newTVarIO Map.empty
+    observedVar <- newTVarIO Map.empty
+    action (mkHandle runner waitersVar observedVar)
 
 -- Internal -------------------------------------------------------
 
 type Op = (Int, BS.ByteString, Maybe BS.ByteString)
 
+{- | Map from a TxIn awaited by some caller to the
+list of empty TMVars waiting on it. Each TMVar gets
+'putTMVar'd with the observation when the TxIn is
+created.
+-}
+type Waiters = TVar (Map TxIn [TMVar AwaitObservation])
+
+{- | Map from observed TxIns to their last observation.
+Lets 'awaitTxIn' return immediately when called for a
+TxIn that was already created; entries are pruned on
+spend / rollback.
+-}
+type Observed = TVar (Map TxIn AwaitObservation)
+
 mkHandle ::
     RunTransaction IO Int Cols Op ->
+    Waiters ->
+    Observed ->
     IndexerHandle
-mkHandle RunTransaction{runTransaction} =
+mkHandle RunTransaction{runTransaction} waitersVar observedVar =
     IndexerHandle
-        { applyAtSlot = \slot ops ->
+        { applyAtSlot = \slot bh ops -> do
             runTransaction (applyAndLog slot ops)
-        , rollbackTo = runTransaction . rollbackToSlot
+            atomically $
+                fireWaiters
+                    waitersVar
+                    observedVar
+                    slot
+                    bh
+                    ops
+        , rollbackTo = \slot -> do
+            runTransaction (rollbackToSlot slot)
+            atomically (pruneObservedAfter observedVar slot)
         , snapshotAt =
             runTransaction . iterating AddressIndex . scanAddress
+        , awaitTxIn = doAwait waitersVar observedVar
         }
 
 {- | Within one transaction: for each op compute its
@@ -157,19 +216,89 @@ applyAndLog slot ops = do
         applyOne op
         pure inv
 
+{- | After @applyAndLog@ commits, walk the ops and:
+
+* For each @UtxoCreate txIn _addr txOut@: build an
+  observation and store it in the 'Observed' map; pop
+  any waiters from the 'Waiters' map and signal each
+  via @putTMVar@.
+* For each @UtxoSpend txIn@: remove @txIn@ from the
+  'Observed' map (a subsequent re-creation of the same
+  TxIn after rollback will repopulate it).
+
+All in one STM transaction so the maps stay consistent.
+-}
+fireWaiters ::
+    Waiters ->
+    Observed ->
+    SlotNo ->
+    BlockHash ->
+    [UtxoOp] ->
+    STM ()
+fireWaiters waitersVar observedVar slot bh = traverse_ go
+  where
+    go (UtxoCreate txIn _addr txOut) = do
+        let obs =
+                AwaitObservation
+                    { aoSlot = slot
+                    , aoBlockHash = bh
+                    , aoTxOut = txOut
+                    }
+        modifyTVar' observedVar (Map.insert txIn obs)
+        waiters <- readTVar waitersVar
+        case Map.lookup txIn waiters of
+            Nothing -> pure ()
+            Just ws -> do
+                writeTVar waitersVar (Map.delete txIn waiters)
+                traverse_ (`putTMVar` obs) ws
+    go (UtxoSpend txIn) =
+        modifyTVar' observedVar (Map.delete txIn)
+
+{- | After a rollback, drop observations whose slot is
+@> target@. Observations at-or-below the target stay
+(they reflect state that survived).
+-}
+pruneObservedAfter :: Observed -> SlotNo -> STM ()
+pruneObservedAfter observedVar target =
+    modifyTVar'
+        observedVar
+        (Map.filter (\obs -> aoSlot obs <= target))
+
+doAwait ::
+    Waiters ->
+    Observed ->
+    TxIn ->
+    Maybe Int ->
+    IO (Maybe AwaitObservation)
+doAwait waitersVar observedVar txIn mTimeout = do
+    -- Fast path: already observed.
+    observed <- readTVarIO observedVar
+    case Map.lookup txIn observed of
+        Just obs -> pure (Just obs)
+        Nothing -> do
+            tmv <- atomically $ do
+                t <- newEmptyTMVar
+                modifyTVar'
+                    waitersVar
+                    (Map.alter (insertWaiter t) txIn)
+                pure t
+            case mTimeout of
+                Nothing -> Just <$> atomically (readTMVar tmv)
+                Just secs ->
+                    either Just (\() -> Nothing)
+                        <$> race
+                            (atomically (readTMVar tmv))
+                            (threadDelay (secs * 1_000_000))
+  where
+    insertWaiter t Nothing = Just [t]
+    insertWaiter t (Just xs) = Just (t : xs)
+
 {- | Roll back every slot strictly greater than
 @target@. Walks 'RollbackCol' from the highest slot
 down via 'lastEntry'/'prevEntry', collecting entries
 @> target@, then in a second pass replays each
 inverse-op list and deletes the corresponding rollback
 entry — both inside the same transaction.
-
-Two passes are needed because applying inverses (which
-@insert@/@delete@ into the workspace) does not affect
-the live cursor: the cursor reads from a snapshot of
-the underlying column. Collecting first guarantees we
-do not skip entries when later steps mutate the
-column.
 -}
 rollbackToSlot ::
     SlotNo ->
@@ -201,17 +330,7 @@ collectGreaterThan target =
             prevEntry >>= go ((slot, invs) : acc)
         | otherwise = pure (reverse acc)
 
-{- | Inverse of a single op against current state.
-
-* @inv (UtxoCreate txIn _a _v)@: query 'TxInCol' for
-  @txIn@. If present (with @a_old@), query
-  'AddressIndex' for @(a_old, txIn)@'s @v_old@; the
-  inverse is @UtxoCreate txIn a_old v_old@. If absent,
-  the inverse is @UtxoSpend txIn@.
-* @inv (UtxoSpend txIn)@: same shape — query current
-  state, restore via @UtxoCreate@; if absent the spend
-  was a no-op so the inverse is too.
--}
+-- | Inverse of a single op against current state.
 inverseOf ::
     UtxoOp ->
     Transaction IO Int Cols Op UtxoOp
@@ -246,11 +365,7 @@ applyOne (UtxoSpend txIn) = do
 
 {- | Cursor program: seek to the synthetic minimum key
 under @addr@ and walk forward, collecting every entry
-whose key still lives under @addr@. Stops at the first
-entry whose address differs (or end of column).
-
-Each entry of 'AddressIndex' carries the 'TxOut'
-inline, so no second-stage lookup is required.
+whose key still lives under @addr@.
 -}
 scanAddress ::
     (Monad m) =>

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/IndexerOp.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/IndexerOp.hs
@@ -1,0 +1,37 @@
+{- |
+Module      : Cardano.Node.Client.UTxOIndexer.IndexerOp
+Description : The 'UtxoOp' create\/spend sum
+License     : Apache-2.0
+
+Defined in its own module so
+'Cardano.Node.Client.UTxOIndexer.Columns' can reference
+the 'UtxoOp' constructors in the rollback-column codec
+without importing
+'Cardano.Node.Client.UTxOIndexer.Indexer' (which imports
+'Cardano.Node.Client.UTxOIndexer.Columns' for the
+typed-column GADT). Re-exported by the @Indexer@ module
+so the public surface is unchanged.
+-}
+module Cardano.Node.Client.UTxOIndexer.IndexerOp (
+    UtxoOp (..),
+) where
+
+import Cardano.Node.Client.UTxOIndexer.Types (
+    Address,
+    TxIn,
+    TxOut,
+ )
+
+{- | A single mutation against the indexer's live state.
+Apply-block expands a chain block into a list of these.
+-}
+data UtxoOp
+    = -- | Create the UTxO @(txIn, addr, txOut)@:
+      -- insert into both 'TxInCol' (txIn → addr) and
+      -- 'AddressIndex' ((addr, txIn) → txOut).
+      UtxoCreate !TxIn !Address !TxOut
+    | -- | Spend the UTxO at @txIn@: look up its address
+      -- via 'TxInCol', delete from both columns. No-op if
+      -- the TxIn is not in the index.
+      UtxoSpend !TxIn
+    deriving stock (Eq, Show)

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Types.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Types.hs
@@ -41,6 +41,7 @@ module Cardano.Node.Client.UTxOIndexer.Types (
     TxOut (..),
     AddrKey (..),
     SlotNo (..),
+    BlockHash (..),
 
     -- * Composite-key encoding (AddressIndex column)
     addrKeyToBytes,
@@ -186,6 +187,14 @@ matches numeric ordering (a lower slot lexicographically
 precedes a higher slot at the byte level).
 -}
 newtype SlotNo = SlotNo {unSlotNo :: Word64}
+    deriving newtype (Eq, Ord, Show)
+
+{- | Cardano block hash, raw 32 bytes. Stored alongside
+the slot in @await@ observations and (in a follow-up
+patch) wired through to the rollback column for
+chain-rewind fidelity.
+-}
+newtype BlockHash = BlockHash {unBlockHash :: ByteString}
     deriving newtype (Eq, Ord, Show)
 
 -- | Serialise a 'SlotNo' to its 8-byte big-endian form.

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Types.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Types.hs
@@ -40,6 +40,7 @@ module Cardano.Node.Client.UTxOIndexer.Types (
     TxIn (..),
     TxOut (..),
     AddrKey (..),
+    SlotNo (..),
 
     -- * Composite-key encoding (AddressIndex column)
     addrKeyToBytes,
@@ -49,12 +50,16 @@ module Cardano.Node.Client.UTxOIndexer.Types (
     -- * TxIn key encoding (TxInCol column)
     txInToBytes,
     txInFromBytes,
+
+    -- * Slot encoding (RollbackCol column key)
+    slotToBytes,
+    slotFromBytes,
 ) where
 
 import Data.Bits (shiftL, shiftR, (.&.), (.|.))
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
-import Data.Word (Word16, Word8)
+import Data.Word (Word16, Word64, Word8)
 
 {- | Raw payment-address bytes as observed in a 'TxOut'.
 The indexer does not parse Cardano address structure;
@@ -173,6 +178,28 @@ txInFromBytes bs
         let (tid, ixBs) = BS.splitAt 32 bs
          in TxIn tid <$> word16FromBE ixBs
 
+-- Slot encoding ------------------------------------------------------
+
+{- | Cardano slot number. Stored as the 'KeyOf' of the
+rollback column; encoded big-endian so cursor ordering
+matches numeric ordering (a lower slot lexicographically
+precedes a higher slot at the byte level).
+-}
+newtype SlotNo = SlotNo {unSlotNo :: Word64}
+    deriving newtype (Eq, Ord, Show)
+
+-- | Serialise a 'SlotNo' to its 8-byte big-endian form.
+slotToBytes :: SlotNo -> ByteString
+slotToBytes (SlotNo w) = word64BE w
+
+{- | Parse the inverse of 'slotToBytes'. Returns 'Nothing'
+if the byte string is not exactly 8 bytes.
+-}
+slotFromBytes :: ByteString -> Maybe SlotNo
+slotFromBytes bs
+    | BS.length bs /= 8 = Nothing
+    | otherwise = Just $ SlotNo $ word64FromBE bs
+
 -- Internal helpers --------------------------------------------------
 
 word16ToBE :: Word16 -> ByteString
@@ -181,6 +208,21 @@ word16ToBE w =
         [ fromIntegral (w `shiftR` 8) .&. 0xFF
         , fromIntegral w .&. 0xFF
         ]
+
+word64BE :: Word64 -> ByteString
+word64BE w =
+    BS.pack
+        [ fromIntegral (w `shiftR` n) .&. 0xFF
+        | n <- [56, 48, 40, 32, 24, 16, 8, 0]
+        ]
+
+word64FromBE :: ByteString -> Word64
+word64FromBE =
+    foldr (.|.) 0
+        . zipWith
+            (\s b -> fromIntegral b `shiftL` s)
+            [56, 48, 40, 32, 24, 16, 8, 0]
+        . BS.unpack
 
 word16FromBE :: ByteString -> Maybe Word16
 word16FromBE bs

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Types.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Types.hs
@@ -1,0 +1,197 @@
+{- |
+Module      : Cardano.Node.Client.UTxOIndexer.Types
+Description : Domain types for the address->UTxO indexer
+License     : Apache-2.0
+
+Era-agnostic, ledger-decoupled types used by the indexer's
+'Cardano.Node.Client.UTxOIndexer.Columns' database layout
+and by the NDJSON wire. Address bytes, transaction inputs,
+and transaction outputs are all kept as raw 'ByteString' so
+the indexer never decodes era-specific structure: it stores
+exactly what chain-sync gives it and forwards exactly that
+to consumers (as base16 over the wire).
+
+= Composite-key encoding
+
+Cardano addresses are variable-length (Byron and Shelley
+differ; Shelley itself has multiple shapes). To keep prefix
+scans correct across mixed lengths, the address is
+length-prefixed:
+
+@
+key = lenByte || addressBytes || txIdBytes || ixBE16
+@
+
+@lenByte@ is a single byte holding the address length in
+bytes (Cardano addresses fit comfortably in 0..255). Two
+addresses with different lengths therefore have distinct
+leading bytes, so a 'Cursor' seek to @lenByte || addr@
+lands inside the right address bucket and never bleeds into
+a neighbouring bucket.
+
+This is the @aiken-csmt@ trick of prepending the @TxIn@
+with its address so prefix scans under an address yield
+every UTxO at that address — generalised to variable-length
+addresses via the explicit length byte.
+-}
+module Cardano.Node.Client.UTxOIndexer.Types (
+    -- * Indexer domain types
+    Address (..),
+    TxIn (..),
+    TxOut (..),
+    AddrKey (..),
+
+    -- * Composite-key encoding (AddressIndex column)
+    addrKeyToBytes,
+    addrKeyFromBytes,
+    addressPrefix,
+
+    -- * TxIn key encoding (TxInCol column)
+    txInToBytes,
+    txInFromBytes,
+) where
+
+import Data.Bits (shiftL, shiftR, (.&.), (.|.))
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.Word (Word16, Word8)
+
+{- | Raw payment-address bytes as observed in a 'TxOut'.
+The indexer does not parse Cardano address structure;
+consumers can pass either a bech32 string or a base16-encoded
+byte string on the wire and we match by prefix on the
+canonical raw bytes recorded during apply-block.
+-}
+newtype Address = Address {unAddress :: ByteString}
+    deriving newtype (Eq, Ord, Show)
+
+{- | A transaction input: the producing transaction's
+32-byte hash plus the output index within that
+transaction.
+-}
+data TxIn = TxIn
+    { txInId :: !ByteString
+    -- ^ Transaction ID (32 raw bytes).
+    , txInIx :: !Word16
+    -- ^ Output index inside the transaction body.
+    }
+    deriving stock (Eq, Ord, Show)
+
+{- | Raw CBOR-encoded transaction output. The indexer
+forwards these unchanged on the wire (as base16);
+consumers parse value/datum themselves if they need
+to.
+-}
+newtype TxOut = TxOut {unTxOut :: ByteString}
+    deriving newtype (Eq, Ord, Show)
+
+{- | Composite key under which UTxOs are indexed.
+
+The on-disk byte form is @lenByte || addressBytes ||
+txIdBytes || ixBE16@; see the module header for the
+length-prefix rationale.
+-}
+data AddrKey = AddrKey
+    { addrKeyAddress :: !Address
+    , addrKeyTxIn :: !TxIn
+    }
+    deriving stock (Eq, Ord, Show)
+
+{- | Maximum address length the indexer accepts. Cardano
+addresses fit comfortably under this; reject anything
+larger so the single-byte length prefix stays sufficient.
+-}
+maxAddressLength :: Int
+maxAddressLength = 255
+
+{- | Serialise an 'AddrKey' to its composite-key byte
+form. Returns 'Nothing' if the address exceeds
+'maxAddressLength' (an invariant violation: the indexer
+never observes such an address from real ledger data).
+
+Inverse of 'addrKeyFromBytes'.
+-}
+addrKeyToBytes :: AddrKey -> Maybe ByteString
+addrKeyToBytes (AddrKey (Address addr) (TxIn tid ix))
+    | BS.length addr > maxAddressLength = Nothing
+    | otherwise =
+        Just $
+            BS.cons (fromIntegral (BS.length addr)) addr
+                <> tid
+                <> word16ToBE ix
+
+{- | Parse a composite key produced by 'addrKeyToBytes'.
+Returns 'Nothing' if the byte string is shorter than
+required, declares an address length that does not match
+the remaining bytes, or has trailing garbage past the
+@ixBE16@.
+-}
+addrKeyFromBytes :: ByteString -> Maybe AddrKey
+addrKeyFromBytes bs0 = do
+    (lenByte, rest0) <- BS.uncons bs0
+    let addrLen = fromIntegral lenByte
+    if BS.length rest0 /= addrLen + 32 + 2
+        then Nothing
+        else do
+            let (addr, rest1) = BS.splitAt addrLen rest0
+                (tid, ixBs) = BS.splitAt 32 rest1
+            ix <- word16FromBE ixBs
+            pure $ AddrKey (Address addr) (TxIn tid ix)
+
+{- | The byte-string prefix corresponding to "all UTxOs
+at this address" — i.e. @lenByte || addressBytes@. Pass
+to a 'Cursor' as the seek prefix for a snapshot scan.
+
+Returns 'Nothing' for addresses exceeding
+'maxAddressLength' (same invariant as 'addrKeyToBytes').
+-}
+addressPrefix :: Address -> Maybe ByteString
+addressPrefix (Address bs)
+    | BS.length bs > maxAddressLength = Nothing
+    | otherwise =
+        Just $ BS.cons (fromIntegral (BS.length bs)) bs
+
+-- TxIn encoding -----------------------------------------------------
+
+{- | Serialise a 'TxIn' to its 34-byte fixed-width
+form: @txId (32 bytes) || ix (Word16 BE)@. Total: 34
+bytes.
+
+Used as the key codec of the 'TxInCol' column.
+-}
+txInToBytes :: TxIn -> ByteString
+txInToBytes (TxIn tid ix) = tid <> word16ToBE ix
+
+{- | Parse the inverse of 'txInToBytes'. Returns
+'Nothing' if the byte string is not exactly 34 bytes
+or if the embedded TxId is not 32 bytes.
+-}
+txInFromBytes :: ByteString -> Maybe TxIn
+txInFromBytes bs
+    | BS.length bs /= 34 = Nothing
+    | otherwise =
+        let (tid, ixBs) = BS.splitAt 32 bs
+         in TxIn tid <$> word16FromBE ixBs
+
+-- Internal helpers --------------------------------------------------
+
+word16ToBE :: Word16 -> ByteString
+word16ToBE w =
+    BS.pack
+        [ fromIntegral (w `shiftR` 8) .&. 0xFF
+        , fromIntegral w .&. 0xFF
+        ]
+
+word16FromBE :: ByteString -> Maybe Word16
+word16FromBE bs
+    | BS.length bs /= 2 = Nothing
+    | otherwise =
+        let bytes :: [Word8]
+            bytes = BS.unpack bs
+            shifted :: [Word16]
+            shifted =
+                zipWith
+                    (\b s -> fromIntegral b `shiftL` s)
+                    bytes
+                    [8, 0]
+         in Just $ foldr (.|.) 0 shifted

--- a/lib/Cardano/Node/Client/UTxOIndexer/BlockExtract.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/BlockExtract.hs
@@ -1,0 +1,165 @@
+{- |
+Module      : Cardano.Node.Client.UTxOIndexer.BlockExtract
+Description : Extract @(SlotNo, [UtxoOp])@ from a Cardano consensus block
+License     : Apache-2.0
+
+Era-polymorphic block decoding using @cardano-ledger-read@'s
+'Cardano.Read.Ledger' helpers — the same abstraction
+'cardano-utxo-csmt' uses. Each block is mapped through
+'fromConsensusBlock' into an era-tagged value; the
+extraction logic is then expressed once over an
+@IsEra era@ constraint and run via 'applyEraFun'.
+
+This sidesteps the renames the raw @cardano-ledger-api@
+goes through (e.g. @SafeHash@ → @Hashes@,
+@Cardano.Ledger.Shelley.BlockChain@ →
+@Cardano.Ledger.Shelley.BlockBody@, @txid@ → @txIdTx@,
+@Tx era@ → @Tx l era@, @TxId c@ → @TxId@) — they all
+live below 'cardano-ledger-read''s API surface.
+
+Byron support is stubbed (returns @[]@). Devnet
+workloads post-date the Byron→Shelley hard fork; if a
+consumer ever needs Byron data, the stub is the obvious
+place to wire it in.
+-}
+module Cardano.Node.Client.UTxOIndexer.BlockExtract
+    ( extractBlock
+    ) where
+
+import Cardano.Crypto.Hash.Class (hashToBytes)
+import Cardano.Ledger.Address (serialiseAddr)
+import Cardano.Ledger.Binary (serialize')
+import Cardano.Ledger.Core
+    ( EraTx
+    , EraTxBody
+    , EraTxOut
+    , TopTx
+    , addrTxOutL
+    , bodyTxL
+    , eraProtVerLow
+    , inputsTxBodyL
+    , outputsTxBodyL
+    , txIdTxBody
+    )
+import Cardano.Ledger.Core qualified as Ledger
+import Cardano.Ledger.Hashes (extractHash)
+import Cardano.Ledger.BaseTypes (TxIx (..))
+import Cardano.Ledger.TxIn qualified as SH
+import Cardano.Node.Client.Types (Block)
+import Cardano.Node.Client.UTxOIndexer.IndexerOp (UtxoOp (..))
+import Cardano.Node.Client.UTxOIndexer.Types
+    ( Address (..)
+    , SlotNo (..)
+    , TxIn (..)
+    , TxOut (..)
+    )
+import Cardano.Read.Ledger.Block.Block (fromConsensusBlock)
+import Cardano.Read.Ledger.Block.Txs (getEraTransactions)
+import Cardano.Read.Ledger.Eras.EraValue (applyEraFun)
+import Cardano.Read.Ledger.Eras.KnownEras
+    ( Era (..)
+    , IsEra
+    , theEra
+    )
+-- Era pattern aliases are exported via 'Era (..)' above; the
+-- 'Dijkstra' case in 'changes' below requires this re-export
+-- pattern match to be exhaustive.
+import Cardano.Read.Ledger.Tx.Tx (Tx (..))
+import Data.ByteString (ByteString)
+import Data.Foldable (toList)
+import Data.Word (Word16)
+import Lens.Micro ((^.))
+import Ouroboros.Consensus.Cardano.Node ()
+import Ouroboros.Consensus.Protocol.Praos.Header ()
+import Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion ()
+import Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
+import Ouroboros.Network.Block qualified as Network
+import Ouroboros.Network.Point qualified as Network.Point
+
+{- | Extract @(slot, ops)@ from a Cardano consensus block.
+
+The slot comes from the block header; the ops list is
+the concatenation, in transaction order, of each tx's
+spends followed by its creates.
+-}
+extractBlock :: Block -> (SlotNo, [UtxoOp])
+extractBlock blk =
+    ( blockSlot blk
+    , applyEraFun (changes . getEraTransactions) (fromConsensusBlock blk)
+    )
+
+-- | Slot of the block. Cardano blocks are non-genesis;
+-- the @Origin@ case is structurally impossible here so
+-- we map it to slot 0 (defensive).
+blockSlot :: Block -> SlotNo
+blockSlot blk =
+    case Network.pointSlot (Network.blockPoint blk) of
+        Network.Point.Origin -> SlotNo 0
+        Network.Point.At s -> SlotNo (Network.unSlotNo s)
+
+-- | UTxO ops produced by a single era's tx list. Byron
+-- returns @[]@ — pre-Shelley blocks are not exercised by
+-- current workloads. Each Shelley-family branch narrows
+-- @TxT era ~ Core.Tx Core.TopTx era@ so the
+-- @bodyTxL@/@inputsTxBodyL@/@outputsTxBodyL@ lenses
+-- become applicable.
+changes :: forall era. (IsEra era) => [Tx era] -> [UtxoOp]
+changes txs = case theEra @era of
+    Byron -> []
+    Shelley -> concatMap (shelleyTxChanges . unTx) txs
+    Allegra -> concatMap (shelleyTxChanges . unTx) txs
+    Mary -> concatMap (shelleyTxChanges . unTx) txs
+    Alonzo -> concatMap (shelleyTxChanges . unTx) txs
+    Babbage -> concatMap (shelleyTxChanges . unTx) txs
+    Conway -> concatMap (shelleyTxChanges . unTx) txs
+    Dijkstra -> concatMap (shelleyTxChanges . unTx) txs
+
+-- | Convert a Shelley-family @'Core.Tx' TopTx era@ into a
+-- list of @UtxoOp@s.
+shelleyTxChanges
+    :: forall era
+     . (EraTx era)
+    => Ledger.Tx TopTx era
+    -> [UtxoOp]
+shelleyTxChanges tx =
+    let body = tx ^. bodyTxL
+        tid = txBodyIdBytes @era body
+        ins = body ^. inputsTxBodyL
+        outs = body ^. outputsTxBodyL
+        spends = UtxoSpend . shelleyTxInToIndexer <$> toList ins
+        creates =
+            zipWith
+                (mkCreate @era tid)
+                [0 ..]
+                (toList outs)
+     in spends <> creates
+
+-- | Bytes of the Shelley-family TxBody's hash (used as
+-- @txInId@ for outputs created by this body).
+txBodyIdBytes
+    :: forall era. (EraTxBody era) => Ledger.TxBody TopTx era -> ByteString
+txBodyIdBytes body =
+    case txIdTxBody body of
+        SH.TxId safeHash -> hashToBytes (extractHash safeHash)
+
+shelleyTxInToIndexer :: SH.TxIn -> TxIn
+shelleyTxInToIndexer (SH.TxIn (SH.TxId safeHash) (TxIx ix)) =
+    TxIn
+        { txInId = hashToBytes (extractHash safeHash)
+        , txInIx = fromIntegral ix
+        }
+
+mkCreate
+    :: forall era
+     . (EraTxOut era)
+    => ByteString
+    -- ^ producing tx id (32 raw bytes)
+    -> Word16
+    -- ^ output index
+    -> Ledger.TxOut era
+    -> UtxoOp
+mkCreate tid ix out =
+    UtxoCreate
+        TxIn{txInId = tid, txInIx = ix}
+        (Address (serialiseAddr (out ^. addrTxOutL)))
+        (TxOut (serialize' (eraProtVerLow @era) out))

--- a/lib/Cardano/Node/Client/UTxOIndexer/BlockExtract.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/BlockExtract.hs
@@ -22,45 +22,46 @@ workloads post-date the Byron→Shelley hard fork; if a
 consumer ever needs Byron data, the stub is the obvious
 place to wire it in.
 -}
-module Cardano.Node.Client.UTxOIndexer.BlockExtract
-    ( extractBlock
-    ) where
+module Cardano.Node.Client.UTxOIndexer.BlockExtract (
+    extractBlock,
+) where
 
 import Cardano.Crypto.Hash.Class (hashToBytes)
 import Cardano.Ledger.Address (serialiseAddr)
+import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.Binary (serialize')
-import Cardano.Ledger.Core
-    ( EraTx
-    , EraTxBody
-    , EraTxOut
-    , TopTx
-    , addrTxOutL
-    , bodyTxL
-    , eraProtVerLow
-    , inputsTxBodyL
-    , outputsTxBodyL
-    , txIdTxBody
-    )
+import Cardano.Ledger.Core (
+    EraTx,
+    EraTxBody,
+    EraTxOut,
+    TopTx,
+    addrTxOutL,
+    bodyTxL,
+    eraProtVerLow,
+    inputsTxBodyL,
+    outputsTxBodyL,
+    txIdTxBody,
+ )
 import Cardano.Ledger.Core qualified as Ledger
 import Cardano.Ledger.Hashes (extractHash)
-import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.TxIn qualified as SH
 import Cardano.Node.Client.Types (Block)
 import Cardano.Node.Client.UTxOIndexer.IndexerOp (UtxoOp (..))
-import Cardano.Node.Client.UTxOIndexer.Types
-    ( Address (..)
-    , SlotNo (..)
-    , TxIn (..)
-    , TxOut (..)
-    )
+import Cardano.Node.Client.UTxOIndexer.Types (
+    Address (..),
+    SlotNo (..),
+    TxIn (..),
+    TxOut (..),
+ )
 import Cardano.Read.Ledger.Block.Block (fromConsensusBlock)
 import Cardano.Read.Ledger.Block.Txs (getEraTransactions)
 import Cardano.Read.Ledger.Eras.EraValue (applyEraFun)
-import Cardano.Read.Ledger.Eras.KnownEras
-    ( Era (..)
-    , IsEra
-    , theEra
-    )
+import Cardano.Read.Ledger.Eras.KnownEras (
+    Era (..),
+    IsEra,
+    theEra,
+ )
+
 -- Era pattern aliases are exported via 'Era (..)' above; the
 -- 'Dijkstra' case in 'changes' below requires this re-export
 -- pattern match to be exhaustive.
@@ -88,21 +89,23 @@ extractBlock blk =
     , applyEraFun (changes . getEraTransactions) (fromConsensusBlock blk)
     )
 
--- | Slot of the block. Cardano blocks are non-genesis;
--- the @Origin@ case is structurally impossible here so
--- we map it to slot 0 (defensive).
+{- | Slot of the block. Cardano blocks are non-genesis;
+the @Origin@ case is structurally impossible here so
+we map it to slot 0 (defensive).
+-}
 blockSlot :: Block -> SlotNo
 blockSlot blk =
     case Network.pointSlot (Network.blockPoint blk) of
         Network.Point.Origin -> SlotNo 0
         Network.Point.At s -> SlotNo (Network.unSlotNo s)
 
--- | UTxO ops produced by a single era's tx list. Byron
--- returns @[]@ — pre-Shelley blocks are not exercised by
--- current workloads. Each Shelley-family branch narrows
--- @TxT era ~ Core.Tx Core.TopTx era@ so the
--- @bodyTxL@/@inputsTxBodyL@/@outputsTxBodyL@ lenses
--- become applicable.
+{- | UTxO ops produced by a single era's tx list. Byron
+returns @[]@ — pre-Shelley blocks are not exercised by
+current workloads. Each Shelley-family branch narrows
+@TxT era ~ Core.Tx Core.TopTx era@ so the
+@bodyTxL@/@inputsTxBodyL@/@outputsTxBodyL@ lenses
+become applicable.
+-}
 changes :: forall era. (IsEra era) => [Tx era] -> [UtxoOp]
 changes txs = case theEra @era of
     Byron -> []
@@ -114,13 +117,14 @@ changes txs = case theEra @era of
     Conway -> concatMap (shelleyTxChanges . unTx) txs
     Dijkstra -> concatMap (shelleyTxChanges . unTx) txs
 
--- | Convert a Shelley-family @'Core.Tx' TopTx era@ into a
--- list of @UtxoOp@s.
-shelleyTxChanges
-    :: forall era
-     . (EraTx era)
-    => Ledger.Tx TopTx era
-    -> [UtxoOp]
+{- | Convert a Shelley-family @'Core.Tx' TopTx era@ into a
+list of @UtxoOp@s.
+-}
+shelleyTxChanges ::
+    forall era.
+    (EraTx era) =>
+    Ledger.Tx TopTx era ->
+    [UtxoOp]
 shelleyTxChanges tx =
     let body = tx ^. bodyTxL
         tid = txBodyIdBytes @era body
@@ -134,10 +138,11 @@ shelleyTxChanges tx =
                 (toList outs)
      in spends <> creates
 
--- | Bytes of the Shelley-family TxBody's hash (used as
--- @txInId@ for outputs created by this body).
-txBodyIdBytes
-    :: forall era. (EraTxBody era) => Ledger.TxBody TopTx era -> ByteString
+{- | Bytes of the Shelley-family TxBody's hash (used as
+@txInId@ for outputs created by this body).
+-}
+txBodyIdBytes ::
+    forall era. (EraTxBody era) => Ledger.TxBody TopTx era -> ByteString
 txBodyIdBytes body =
     case txIdTxBody body of
         SH.TxId safeHash -> hashToBytes (extractHash safeHash)
@@ -149,15 +154,15 @@ shelleyTxInToIndexer (SH.TxIn (SH.TxId safeHash) (TxIx ix)) =
         , txInIx = fromIntegral ix
         }
 
-mkCreate
-    :: forall era
-     . (EraTxOut era)
-    => ByteString
-    -- ^ producing tx id (32 raw bytes)
-    -> Word16
-    -- ^ output index
-    -> Ledger.TxOut era
-    -> UtxoOp
+mkCreate ::
+    forall era.
+    (EraTxOut era) =>
+    -- | producing tx id (32 raw bytes)
+    ByteString ->
+    -- | output index
+    Word16 ->
+    Ledger.TxOut era ->
+    UtxoOp
 mkCreate tid ix out =
     UtxoCreate
         TxIn{txInId = tid, txInIx = ix}

--- a/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
@@ -1,0 +1,181 @@
+{- |
+Module      : Cardano.Node.Client.UTxOIndexer.Daemon
+Description : Daemon entrypoint — wires ChainSync, Indexer, Server
+License     : Apache-2.0
+
+Composes the four pieces the daemon needs:
+
+* 'IndexerHandle' from @utxo-indexer-lib@ — the in-memory
+  address->UTxO index plus its rollback log and await
+  waiters.
+* 'Cardano.Node.Client.UTxOIndexer.BlockExtract.extractBlock'
+  — block→@(slot, [UtxoOp])@ era-polymorphic decoder.
+* 'Cardano.Node.Client.UTxOIndexer.Server.runServer' —
+  NDJSON Unix-socket server.
+* 'Cardano.Node.Client.N2C.ChainSync.runChainSyncN2C' —
+  the chain-sync follower itself.
+
+A 'TVar' 'ReadyStatus' is updated as blocks land so the
+@ready@ NDJSON request reflects the daemon's current
+catch-up state.
+-}
+module Cardano.Node.Client.UTxOIndexer.Daemon (
+    DaemonConfig (..),
+    runDaemon,
+) where
+
+import Cardano.Chain.Slotting (EpochSlots (..))
+import Cardano.Node.Client.N2C.ChainSync (
+    Fetched (..),
+    HeaderPoint,
+    mkChainSyncN2C,
+    runChainSyncN2C,
+ )
+import Cardano.Node.Client.UTxOIndexer.BlockExtract (extractBlock)
+import Cardano.Node.Client.UTxOIndexer.Indexer (
+    IndexerHandle (..),
+    withInMemoryIndexer,
+ )
+import Cardano.Node.Client.UTxOIndexer.Server (
+    ReadyStatus (..),
+    runServer,
+ )
+import Cardano.Node.Client.UTxOIndexer.Types (
+    BlockHash (..),
+    SlotNo (..),
+ )
+import ChainFollower (
+    Follower (..),
+    Intersector (..),
+    ProgressOrRewind (..),
+ )
+import Control.Concurrent.Async (concurrently_)
+import Control.Concurrent.STM (
+    TVar,
+    atomically,
+    newTVarIO,
+    readTVarIO,
+    writeTVar,
+ )
+import Control.Monad (void)
+import Control.Tracer (nullTracer)
+import Data.ByteString.Short qualified as SBS
+import Data.Word (Word32, Word64)
+import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (
+    OneEraHash (..),
+ )
+import Ouroboros.Network.Block qualified as Network
+import Ouroboros.Network.Magic (NetworkMagic (..))
+import Ouroboros.Network.Point qualified as Network.Point
+
+{- | Daemon runtime configuration. Plain Haskell record;
+the CLI-parsing in @Main@ produces this.
+-}
+data DaemonConfig = DaemonConfig
+    { dcRelaySocket :: FilePath
+    , dcListenSocket :: FilePath
+    , dcNetworkMagic :: Word32
+    , dcByronEpochSlots :: Word64
+    , dcReadyThresholdSlots :: Word64
+    }
+    deriving stock (Show)
+
+{- | Open an in-memory indexer, start the NDJSON server
+and the chain-sync follower, and block. Returns when
+either side exits (chain-sync disconnect, server crash,
+etc.) — the caller is expected to supervise.
+-}
+runDaemon :: DaemonConfig -> IO ()
+runDaemon cfg = do
+    readyVar <- newTVarIO initialReady
+    withInMemoryIndexer $ \idx -> do
+        let getReady = readTVarIO readyVar
+            chainAction =
+                runChainSyncN2C
+                    (EpochSlots (dcByronEpochSlots cfg))
+                    (NetworkMagic (dcNetworkMagic cfg))
+                    (dcRelaySocket cfg)
+                    ( mkChainSyncN2C
+                        nullTracer
+                        nullTracer
+                        (mkIntersector cfg readyVar idx)
+                        [Network.Point Network.Point.Origin]
+                    )
+            serverAction = runServer (dcListenSocket cfg) idx getReady
+        concurrently_ (void chainAction) serverAction
+  where
+    initialReady =
+        ReadyStatus
+            { rsReady = False
+            , rsTipSlot = Nothing
+            , rsProcessedSlot = Nothing
+            , rsSlotsBehind = Nothing
+            }
+
+mkIntersector ::
+    DaemonConfig ->
+    TVar ReadyStatus ->
+    IndexerHandle ->
+    Intersector HeaderPoint Network.SlotNo Fetched
+mkIntersector cfg readyVar idx =
+    Intersector
+        { intersectFound = \_pt -> pure (mkFollower cfg readyVar idx)
+        , intersectNotFound =
+            pure
+                ( mkIntersector cfg readyVar idx
+                , [Network.Point Network.Point.Origin]
+                )
+        }
+
+mkFollower ::
+    DaemonConfig ->
+    TVar ReadyStatus ->
+    IndexerHandle ->
+    Follower HeaderPoint Network.SlotNo Fetched
+mkFollower cfg readyVar idx = self
+  where
+    self =
+        Follower
+            { rollForward = \fetched tip -> do
+                let (slot, ops) = extractBlock (fetchedBlock fetched)
+                    bh = pointToBlockHash (fetchedPoint fetched)
+                applyAtSlot idx slot bh ops
+                updateReady cfg readyVar slot tip
+                pure self
+            , rollBackward = \point -> do
+                let slot = case Network.pointSlot point of
+                        Network.Point.Origin -> SlotNo 0
+                        Network.Point.At s -> SlotNo (Network.unSlotNo s)
+                rollbackTo idx slot
+                pure (Progress self)
+            }
+
+{- | Pull the block hash bytes out of an
+'OneEraHash'-shaped 'HeaderPoint'. Origin (no block)
+maps to an empty 'BlockHash'.
+-}
+pointToBlockHash :: HeaderPoint -> BlockHash
+pointToBlockHash p =
+    case p of
+        Network.Point Network.Point.Origin -> BlockHash mempty
+        Network.Point (Network.Point.At (Network.Point.Block _ h)) ->
+            BlockHash (SBS.fromShort (getOneEraHash h))
+
+updateReady ::
+    DaemonConfig ->
+    TVar ReadyStatus ->
+    SlotNo ->
+    Network.SlotNo ->
+    IO ()
+updateReady cfg readyVar (SlotNo processed) tipNet =
+    let tip = Network.unSlotNo tipNet
+        behind = if tip > processed then tip - processed else 0
+        ready = behind <= dcReadyThresholdSlots cfg
+        rs =
+            ReadyStatus
+                { rsReady = ready
+                , rsTipSlot = Just (SlotNo tip)
+                , rsProcessedSlot = Just (SlotNo processed)
+                , rsSlotsBehind = Just behind
+                }
+     in atomically (writeTVar readyVar rs)

--- a/lib/Cardano/Node/Client/UTxOIndexer/Server.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Server.hs
@@ -36,10 +36,12 @@ module Cardano.Node.Client.UTxOIndexer.Server (
 ) where
 
 import Cardano.Node.Client.UTxOIndexer.Indexer (
+    AwaitObservation (..),
     IndexerHandle (..),
  )
 import Cardano.Node.Client.UTxOIndexer.Types (
     Address (..),
+    BlockHash (..),
     SlotNo (..),
     TxIn (..),
     TxOut (..),
@@ -164,6 +166,9 @@ handleConn idx getReady conn = (`finally` close conn) $ do
         Just Ready -> do
             rs <- getReady
             sendLine conn (encode rs)
+        Just (Await txIn mTimeout) -> do
+            mObs <- awaitTxIn idx txIn mTimeout
+            sendLine conn (encode (AwaitResponse mObs))
 
 {- | Read up to and including the first @\n@. The line
 itself is returned without the trailing newline.
@@ -201,6 +206,7 @@ sendLine s payload =
 data Request
     = UtxosAt !Address
     | Ready
+    | Await !TxIn !(Maybe Int)
     deriving stock (Eq, Show)
 
 instance FromJSON Request where
@@ -211,12 +217,37 @@ instance FromJSON Request where
                         _ <- o .: "ready" :: Aeson.Parser Aeson.Value
                         pure Ready
                     )
+                <|> ( do
+                        s <- o .: "await"
+                        txIn <- parseTxInWire s
+                        mt <-
+                            o Aeson..:? "timeout_seconds" ::
+                                Aeson.Parser (Maybe Int)
+                        pure (Await txIn mt)
+                    )
       where
         parseHexAddress :: Text -> Aeson.Parser Address
         parseHexAddress t = case Base16.decode (Text.encodeUtf8 t) of
             Right bs -> pure (Address bs)
             Left err ->
                 fail $ "utxos_at: invalid base16 — " <> err
+
+parseTxInWire :: Text -> Aeson.Parser TxIn
+parseTxInWire s =
+    case Text.splitOn (Text.pack "#") s of
+        [tidT, ixT] -> do
+            tid <- case Base16.decode (Text.encodeUtf8 tidT) of
+                Right bs
+                    | BS.length bs == 32 -> pure bs
+                Right _ -> fail "await: txid must be 32 bytes (64 hex)"
+                Left err -> fail $ "await: invalid txid hex — " <> err
+            ix <- case reads (Text.unpack ixT) of
+                [(n, "")] | n >= 0 && n <= 65535 -> pure (fromInteger n)
+                _ ->
+                    fail
+                        "await: ix must be a non-negative integer ≤ 65535"
+            pure (TxIn tid ix)
+        _ -> fail "await: expected \"<txid_hex>#<ix>\""
 
 newtype UtxosResponse = UtxosResponse [(TxIn, TxOut)]
 
@@ -240,3 +271,24 @@ txInWire (TxIn tid ix) =
 
 errorResponse :: Text -> Value
 errorResponse msg = object ["error" .= msg]
+
+newtype AwaitResponse = AwaitResponse (Maybe AwaitObservation)
+
+instance ToJSON AwaitResponse where
+    toJSON (AwaitResponse Nothing) =
+        object ["timeout" .= True]
+    toJSON
+        ( AwaitResponse
+                ( Just
+                        AwaitObservation
+                            { aoSlot = SlotNo s
+                            , aoBlockHash = BlockHash bh
+                            , aoTxOut = txOut
+                            }
+                    )
+            ) =
+            object
+                [ "slot" .= s
+                , "blockHash" .= Text.decodeUtf8 (Base16.encode bh)
+                , "txout" .= Text.decodeUtf8 (Base16.encode (unTxOut txOut))
+                ]

--- a/lib/Cardano/Node/Client/UTxOIndexer/Server.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Server.hs
@@ -1,0 +1,242 @@
+{- |
+Module      : Cardano.Node.Client.UTxOIndexer.Server
+Description : NDJSON Unix-socket server for the indexer
+License     : Apache-2.0
+
+Listens on a Unix domain socket and serves the read
+side of the indexer using newline-delimited JSON.
+
+Wire (per @cardano-node-clients#78@):
+
+@
+REQ:  {"utxos_at": "<hex-of-address-bytes>"}
+RESP: {"utxos": [{"txin": "<txid>#<ix>",
+                  "txout": "<base16-cbor>"}, ...]}
+
+REQ:  {"ready": null}
+RESP: {"ready":<bool>, "tipSlot":<int|null>,
+       "processedSlot":<int|null>, "slotsBehind":<int|null>}
+@
+
+Each connection is a single request → single response →
+EOF; the @await@ streaming primitive lands in a separate
+patch.
+
+Address bytes are sent on the wire as hex. Bech32
+parsing lives in the consumer (consumers either already
+have raw bytes from the ledger or hex-encode them
+explicitly before calling).
+-}
+module Cardano.Node.Client.UTxOIndexer.Server (
+    -- * Server
+    runServer,
+
+    -- * Ready status
+    ReadyStatus (..),
+) where
+
+import Cardano.Node.Client.UTxOIndexer.Indexer (
+    IndexerHandle (..),
+ )
+import Cardano.Node.Client.UTxOIndexer.Types (
+    Address (..),
+    SlotNo (..),
+    TxIn (..),
+    TxOut (..),
+ )
+import Control.Applicative ((<|>))
+import Control.Concurrent (forkIO)
+import Control.Exception (bracket, finally, try)
+import Data.Aeson (
+    FromJSON (..),
+    ToJSON (..),
+    Value,
+    decodeStrict',
+    encode,
+    object,
+    (.:),
+    (.=),
+ )
+import Data.Aeson.Types qualified as Aeson
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Builder (toLazyByteString)
+import Data.ByteString.Builder qualified as Builder
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Data.Word (Word64)
+import Network.Socket (
+    Family (AF_UNIX),
+    SockAddr (SockAddrUnix),
+    Socket,
+    SocketType (Stream),
+    accept,
+    bind,
+    close,
+    listen,
+    socket,
+ )
+import Network.Socket.ByteString qualified as Net
+import System.Directory (removeFile)
+import System.IO.Error (isDoesNotExistError)
+
+{- | Sync-readiness snapshot used for the @ready@
+endpoint. Mirrors @cardano-utxo-csmt@'s @ReadyResponse@
+field shape (@ready@/@tipSlot@/@processedSlot@/
+@slotsBehind@) so consumers wired against either
+daemon get the same JSON.
+-}
+data ReadyStatus = ReadyStatus
+    { rsReady :: !Bool
+    , rsTipSlot :: !(Maybe SlotNo)
+    , rsProcessedSlot :: !(Maybe SlotNo)
+    , rsSlotsBehind :: !(Maybe Word64)
+    }
+    deriving stock (Eq, Show)
+
+instance ToJSON ReadyStatus where
+    toJSON ReadyStatus{rsReady, rsTipSlot, rsProcessedSlot, rsSlotsBehind} =
+        object
+            [ "ready" .= rsReady
+            , "tipSlot" .= fmap unSlotNo rsTipSlot
+            , "processedSlot" .= fmap unSlotNo rsProcessedSlot
+            , "slotsBehind" .= rsSlotsBehind
+            ]
+      where
+        unSlotNo (SlotNo s) = s
+
+{- | Run the NDJSON server on @socketPath@ until killed
+(by exception). Removes any stale socket file at
+@socketPath@ first.
+
+The accept loop forks a new thread per accepted
+connection. Each handler reads one request line, writes
+one response line, closes.
+-}
+runServer ::
+    FilePath ->
+    IndexerHandle ->
+    IO ReadyStatus ->
+    IO ()
+runServer socketPath idx getReady =
+    bracket (openListenSocket socketPath) close $ \sock -> do
+        listen sock 16
+        let acceptLoop = do
+                (conn, _) <- accept sock
+                _ <- forkIO (handleConn idx getReady conn)
+                acceptLoop
+        acceptLoop
+
+openListenSocket :: FilePath -> IO Socket
+openListenSocket path = do
+    removeIfPresent path
+    sock <- socket AF_UNIX Stream 0
+    bind sock (SockAddrUnix path)
+    pure sock
+
+removeIfPresent :: FilePath -> IO ()
+removeIfPresent p = do
+    r <- try (removeFile p)
+    case r of
+        Right () -> pure ()
+        Left e
+            | isDoesNotExistError e -> pure ()
+            | otherwise -> ioError e
+
+-- Per-connection handler ----------------------------------------------
+
+handleConn ::
+    IndexerHandle ->
+    IO ReadyStatus ->
+    Socket ->
+    IO ()
+handleConn idx getReady conn = (`finally` close conn) $ do
+    line <- recvLine conn
+    case decodeStrict' line :: Maybe Request of
+        Nothing ->
+            sendLine conn (encode (errorResponse "malformed json"))
+        Just (UtxosAt addr) -> do
+            utxos <- snapshotAt idx addr
+            sendLine conn (encode (UtxosResponse utxos))
+        Just Ready -> do
+            rs <- getReady
+            sendLine conn (encode rs)
+
+{- | Read up to and including the first @\n@. The line
+itself is returned without the trailing newline.
+-}
+recvLine :: Socket -> IO ByteString
+recvLine s = go BS.empty
+  where
+    go acc = do
+        chunk <- Net.recv s 4096
+        if BS.null chunk
+            then pure (stripNewline acc)
+            else case BS.elemIndex 0x0A chunk of
+                Just i ->
+                    let (hd, _) = BS.splitAt i chunk
+                     in pure (stripNewline (acc <> hd))
+                Nothing -> go (acc <> chunk)
+
+stripNewline :: ByteString -> ByteString
+stripNewline bs
+    | not (BS.null bs) && BS.last bs == 0x0A =
+        BS.init bs
+    | otherwise = bs
+
+-- | Send one JSON line followed by @\n@.
+sendLine :: Socket -> LBS.ByteString -> IO ()
+sendLine s payload =
+    Net.sendAll s $
+        LBS.toStrict $
+            toLazyByteString $
+                Builder.lazyByteString payload
+                    <> Builder.char7 '\n'
+
+-- Wire types ----------------------------------------------------------
+
+data Request
+    = UtxosAt !Address
+    | Ready
+    deriving stock (Eq, Show)
+
+instance FromJSON Request where
+    parseJSON =
+        Aeson.withObject "Request" $ \o ->
+            (UtxosAt <$> (o .: "utxos_at" >>= parseHexAddress))
+                <|> ( do
+                        _ <- o .: "ready" :: Aeson.Parser Aeson.Value
+                        pure Ready
+                    )
+      where
+        parseHexAddress :: Text -> Aeson.Parser Address
+        parseHexAddress t = case Base16.decode (Text.encodeUtf8 t) of
+            Right bs -> pure (Address bs)
+            Left err ->
+                fail $ "utxos_at: invalid base16 — " <> err
+
+newtype UtxosResponse = UtxosResponse [(TxIn, TxOut)]
+
+instance ToJSON UtxosResponse where
+    toJSON (UtxosResponse xs) =
+        object ["utxos" .= map utxoEntry xs]
+      where
+        utxoEntry :: (TxIn, TxOut) -> Value
+        utxoEntry (txin, txout) =
+            object
+                [ "txin" .= txInWire txin
+                , "txout"
+                    .= Text.decodeUtf8 (Base16.encode (unTxOut txout))
+                ]
+
+txInWire :: TxIn -> Text
+txInWire (TxIn tid ix) =
+    Text.decodeUtf8 (Base16.encode tid)
+        <> "#"
+        <> Text.pack (show ix)
+
+errorResponse :: Text -> Value
+errorResponse msg = object ["error" .= msg]

--- a/test/Cardano/Node/Client/E2E/UTxOIndexerSpec.hs
+++ b/test/Cardano/Node/Client/E2E/UTxOIndexerSpec.hs
@@ -1,0 +1,389 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Cardano.Node.Client.E2E.UTxOIndexerSpec
+Description : End-to-end test for the UTxO indexer daemon
+License     : Apache-2.0
+
+Boots a real @cardano-node@ devnet, runs 'runDaemon' in
+the same process pointed at the node's Unix socket, then
+exercises the daemon's NDJSON wire surface from a separate
+client:
+
+* @ready@ — poll until the daemon reports caught-up.
+* Submit a self-transfer through 'Submitter' and use
+  @await@ to block until the resulting @TxIn@ appears
+  in a block — verifies the chain-sync → applyAtSlot →
+  fireWaiters path end-to-end.
+* @utxos_at@ — once the self-transfer has been observed,
+  query the genesis address: the change output of the
+  self-transfer must be visible. (Genesis funds live in
+  the ledger seed, not in any block, so a chain-sync
+  follower never sees them directly — exercising
+  utxos_at first requires producing a block-level UTxO
+  at the queried address.)
+
+The daemon is run in-process via 'runDaemon' (rather than
+as a separate binary) so the test exercises the same code
+paths the executable does without paying for a process
+spawn or for binary lookup.
+-}
+module Cardano.Node.Client.E2E.UTxOIndexerSpec (spec) where
+
+import Cardano.Crypto.Hash (hashToBytes)
+import Cardano.Ledger.Address (Addr, serialiseAddr)
+import Cardano.Ledger.Api.Tx (
+    mkBasicTx,
+    txIdTx,
+ )
+import Cardano.Ledger.Api.Tx.Body (
+    collateralInputsTxBodyL,
+    inputsTxBodyL,
+    mkBasicTxBody,
+ )
+import Cardano.Ledger.Api.Tx.Out (
+    TxOut,
+    coinTxOutL,
+    mkBasicTxOut,
+ )
+import Cardano.Ledger.BaseTypes (Inject (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core (PParams, extractHash)
+import Cardano.Ledger.TxIn (TxId (..), TxIn)
+import Cardano.Node.Client.Balance (balanceFeeLoop)
+import Cardano.Node.Client.E2E.Devnet (withCardanoNode)
+import Cardano.Node.Client.E2E.Setup (
+    addKeyWitness,
+    devnetMagic,
+    genesisAddr,
+    genesisDir,
+    genesisSignKey,
+ )
+import Cardano.Node.Client.Ledger (ConwayTx)
+import Cardano.Node.Client.N2C.Connection (
+    newLSQChannel,
+    newLTxSChannel,
+    runNodeClient,
+ )
+import Cardano.Node.Client.N2C.Provider (mkN2CProvider)
+import Cardano.Node.Client.N2C.Submitter (mkN2CSubmitter)
+import Cardano.Node.Client.N2C.Types (LSQChannel, LTxSChannel)
+import Cardano.Node.Client.Provider (Provider (..))
+import Cardano.Node.Client.Submitter (
+    SubmitResult (..),
+    Submitter (..),
+ )
+import Cardano.Node.Client.UTxOIndexer.Daemon (
+    DaemonConfig (..),
+    runDaemon,
+ )
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (
+    async,
+    cancel,
+    poll,
+    withAsync,
+ )
+import Control.Exception (bracket)
+import Data.Aeson qualified as Aeson
+import Data.Aeson.KeyMap qualified as KM
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
+import Data.Sequence.Strict qualified as StrictSeq
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text.Encoding qualified as Text
+import Lens.Micro ((&), (.~), (^.))
+import Network.Socket (
+    Family (AF_UNIX),
+    SockAddr (SockAddrUnix),
+    Socket,
+    SocketType (Stream),
+    close,
+    connect,
+    socket,
+ )
+import Network.Socket.ByteString qualified as Net
+import System.Directory (doesPathExist)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec (
+    Spec,
+    describe,
+    expectationFailure,
+    it,
+ )
+
+spec :: Spec
+spec =
+    describe "UTxO indexer daemon (E2E)" $
+        it
+            "syncs devnet, serves ready / utxos_at / await over NDJSON"
+            runE2E
+
+-- | Single E2E that spans the whole daemon contract.
+runE2E :: IO ()
+runE2E = do
+    gDir <- genesisDir
+    withCardanoNode gDir $ \nodeSock _startMs ->
+        withSystemTempDirectory "utxo-indexer-e2e" $ \tmp -> do
+            let daemonSock = tmp </> "indexer.sock"
+                cfg =
+                    DaemonConfig
+                        { dcRelaySocket = nodeSock
+                        , dcListenSocket = daemonSock
+                        , dcNetworkMagic = 42
+                        , dcByronEpochSlots = 42
+                        , dcReadyThresholdSlots = 60
+                        }
+            withAsync (runDaemon cfg) $ \daemonThread -> do
+                waitForFile daemonSock 600
+                poll daemonThread >>= \case
+                    Just (Left e) ->
+                        expectationFailure $
+                            "daemon crashed during startup: "
+                                <> show e
+                    _ -> pure ()
+
+                checkReady daemonSock 60
+                txid <- driveSelfTransferAndAwait nodeSock daemonSock
+                checkUtxosAtGenesisAfter daemonSock txid
+
+-- * Sub-checks
+
+-- | Poll @ready@ until @rsReady=true@ (or fail).
+checkReady :: FilePath -> Int -> IO ()
+checkReady _ 0 =
+    expectationFailure "daemon never became ready"
+checkReady sockPath n = do
+    resp <- ndjsonRequest sockPath "{\"ready\":null}"
+    case decodeReady resp of
+        Just (True, _, _, _) -> pure ()
+        _ -> threadDelay 1_000_000 >> checkReady sockPath (n - 1)
+
+{- | Submit a self-transfer through 'Submitter' and use
+@await@ to block until the resulting @TxIn@ shows up in
+a block. Returns the txid bytes so the caller can keep
+querying about the same tx.
+-}
+driveSelfTransferAndAwait ::
+    FilePath -> FilePath -> IO ByteString
+driveSelfTransferAndAwait nodeSock daemonSock =
+    withN2CChannels nodeSock $ \lsq ltxs -> do
+        let prov = mkN2CProvider lsq
+            subm = mkN2CSubmitter ltxs
+        pp <- queryProtocolParams prov
+        seeds <- queryUTxOs prov genesisAddr
+        case seeds of
+            [] -> do
+                expectationFailure "no genesis UTxOs"
+                error "unreachable"
+            (seed : _) -> do
+                let tx = signSelfTransfer pp genesisAddr seed
+                    TxId tidHash = txIdTx tx
+                    tidBytes = hashToBytes (extractHash tidHash)
+                    txInWire =
+                        Text.encodeUtf8 (hex tidBytes) <> "#0"
+                    req =
+                        "{\"await\":\""
+                            <> txInWire
+                            <> "\",\"timeout_seconds\":60}"
+                submitTx subm tx >>= \case
+                    Submitted _ -> pure ()
+                    Rejected r ->
+                        expectationFailure $
+                            "submitTx rejected: " <> show r
+                resp <- ndjsonRequest daemonSock req
+                case Aeson.decodeStrict' resp of
+                    Just (Aeson.Object o)
+                        | KM.lookup "timeout" o
+                            == Just (Aeson.Bool True) ->
+                            expectationFailure
+                                "await timed out before the \
+                                \submitted tx was observed"
+                        | KM.member "slot" o -> pure ()
+                    _ ->
+                        expectationFailure $
+                            "await response unexpected: "
+                                <> show resp
+                pure tidBytes
+
+{- | Once a self-transfer has been observed in a block,
+the indexer's view of @genesisAddr@ must contain its
+change output (the only UTxO at @genesisAddr@ produced
+inside a block — genesis-funded UTxOs live in the ledger
+seed and are invisible to chain-sync). The change output
+sits at index 0 of the just-submitted transaction.
+-}
+checkUtxosAtGenesisAfter :: FilePath -> ByteString -> IO ()
+checkUtxosAtGenesisAfter sockPath tidBytes = do
+    let addrHex = hex (serialiseAddr genesisAddr)
+        req =
+            "{\"utxos_at\":\""
+                <> Text.encodeUtf8 addrHex
+                <> "\"}"
+        expected =
+            hex tidBytes <> "#0"
+    resp <- ndjsonRequest sockPath req
+    case decodeUtxos resp of
+        Just xs
+            | any ((== expected) . fst) xs -> pure ()
+        other ->
+            expectationFailure $
+                "utxos_at(genesis) missing self-transfer change: "
+                    <> show other
+
+-- * Self-transfer construction
+
+{- | Balance and sign a single-output self-transfer back
+to @addr@. Inputs == outputs + fee (strict conservation):
+the change output absorbs everything left after the fee.
+The same UTxO acts as spend input and collateral so the
+transaction is self-contained.
+-}
+signSelfTransfer ::
+    PParams ConwayEra ->
+    Addr ->
+    (TxIn, TxOut ConwayEra) ->
+    ConwayTx
+signSelfTransfer pp addr (seedIn, seedOut) =
+    let Coin inputVal = seedOut ^. coinTxOutL
+        mkOutputs (Coin fee) =
+            let refund = inputVal - fee
+             in if refund < 0
+                    then Left "insufficient"
+                    else
+                        Right $
+                            StrictSeq.singleton $
+                                mkBasicTxOut
+                                    addr
+                                    (inject (Coin refund))
+        template =
+            mkBasicTx
+                ( mkBasicTxBody
+                    & inputsTxBodyL
+                        .~ Set.singleton seedIn
+                    & collateralInputsTxBodyL
+                        .~ Set.singleton seedIn
+                )
+     in case balanceFeeLoop pp mkOutputs 1 [] template of
+            Left err ->
+                error $ "signSelfTransfer: " <> show err
+            Right tx -> addKeyWitness genesisSignKey tx
+
+-- * N2C client bracket against an already-running node
+
+{- | Connect 'LSQChannel' + 'LTxSChannel' to a
+@cardano-node@ running on @sock@. Mirrors the inner
+half of 'Cardano.Node.Client.E2E.Setup.withDevnet' so
+this test can run alongside an already-spawned node.
+-}
+withN2CChannels ::
+    FilePath ->
+    (LSQChannel -> LTxSChannel -> IO a) ->
+    IO a
+withN2CChannels sock action =
+    bracket
+        ( do
+            lsq <- newLSQChannel 16
+            ltxs <- newLTxSChannel 16
+            t <- async (runNodeClient devnetMagic sock lsq ltxs)
+            threadDelay 3_000_000
+            poll t >>= \case
+                Just (Left e) ->
+                    error $ "N2C connect failed: " <> show e
+                Just (Right (Left e)) ->
+                    error $ "N2C connect error: " <> show e
+                Just (Right (Right ())) ->
+                    error "N2C closed unexpectedly"
+                Nothing -> pure (lsq, ltxs, t)
+        )
+        (\(_, _, t) -> cancel t)
+        (\(lsq, ltxs, _) -> action lsq ltxs)
+
+-- * NDJSON client helpers
+
+{- | One request, one response: open the daemon socket,
+send @payload <> "\n"@, slurp the response until EOF.
+-}
+ndjsonRequest :: FilePath -> ByteString -> IO ByteString
+ndjsonRequest sockPath payload =
+    bracket connectClient close $ \s -> do
+        Net.sendAll s (payload <> "\n")
+        recvAll s
+  where
+    connectClient :: IO Socket
+    connectClient = do
+        s <- socket AF_UNIX Stream 0
+        connect s (SockAddrUnix sockPath)
+        pure s
+    recvAll s = go BS.empty
+      where
+        go acc = do
+            chunk <- Net.recv s 4096
+            if BS.null chunk
+                then pure acc
+                else go (acc <> chunk)
+
+{- | Wait up to @n@ deciseconds (100ms units) for a
+filesystem path to appear. The daemon's listen socket
+is bound asynchronously after 'runDaemon' starts.
+-}
+waitForFile :: FilePath -> Int -> IO ()
+waitForFile path = go
+  where
+    go 0 =
+        error $
+            "waitForFile: nothing appeared at " <> path
+    go n = do
+        ok <- doesPathExist path
+        if ok
+            then pure ()
+            else threadDelay 100_000 >> go (n - 1)
+
+-- * Decoders
+
+{- | @ready@ envelope: @(ready, tipSlot, processedSlot,
+slotsBehind)@. The numeric fields are 'Maybe' because
+the daemon emits @null@ when it has not yet seen a tip.
+-}
+decodeReady ::
+    ByteString ->
+    Maybe (Bool, Maybe Integer, Maybe Integer, Maybe Integer)
+decodeReady bs = do
+    Aeson.Object o <- Aeson.decodeStrict' bs
+    rd <- KM.lookup "ready" o >>= asBool
+    let tip = KM.lookup "tipSlot" o >>= asInt
+        proc' = KM.lookup "processedSlot" o >>= asInt
+        beh = KM.lookup "slotsBehind" o >>= asInt
+    pure (rd, tip, proc', beh)
+  where
+    asBool (Aeson.Bool b) = Just b
+    asBool _ = Nothing
+    asInt :: Aeson.Value -> Maybe Integer
+    asInt (Aeson.Number n) = Just (round n)
+    asInt _ = Nothing
+
+{- | Decode @{"utxos":[...]}@ into a list of
+@(txin-text, txout-hex-text)@ pairs.
+-}
+decodeUtxos :: ByteString -> Maybe [(Text, Text)]
+decodeUtxos bs = do
+    Aeson.Object o <- Aeson.decodeStrict' bs
+    Aeson.Array arr <- KM.lookup "utxos" o
+    traverse decodeEntry (foldr (:) [] arr)
+  where
+    decodeEntry (Aeson.Object o) = do
+        Aeson.String txin <- KM.lookup "txin" o
+        Aeson.String txout <- KM.lookup "txout" o
+        pure (txin, txout)
+    decodeEntry _ = Nothing
+
+-- * Misc
+
+hex :: ByteString -> Text
+hex = Text.decodeUtf8 . Base16.encode

--- a/test/Cardano/Node/Client/UTxOIndexer/IndexerSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/IndexerSpec.hs
@@ -19,6 +19,7 @@ import Cardano.Node.Client.UTxOIndexer.Indexer (
  )
 import Cardano.Node.Client.UTxOIndexer.Types (
     Address (..),
+    BlockHash (..),
     SlotNo (..),
     TxIn (..),
     TxOut (..),
@@ -39,7 +40,7 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
                 let addr = mkAddr 0xAA 29
                     txin = TxIn (BS.replicate 32 0x11) 0
                     txout = TxOut "value-bytes-0"
-                applyAtSlot h (SlotNo 1) [UtxoCreate txin addr txout]
+                applyAtSlot h (SlotNo 1) testBlockHash [UtxoCreate txin addr txout]
                 xs <- snapshotAt h addr
                 xs `shouldBe` [(txin, txout)]
 
@@ -54,6 +55,7 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
                 applyAtSlot
                     h
                     (SlotNo 1)
+                    testBlockHash
                     [ mkRow 0x33 5 "c"
                     , mkRow 0x11 0 "a"
                     , mkRow 0x22 0 "b"
@@ -73,6 +75,7 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
                 applyAtSlot
                     h
                     (SlotNo 1)
+                    testBlockHash
                     [ UtxoCreate txin a1 (TxOut "for-a1")
                     , UtxoCreate txin a2 (TxOut "for-a2")
                     ]
@@ -89,6 +92,7 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
                 applyAtSlot
                     h
                     (SlotNo 1)
+                    testBlockHash
                     [ UtxoCreate txin a29 (TxOut "29")
                     , UtxoCreate txin a60 (TxOut "60")
                     ]
@@ -105,10 +109,11 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
                 applyAtSlot
                     h
                     (SlotNo 1)
+                    testBlockHash
                     [ UtxoCreate txin1 addr (TxOut "v1")
                     , UtxoCreate txin2 addr (TxOut "v2")
                     ]
-                applyAtSlot h (SlotNo 2) [UtxoSpend txin1]
+                applyAtSlot h (SlotNo 2) testBlockHash [UtxoSpend txin1]
                 xs <- snapshotAt h addr
                 xs `shouldBe` [(txin2, TxOut "v2")]
 
@@ -120,8 +125,9 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
                 applyAtSlot
                     h
                     (SlotNo 1)
+                    testBlockHash
                     [UtxoCreate txin1 addr (TxOut "v")]
-                applyAtSlot h (SlotNo 2) [UtxoSpend txin2]
+                applyAtSlot h (SlotNo 2) testBlockHash [UtxoSpend txin2]
                 xs <- snapshotAt h addr
                 xs `shouldBe` [(txin1, TxOut "v")]
 
@@ -139,6 +145,7 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
                 applyAtSlot
                     h
                     (SlotNo 5)
+                    testBlockHash
                     [UtxoCreate txin addr (TxOut "v")]
                 rollbackTo h (SlotNo 4)
                 xs <- snapshotAt h addr
@@ -152,10 +159,10 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
                             (TxIn (BS.replicate 32 tid) 0)
                             addr
                             (TxOut (BS.singleton tid))
-                applyAtSlot h (SlotNo 1) [mk 0x01]
-                applyAtSlot h (SlotNo 2) [mk 0x02]
-                applyAtSlot h (SlotNo 3) [mk 0x03]
-                applyAtSlot h (SlotNo 4) [mk 0x04]
+                applyAtSlot h (SlotNo 1) testBlockHash [mk 0x01]
+                applyAtSlot h (SlotNo 2) testBlockHash [mk 0x02]
+                applyAtSlot h (SlotNo 3) testBlockHash [mk 0x03]
+                applyAtSlot h (SlotNo 4) testBlockHash [mk 0x04]
                 rollbackTo h (SlotNo 2)
                 xs <- snapshotAt h addr
                 fmap (txInId . fst) xs
@@ -170,8 +177,9 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
                 applyAtSlot
                     h
                     (SlotNo 1)
+                    testBlockHash
                     [UtxoCreate txin addr (TxOut "v")]
-                applyAtSlot h (SlotNo 2) [UtxoSpend txin]
+                applyAtSlot h (SlotNo 2) testBlockHash [UtxoSpend txin]
                 rollbackTo h (SlotNo 1)
                 xs <- snapshotAt h addr
                 xs `shouldBe` [(txin, TxOut "v")]
@@ -183,6 +191,7 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
                 applyAtSlot
                     h
                     (SlotNo 5)
+                    testBlockHash
                     [UtxoCreate txin addr (TxOut "v")]
                 rollbackTo h (SlotNo 3)
                 rollbackTo h (SlotNo 3)
@@ -196,3 +205,9 @@ pulling ledger types into the indexer's test deps.
 -}
 mkAddr :: Int -> Int -> Address
 mkAddr body len = Address (BS.replicate len (fromIntegral body))
+
+{- | A constant 32-byte block hash for tests where the
+block hash isn't load-bearing.
+-}
+testBlockHash :: BlockHash
+testBlockHash = BlockHash (BS.replicate 32 0)

--- a/test/Cardano/Node/Client/UTxOIndexer/IndexerSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/IndexerSpec.hs
@@ -1,15 +1,14 @@
 {- |
 Module      : Cardano.Node.Client.UTxOIndexer.IndexerSpec
-Description : Apply / snapshot round-trip against the in-memory backend
+Description : Apply / snapshot / rollback round-trip
 License     : Apache-2.0
 
-Exercises the indexer's apply / snapshot path end-to-end
-through the @kv-transactions@ in-memory backend: open an
-indexer, apply 'UtxoCreate' / 'UtxoSpend' ops, and verify
-@snapshotAt@ returns exactly the surviving UTxOs at each
-queried address — sorted, with the right values, and
-bounded to that address (no bleed across the prefix-scan
-boundary).
+Exercises the indexer's apply / snapshot / rollback path
+end-to-end through the @kv-transactions@ in-memory
+backend: open an indexer, apply 'UtxoCreate' /
+'UtxoSpend' ops at multiple slots, roll back to a target
+slot, and verify @snapshotAt@ reflects the state at the
+target slot.
 -}
 module Cardano.Node.Client.UTxOIndexer.IndexerSpec (spec) where
 
@@ -20,6 +19,7 @@ import Cardano.Node.Client.UTxOIndexer.Indexer (
  )
 import Cardano.Node.Client.UTxOIndexer.Types (
     Address (..),
+    SlotNo (..),
     TxIn (..),
     TxOut (..),
  )
@@ -28,7 +28,7 @@ import Test.Hspec (Spec, describe, it, shouldBe)
 
 spec :: Spec
 spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
-    describe "applyOps + snapshotAt" $ do
+    describe "applyAtSlot + snapshotAt" $ do
         it "snapshots an empty address as an empty list" $
             withInMemoryIndexer $ \h -> do
                 xs <- snapshotAt h (mkAddr 0xAA 29)
@@ -39,7 +39,7 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
                 let addr = mkAddr 0xAA 29
                     txin = TxIn (BS.replicate 32 0x11) 0
                     txout = TxOut "value-bytes-0"
-                applyOps h [UtxoCreate txin addr txout]
+                applyAtSlot h (SlotNo 1) [UtxoCreate txin addr txout]
                 xs <- snapshotAt h addr
                 xs `shouldBe` [(txin, txout)]
 
@@ -51,8 +51,9 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
                             (TxIn (BS.replicate 32 tid) ix)
                             addr
                             (TxOut payload)
-                applyOps
+                applyAtSlot
                     h
+                    (SlotNo 1)
                     [ mkRow 0x33 5 "c"
                     , mkRow 0x11 0 "a"
                     , mkRow 0x22 0 "b"
@@ -69,8 +70,9 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
                 let a1 = mkAddr 0xAA 29
                     a2 = mkAddr 0xBB 29
                     txin = TxIn (BS.replicate 32 0x10) 0
-                applyOps
+                applyAtSlot
                     h
+                    (SlotNo 1)
                     [ UtxoCreate txin a1 (TxOut "for-a1")
                     , UtxoCreate txin a2 (TxOut "for-a2")
                     ]
@@ -80,15 +82,13 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
                 xs2 `shouldBe` [(txin, TxOut "for-a2")]
 
         it "scopes scans across mixed address lengths" $
-            -- Length-prefixed AddressIndex key means a
-            -- 29-byte and a 60-byte address with the same
-            -- body bytes still live in disjoint buckets.
             withInMemoryIndexer $ \h -> do
                 let a29 = mkAddr 0xCC 29
                     a60 = mkAddr 0xCC 60
                     txin = TxIn (BS.replicate 32 0x44) 0
-                applyOps
+                applyAtSlot
                     h
+                    (SlotNo 1)
                     [ UtxoCreate txin a29 (TxOut "29")
                     , UtxoCreate txin a60 (TxOut "60")
                     ]
@@ -98,19 +98,17 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
                 xs60 `shouldBe` [(txin, TxOut "60")]
 
         it "spends the right entry and leaves siblings alone" $
-            -- UtxoSpend takes only a TxIn; the indexer
-            -- resolves its address via TxInCol before
-            -- deleting from AddressIndex.
             withInMemoryIndexer $ \h -> do
                 let addr = mkAddr 0xAA 29
                     txin1 = TxIn (BS.replicate 32 0x11) 0
                     txin2 = TxIn (BS.replicate 32 0x22) 0
-                applyOps
+                applyAtSlot
                     h
+                    (SlotNo 1)
                     [ UtxoCreate txin1 addr (TxOut "v1")
                     , UtxoCreate txin2 addr (TxOut "v2")
                     ]
-                applyOps h [UtxoSpend txin1]
+                applyAtSlot h (SlotNo 2) [UtxoSpend txin1]
                 xs <- snapshotAt h addr
                 xs `shouldBe` [(txin2, TxOut "v2")]
 
@@ -119,10 +117,77 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
                 let addr = mkAddr 0xAA 29
                     txin1 = TxIn (BS.replicate 32 0x11) 0
                     txin2 = TxIn (BS.replicate 32 0x99) 0
-                applyOps h [UtxoCreate txin1 addr (TxOut "v")]
-                applyOps h [UtxoSpend txin2] -- not in index
+                applyAtSlot
+                    h
+                    (SlotNo 1)
+                    [UtxoCreate txin1 addr (TxOut "v")]
+                applyAtSlot h (SlotNo 2) [UtxoSpend txin2]
                 xs <- snapshotAt h addr
                 xs `shouldBe` [(txin1, TxOut "v")]
+
+    describe "rollbackTo" $ do
+        it "is a no-op when no slots exist above target" $
+            withInMemoryIndexer $ \h -> do
+                rollbackTo h (SlotNo 100)
+                xs <- snapshotAt h (mkAddr 0xAA 29)
+                xs `shouldBe` []
+
+        it "undoes a single-slot create" $
+            withInMemoryIndexer $ \h -> do
+                let addr = mkAddr 0xAA 29
+                    txin = TxIn (BS.replicate 32 0x11) 0
+                applyAtSlot
+                    h
+                    (SlotNo 5)
+                    [UtxoCreate txin addr (TxOut "v")]
+                rollbackTo h (SlotNo 4)
+                xs <- snapshotAt h addr
+                xs `shouldBe` []
+
+        it "preserves slots at-or-below the target" $
+            withInMemoryIndexer $ \h -> do
+                let addr = mkAddr 0xAA 29
+                    mk tid =
+                        UtxoCreate
+                            (TxIn (BS.replicate 32 tid) 0)
+                            addr
+                            (TxOut (BS.singleton tid))
+                applyAtSlot h (SlotNo 1) [mk 0x01]
+                applyAtSlot h (SlotNo 2) [mk 0x02]
+                applyAtSlot h (SlotNo 3) [mk 0x03]
+                applyAtSlot h (SlotNo 4) [mk 0x04]
+                rollbackTo h (SlotNo 2)
+                xs <- snapshotAt h addr
+                fmap (txInId . fst) xs
+                    `shouldBe` [ BS.replicate 32 0x01
+                               , BS.replicate 32 0x02
+                               ]
+
+        it "restores a spent UTxO" $
+            withInMemoryIndexer $ \h -> do
+                let addr = mkAddr 0xAA 29
+                    txin = TxIn (BS.replicate 32 0x11) 0
+                applyAtSlot
+                    h
+                    (SlotNo 1)
+                    [UtxoCreate txin addr (TxOut "v")]
+                applyAtSlot h (SlotNo 2) [UtxoSpend txin]
+                rollbackTo h (SlotNo 1)
+                xs <- snapshotAt h addr
+                xs `shouldBe` [(txin, TxOut "v")]
+
+        it "is idempotent at the same target" $
+            withInMemoryIndexer $ \h -> do
+                let addr = mkAddr 0xAA 29
+                    txin = TxIn (BS.replicate 32 0x11) 0
+                applyAtSlot
+                    h
+                    (SlotNo 5)
+                    [UtxoCreate txin addr (TxOut "v")]
+                rollbackTo h (SlotNo 3)
+                rollbackTo h (SlotNo 3)
+                xs <- snapshotAt h addr
+                xs `shouldBe` []
 
 {- | Build a synthetic 'Address' of the given length with
 a fixed body byte. Lets tests construct Shelley-shaped

--- a/test/Cardano/Node/Client/UTxOIndexer/IndexerSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/IndexerSpec.hs
@@ -1,0 +1,133 @@
+{- |
+Module      : Cardano.Node.Client.UTxOIndexer.IndexerSpec
+Description : Apply / snapshot round-trip against the in-memory backend
+License     : Apache-2.0
+
+Exercises the indexer's apply / snapshot path end-to-end
+through the @kv-transactions@ in-memory backend: open an
+indexer, apply 'UtxoCreate' / 'UtxoSpend' ops, and verify
+@snapshotAt@ returns exactly the surviving UTxOs at each
+queried address — sorted, with the right values, and
+bounded to that address (no bleed across the prefix-scan
+boundary).
+-}
+module Cardano.Node.Client.UTxOIndexer.IndexerSpec (spec) where
+
+import Cardano.Node.Client.UTxOIndexer.Indexer (
+    IndexerHandle (..),
+    UtxoOp (..),
+    withInMemoryIndexer,
+ )
+import Cardano.Node.Client.UTxOIndexer.Types (
+    Address (..),
+    TxIn (..),
+    TxOut (..),
+ )
+import Data.ByteString qualified as BS
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
+    describe "applyOps + snapshotAt" $ do
+        it "snapshots an empty address as an empty list" $
+            withInMemoryIndexer $ \h -> do
+                xs <- snapshotAt h (mkAddr 0xAA 29)
+                xs `shouldBe` []
+
+        it "round-trips a single create at one address" $
+            withInMemoryIndexer $ \h -> do
+                let addr = mkAddr 0xAA 29
+                    txin = TxIn (BS.replicate 32 0x11) 0
+                    txout = TxOut "value-bytes-0"
+                applyOps h [UtxoCreate txin addr txout]
+                xs <- snapshotAt h addr
+                xs `shouldBe` [(txin, txout)]
+
+        it "returns entries in ascending TxIn order" $
+            withInMemoryIndexer $ \h -> do
+                let addr = mkAddr 0xAA 29
+                    mkRow tid ix payload =
+                        UtxoCreate
+                            (TxIn (BS.replicate 32 tid) ix)
+                            addr
+                            (TxOut payload)
+                applyOps
+                    h
+                    [ mkRow 0x33 5 "c"
+                    , mkRow 0x11 0 "a"
+                    , mkRow 0x22 0 "b"
+                    ]
+                xs <- snapshotAt h addr
+                fmap (txInId . fst) xs
+                    `shouldBe` [ BS.replicate 32 0x11
+                               , BS.replicate 32 0x22
+                               , BS.replicate 32 0x33
+                               ]
+
+        it "scopes scans to the queried address only" $
+            withInMemoryIndexer $ \h -> do
+                let a1 = mkAddr 0xAA 29
+                    a2 = mkAddr 0xBB 29
+                    txin = TxIn (BS.replicate 32 0x10) 0
+                applyOps
+                    h
+                    [ UtxoCreate txin a1 (TxOut "for-a1")
+                    , UtxoCreate txin a2 (TxOut "for-a2")
+                    ]
+                xs1 <- snapshotAt h a1
+                xs2 <- snapshotAt h a2
+                xs1 `shouldBe` [(txin, TxOut "for-a1")]
+                xs2 `shouldBe` [(txin, TxOut "for-a2")]
+
+        it "scopes scans across mixed address lengths" $
+            -- Length-prefixed AddressIndex key means a
+            -- 29-byte and a 60-byte address with the same
+            -- body bytes still live in disjoint buckets.
+            withInMemoryIndexer $ \h -> do
+                let a29 = mkAddr 0xCC 29
+                    a60 = mkAddr 0xCC 60
+                    txin = TxIn (BS.replicate 32 0x44) 0
+                applyOps
+                    h
+                    [ UtxoCreate txin a29 (TxOut "29")
+                    , UtxoCreate txin a60 (TxOut "60")
+                    ]
+                xs29 <- snapshotAt h a29
+                xs60 <- snapshotAt h a60
+                xs29 `shouldBe` [(txin, TxOut "29")]
+                xs60 `shouldBe` [(txin, TxOut "60")]
+
+        it "spends the right entry and leaves siblings alone" $
+            -- UtxoSpend takes only a TxIn; the indexer
+            -- resolves its address via TxInCol before
+            -- deleting from AddressIndex.
+            withInMemoryIndexer $ \h -> do
+                let addr = mkAddr 0xAA 29
+                    txin1 = TxIn (BS.replicate 32 0x11) 0
+                    txin2 = TxIn (BS.replicate 32 0x22) 0
+                applyOps
+                    h
+                    [ UtxoCreate txin1 addr (TxOut "v1")
+                    , UtxoCreate txin2 addr (TxOut "v2")
+                    ]
+                applyOps h [UtxoSpend txin1]
+                xs <- snapshotAt h addr
+                xs `shouldBe` [(txin2, TxOut "v2")]
+
+        it "spending an unknown TxIn is a no-op" $
+            withInMemoryIndexer $ \h -> do
+                let addr = mkAddr 0xAA 29
+                    txin1 = TxIn (BS.replicate 32 0x11) 0
+                    txin2 = TxIn (BS.replicate 32 0x99) 0
+                applyOps h [UtxoCreate txin1 addr (TxOut "v")]
+                applyOps h [UtxoSpend txin2] -- not in index
+                xs <- snapshotAt h addr
+                xs `shouldBe` [(txin1, TxOut "v")]
+
+{- | Build a synthetic 'Address' of the given length with
+a fixed body byte. Lets tests construct Shelley-shaped
+(29-byte) and Byron-shaped (60-byte) addresses without
+pulling ledger types into the indexer's test deps.
+-}
+mkAddr :: Int -> Int -> Address
+mkAddr body len = Address (BS.replicate len (fromIntegral body))

--- a/test/Cardano/Node/Client/UTxOIndexer/ServerSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/ServerSpec.hs
@@ -1,0 +1,223 @@
+{-# LANGUAGE LambdaCase #-}
+
+{- |
+Module      : Cardano.Node.Client.UTxOIndexer.ServerSpec
+Description : NDJSON Unix-socket server round-trip
+License     : Apache-2.0
+
+Spins up the server on a temp-dir Unix socket, connects
+as a client, and exercises both request kinds:
+
+* @{"utxos_at": "<hex>"}@ → JSON list of UTxO entries.
+* @{"ready": null}@ → readiness JSON.
+-}
+module Cardano.Node.Client.UTxOIndexer.ServerSpec (spec) where
+
+import Cardano.Node.Client.UTxOIndexer.Indexer (
+    IndexerHandle (..),
+    UtxoOp (..),
+    withInMemoryIndexer,
+ )
+import Cardano.Node.Client.UTxOIndexer.Server (
+    ReadyStatus (..),
+    runServer,
+ )
+import Cardano.Node.Client.UTxOIndexer.Types (
+    Address (..),
+    SlotNo (..),
+    TxIn (..),
+    TxOut (..),
+ )
+import Control.Concurrent (forkIO, killThread, threadDelay)
+import Control.Exception (bracket, try)
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KM
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Network.Socket (
+    Family (AF_UNIX),
+    SockAddr (SockAddrUnix),
+    Socket,
+    SocketType (Stream),
+    close,
+    connect,
+    socket,
+ )
+import Network.Socket.ByteString qualified as Net
+import System.Directory (createDirectoryIfMissing, doesPathExist, removeFile)
+import System.IO.Error (isDoesNotExistError)
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+
+spec :: Spec
+spec = describe "Cardano.Node.Client.UTxOIndexer.Server" $ do
+    it "ready endpoint returns the ReadyStatus we feed it" $
+        withTestServer ready1 $ \sockPath -> do
+            resp <- request sockPath "{\"ready\":null}\n"
+            decodeReady resp `shouldBe` Just (True, Just 1234, Just 1230, Just 4)
+
+    it "utxos_at returns an empty list when no UTxOs exist" $
+        withTestServer ready1 $ \sockPath -> do
+            let addrHex = Text.unpack (hex (BS.replicate 29 0xAA))
+                req =
+                    "{\"utxos_at\":\""
+                        <> addrHex
+                        <> "\"}\n"
+            resp <- request sockPath (BS.pack (map (fromIntegral . fromEnum) req))
+            decodeUtxos resp `shouldBe` Just []
+
+    it "utxos_at returns previously-applied UTxOs at the address" $
+        withInMemoryIndexer $ \idx -> do
+            let addr = Address (BS.replicate 29 0xAA)
+                txin = TxIn (BS.replicate 32 0x11) 0
+                txout = TxOut "value-bytes-0"
+            applyAtSlot idx (SlotNo 1) [UtxoCreate txin addr txout]
+            withSystemTempDirectory "indexer-server" $ \dir -> do
+                let sockPath = dir <> "/sock"
+                tid <-
+                    forkIO
+                        (runServer sockPath idx (pure ready1))
+                waitForFile sockPath
+                let addrHex = Text.unpack (hex (BS.replicate 29 0xAA))
+                    req =
+                        "{\"utxos_at\":\""
+                            <> addrHex
+                            <> "\"}\n"
+                resp <-
+                    request
+                        sockPath
+                        (BS.pack (map (fromIntegral . fromEnum) req))
+                killThread tid
+                _ <- removeIfPresent sockPath
+                decodeUtxos resp
+                    `shouldSatisfy` ( \case
+                                        Just [(t, _)] | t == "1111111111111111111111111111111111111111111111111111111111111111#0" -> True
+                                        _ -> False
+                                    )
+
+    it "responds with a JSON error for malformed input" $
+        withTestServer ready1 $ \sockPath -> do
+            resp <- request sockPath "not json at all\n"
+            Aeson.decodeStrict' resp
+                `shouldSatisfy` ( \case
+                                    Just (Aeson.Object o) ->
+                                        KM.member (Key.fromText "error") o
+                                    _ -> False
+                                )
+
+-- Test helpers --------------------------------------------------------
+
+ready1 :: ReadyStatus
+ready1 =
+    ReadyStatus
+        { rsReady = True
+        , rsTipSlot = Just (SlotNo 1234)
+        , rsProcessedSlot = Just (SlotNo 1230)
+        , rsSlotsBehind = Just 4
+        }
+
+{- | Spin up an in-memory indexer + server on a tempdir
+Unix socket, run the action, then kill the server.
+-}
+withTestServer ::
+    ReadyStatus ->
+    (FilePath -> IO a) ->
+    IO a
+withTestServer rs action =
+    withInMemoryIndexer $ \idx ->
+        withSystemTempDirectory "indexer-server" $ \dir -> do
+            let sockPath = dir <> "/sock"
+            createDirectoryIfMissing True dir
+            bracket
+                (forkIO (runServer sockPath idx (pure rs)))
+                ( \tid -> do
+                    killThread tid
+                    _ <- removeIfPresent sockPath
+                    pure ()
+                )
+                ( \_ -> do
+                    waitForFile sockPath
+                    action sockPath
+                )
+
+-- | Poll up to 2 s for the server to bind its socket.
+waitForFile :: FilePath -> IO ()
+waitForFile path = go (200 :: Int)
+  where
+    go 0 = error ("waitForFile: socket never appeared at " <> path)
+    go n = do
+        present <- doesPathExist path
+        if present
+            then pure ()
+            else threadDelay 10_000 >> go (n - 1)
+
+removeIfPresent :: FilePath -> IO ()
+removeIfPresent p = do
+    r <- try (removeFile p) :: IO (Either IOError ())
+    case r of
+        Right () -> pure ()
+        Left e
+            | isDoesNotExistError e -> pure ()
+            | otherwise -> ioError e
+
+{- | Open a connection to @sockPath@, send @payload@,
+read the response line, close.
+-}
+request :: FilePath -> BS.ByteString -> IO BS.ByteString
+request sockPath payload =
+    bracket connectClient close $ \s -> do
+        Net.sendAll s payload
+        recvAll s
+  where
+    connectClient :: IO Socket
+    connectClient = do
+        s <- socket AF_UNIX Stream 0
+        connect s (SockAddrUnix sockPath)
+        pure s
+    recvAll s = go BS.empty
+      where
+        go acc = do
+            chunk <- Net.recv s 4096
+            if BS.null chunk
+                then pure acc
+                else go (acc <> chunk)
+
+hex :: BS.ByteString -> Text.Text
+hex = Text.decodeUtf8 . Base16.encode
+
+decodeReady ::
+    BS.ByteString ->
+    Maybe (Bool, Maybe Integer, Maybe Integer, Maybe Integer)
+decodeReady bs = do
+    Aeson.Object o <- Aeson.decodeStrict' bs
+    rd <- KM.lookup (Key.fromText "ready") o >>= asBool
+    let tip = KM.lookup (Key.fromText "tipSlot") o >>= asInt
+        proc' = KM.lookup (Key.fromText "processedSlot") o >>= asInt
+        beh = KM.lookup (Key.fromText "slotsBehind") o >>= asInt
+    pure (rd, tip, proc', beh)
+  where
+    asBool (Aeson.Bool b) = Just b
+    asBool _ = Nothing
+    asInt :: Aeson.Value -> Maybe Integer
+    asInt (Aeson.Number n) = Just (round n)
+    asInt _ = Nothing
+
+{- | Decode a @{"utxos": [...]}@ response into
+a list of @(txin-text, txout-hex-text)@ pairs.
+-}
+decodeUtxos ::
+    BS.ByteString ->
+    Maybe [(Text.Text, Text.Text)]
+decodeUtxos bs = do
+    Aeson.Object o <- Aeson.decodeStrict' bs
+    Aeson.Array arr <- KM.lookup (Key.fromText "utxos") o
+    traverse decodeEntry (foldr (:) [] arr)
+  where
+    decodeEntry (Aeson.Object o) = do
+        Aeson.String txin <- KM.lookup (Key.fromText "txin") o
+        Aeson.String txout <- KM.lookup (Key.fromText "txout") o
+        pure (txin, txout)
+    decodeEntry _ = Nothing

--- a/test/Cardano/Node/Client/UTxOIndexer/ServerSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/ServerSpec.hs
@@ -24,11 +24,13 @@ import Cardano.Node.Client.UTxOIndexer.Server (
  )
 import Cardano.Node.Client.UTxOIndexer.Types (
     Address (..),
+    BlockHash (..),
     SlotNo (..),
     TxIn (..),
     TxOut (..),
  )
 import Control.Concurrent (forkIO, killThread, threadDelay)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Exception (bracket, try)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Key
@@ -74,7 +76,7 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Server" $ do
             let addr = Address (BS.replicate 29 0xAA)
                 txin = TxIn (BS.replicate 32 0x11) 0
                 txout = TxOut "value-bytes-0"
-            applyAtSlot idx (SlotNo 1) [UtxoCreate txin addr txout]
+            applyAtSlot idx (SlotNo 1) testBlockHash [UtxoCreate txin addr txout]
             withSystemTempDirectory "indexer-server" $ \dir -> do
                 let sockPath = dir <> "/sock"
                 tid <-
@@ -105,6 +107,66 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Server" $ do
                 `shouldSatisfy` ( \case
                                     Just (Aeson.Object o) ->
                                         KM.member (Key.fromText "error") o
+                                    _ -> False
+                                )
+
+    it "await fires when the awaited TxIn is later created" $
+        withInMemoryIndexer $ \idx -> do
+            let addr = Address (BS.replicate 29 0xAA)
+                txin = TxIn (BS.replicate 32 0x77) 0
+                txout = TxOut "value-await"
+            withSystemTempDirectory "indexer-server" $ \dir -> do
+                let sockPath = dir <> "/sock"
+                tid <-
+                    forkIO
+                        (runServer sockPath idx (pure ready1))
+                waitForFile sockPath
+                -- Kick off the await client in a background
+                -- thread; meanwhile, apply the create.
+                respMVar <- newEmptyMVar
+                _ <-
+                    forkIO $ do
+                        let req =
+                                "{\"await\":\""
+                                    <> hexStr (BS.replicate 32 0x77)
+                                    <> "#0\"}\n"
+                        r <-
+                            request
+                                sockPath
+                                ( BS.pack
+                                    (map (fromIntegral . fromEnum) req)
+                                )
+                        putMVar respMVar r
+                threadDelay 50_000
+                applyAtSlot
+                    idx
+                    (SlotNo 7)
+                    (BlockHash (BS.replicate 32 0xBB))
+                    [UtxoCreate txin addr txout]
+                resp <- takeMVar respMVar
+                killThread tid
+                _ <- removeIfPresent sockPath
+                case Aeson.decodeStrict' resp of
+                    Just (Aeson.Object o) -> do
+                        KM.lookup (Key.fromText "slot") o
+                            `shouldBe` Just (Aeson.Number 7)
+                    _ -> fail ("unexpected: " <> show resp)
+
+    it "await with a 1-second timeout returns timeout when nothing arrives" $
+        withTestServer ready1 $ \sockPath -> do
+            let req =
+                    "{\"await\":\""
+                        <> hexStr (BS.replicate 32 0x99)
+                        <> "#0\",\"timeout_seconds\":1}\n"
+            resp <-
+                request
+                    sockPath
+                    (BS.pack (map (fromIntegral . fromEnum) req))
+            Aeson.decodeStrict' resp
+                `shouldSatisfy` ( \case
+                                    Just (Aeson.Object o) ->
+                                        KM.lookup (Key.fromText "timeout") o
+                                            == Just (Aeson.Bool True)
                                     _ -> False
                                 )
 
@@ -187,6 +249,12 @@ request sockPath payload =
 
 hex :: BS.ByteString -> Text.Text
 hex = Text.decodeUtf8 . Base16.encode
+
+hexStr :: BS.ByteString -> String
+hexStr = Text.unpack . hex
+
+testBlockHash :: BlockHash
+testBlockHash = BlockHash (BS.replicate 32 0)
 
 decodeReady ::
     BS.ByteString ->

--- a/test/Cardano/Node/Client/UTxOIndexer/TypesSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/TypesSpec.hs
@@ -13,10 +13,13 @@ module Cardano.Node.Client.UTxOIndexer.TypesSpec (spec) where
 import Cardano.Node.Client.UTxOIndexer.Types (
     AddrKey (..),
     Address (..),
+    SlotNo (..),
     TxIn (..),
     addrKeyFromBytes,
     addrKeyToBytes,
     addressPrefix,
+    slotFromBytes,
+    slotToBytes,
     txInFromBytes,
     txInToBytes,
  )
@@ -79,6 +82,32 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Types" $ do
             property $
                 \(SmallishAddrKey k) ->
                     (addrKeyFromBytes =<< addrKeyToBytes k) === Just k
+
+    describe "SlotNo codec" $ do
+        it "round-trips concrete slot values" $ do
+            let go w =
+                    (slotFromBytes . slotToBytes) (SlotNo w)
+                        `shouldBe` Just (SlotNo w)
+            mapM_
+                go
+                [0, 1, 42, 0xFF, 0xFFFF, 0xFFFFFFFF, maxBound]
+
+        it "encodes to exactly 8 bytes" $ do
+            BS.length (slotToBytes (SlotNo 0)) `shouldBe` 8
+            BS.length (slotToBytes (SlotNo maxBound)) `shouldBe` 8
+
+        it "decodes nothing for non-8-byte input" $ do
+            slotFromBytes BS.empty `shouldBe` Nothing
+            slotFromBytes (BS.replicate 7 0) `shouldBe` Nothing
+            slotFromBytes (BS.replicate 9 0) `shouldBe` Nothing
+
+        it "produces big-endian bytes (lex order = numeric)" $ do
+            slotToBytes (SlotNo 1)
+                < slotToBytes (SlotNo 2)
+                `shouldBe` True
+            slotToBytes (SlotNo 0xFF)
+                < slotToBytes (SlotNo 0x100)
+                `shouldBe` True
 
     describe "addressPrefix" $ do
         it "is the strict byte prefix of any AddrKey at that address" $ do

--- a/test/Cardano/Node/Client/UTxOIndexer/TypesSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/TypesSpec.hs
@@ -1,0 +1,141 @@
+{- |
+Module      : Cardano.Node.Client.UTxOIndexer.TypesSpec
+Description : Round-trip tests for the indexer's composite-key codec
+License     : Apache-2.0
+
+Locks the on-disk byte form of 'AddrKey' so a future
+backend swap (in-memory → RocksDB) cannot silently
+break already-indexed data, and exercises the address
+length-prefix invariant.
+-}
+module Cardano.Node.Client.UTxOIndexer.TypesSpec (spec) where
+
+import Cardano.Node.Client.UTxOIndexer.Types (
+    AddrKey (..),
+    Address (..),
+    TxIn (..),
+    addrKeyFromBytes,
+    addrKeyToBytes,
+    addressPrefix,
+    txInFromBytes,
+    txInToBytes,
+ )
+import Data.ByteString qualified as BS
+import Data.Word (Word16, Word8)
+import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.QuickCheck (
+    Arbitrary (..),
+    Gen,
+    choose,
+    property,
+    vectorOf,
+    (===),
+ )
+
+spec :: Spec
+spec = describe "Cardano.Node.Client.UTxOIndexer.Types" $ do
+    describe "AddrKey codec" $ do
+        it "round-trips for a Shelley-shaped key (29-byte address)" $ do
+            let addr = Address (BS.replicate 29 0x42)
+                tid = BS.replicate 32 0xAA
+                ix = 7 :: Word16
+                key = AddrKey addr (TxIn tid ix)
+            (addrKeyFromBytes =<< addrKeyToBytes key) `shouldBe` Just key
+
+        it "round-trips for a Byron-shaped key (typical 60-byte address)" $ do
+            let addr = Address (BS.replicate 60 0x33)
+                tid = BS.replicate 32 0xCC
+                ix = 0 :: Word16
+                key = AddrKey addr (TxIn tid ix)
+            (addrKeyFromBytes =<< addrKeyToBytes key) `shouldBe` Just key
+
+        it "round-trips for a key with a 0-length address" $ do
+            let addr = Address BS.empty
+                tid = BS.replicate 32 0x00
+                ix = 0 :: Word16
+                key = AddrKey addr (TxIn tid ix)
+            (addrKeyFromBytes =<< addrKeyToBytes key) `shouldBe` Just key
+
+        it "rejects keys whose address exceeds 255 bytes" $ do
+            let addr = Address (BS.replicate 256 0x00)
+                tid = BS.replicate 32 0x00
+                key = AddrKey addr (TxIn tid 0)
+            addrKeyToBytes key `shouldBe` Nothing
+
+        it "decodes nothing for truncated input" $ do
+            addrKeyFromBytes BS.empty `shouldBe` Nothing
+            addrKeyFromBytes (BS.singleton 5) `shouldBe` Nothing
+
+        it "decodes nothing for trailing garbage" $ do
+            let addr = Address (BS.replicate 29 0x11)
+                tid = BS.replicate 32 0x22
+            case addrKeyToBytes (AddrKey addr (TxIn tid 0)) of
+                Just bs ->
+                    addrKeyFromBytes (bs <> BS.singleton 0xFF)
+                        `shouldBe` Nothing
+                Nothing -> fail "addrKeyToBytes returned Nothing"
+
+        it "encode/decode is total on Arbitrary keys (≤255-byte addrs)" $
+            property $
+                \(SmallishAddrKey k) ->
+                    (addrKeyFromBytes =<< addrKeyToBytes k) === Just k
+
+    describe "addressPrefix" $ do
+        it "is the strict byte prefix of any AddrKey at that address" $ do
+            let addr = Address (BS.replicate 29 0x55)
+                tid = BS.replicate 32 0x66
+                key = AddrKey addr (TxIn tid 13)
+            case (addrKeyToBytes key, addressPrefix addr) of
+                (Just keyBytes, Just pfx) ->
+                    BS.take (BS.length pfx) keyBytes `shouldBe` pfx
+                _ -> fail "encode returned Nothing"
+
+        it "differs in the length byte for two addresses of different lengths" $ do
+            case ( addressPrefix (Address (BS.replicate 29 0x77))
+                 , addressPrefix (Address (BS.replicate 60 0x77))
+                 ) of
+                (Just p29, Just p60) -> do
+                    BS.head p29 `shouldBe` 29
+                    BS.head p60 `shouldBe` 60
+                _ -> fail "addressPrefix returned Nothing"
+
+    describe "TxIn codec" $ do
+        it "round-trips a concrete TxIn" $ do
+            let tin = TxIn (BS.replicate 32 0x42) 17
+            (txInFromBytes . txInToBytes) tin `shouldBe` Just tin
+
+        it "round-trips ix=0 and ix=maxBound" $ do
+            let mk = TxIn (BS.replicate 32 0xFF)
+            (txInFromBytes . txInToBytes) (mk 0) `shouldBe` Just (mk 0)
+            (txInFromBytes . txInToBytes) (mk maxBound)
+                `shouldBe` Just (mk maxBound)
+
+        it "encodes to exactly 34 bytes" $ do
+            BS.length (txInToBytes (TxIn (BS.replicate 32 0) 0))
+                `shouldBe` 34
+            BS.length (txInToBytes (TxIn (BS.replicate 32 0xFF) 0xFFFF))
+                `shouldBe` 34
+
+        it "decodes nothing for non-34-byte input" $ do
+            txInFromBytes BS.empty `shouldBe` Nothing
+            txInFromBytes (BS.replicate 33 0) `shouldBe` Nothing
+            txInFromBytes (BS.replicate 35 0) `shouldBe` Nothing
+
+-- Generators ------------------------------------------------------
+
+{- | An 'AddrKey' with an address length in @[0, 255]@.
+We never observe larger addresses from the ledger.
+-}
+newtype SmallishAddrKey = SmallishAddrKey AddrKey
+    deriving stock (Show)
+
+instance Arbitrary SmallishAddrKey where
+    arbitrary = do
+        addrLen <- choose (0, 255)
+        addr <- BS.pack <$> bytes addrLen
+        tid <- BS.pack <$> bytes 32
+        SmallishAddrKey . AddrKey (Address addr) . TxIn tid
+            <$> arbitrary
+      where
+        bytes :: Int -> Gen [Word8]
+        bytes = flip vectorOf arbitrary

--- a/test/main.hs
+++ b/test/main.hs
@@ -8,6 +8,7 @@ import Cardano.Node.Client.E2E.ChainSyncSpec qualified as ChainSyncSpec
 import Cardano.Node.Client.E2E.MultiAssetChangeSpec qualified as MultiAssetChangeSpec
 import Cardano.Node.Client.E2E.ProviderSpec qualified as ProviderSpec
 import Cardano.Node.Client.E2E.TxBuildSpec qualified as TxBuildSpec
+import Cardano.Node.Client.E2E.UTxOIndexerSpec qualified as UTxOIndexerSpec
 
 main :: IO ()
 main = hspec $ do
@@ -17,3 +18,4 @@ main = hspec $ do
     MultiAssetChangeSpec.spec
     ChainSyncSpec.spec
     ChainPopulatorSpec.spec
+    UTxOIndexerSpec.spec

--- a/test/unit-main.hs
+++ b/test/unit-main.hs
@@ -5,6 +5,7 @@ import Test.Hspec (hspec)
 import Cardano.Node.Client.BalanceSpec qualified as BalanceSpec
 import Cardano.Node.Client.TxBuildGoldenSpec qualified as TxBuildGoldenSpec
 import Cardano.Node.Client.TxBuildSpec qualified as TxBuildSpec
+import Cardano.Node.Client.UTxOIndexer.TypesSpec qualified as UTxOIndexerTypesSpec
 import Data.List.SampleFibonacciSpec qualified as SampleFibonacciSpec
 
 main :: IO ()
@@ -13,3 +14,4 @@ main = hspec $ do
     BalanceSpec.spec
     TxBuildSpec.spec
     TxBuildGoldenSpec.spec
+    UTxOIndexerTypesSpec.spec

--- a/test/unit-main.hs
+++ b/test/unit-main.hs
@@ -6,6 +6,7 @@ import Cardano.Node.Client.BalanceSpec qualified as BalanceSpec
 import Cardano.Node.Client.TxBuildGoldenSpec qualified as TxBuildGoldenSpec
 import Cardano.Node.Client.TxBuildSpec qualified as TxBuildSpec
 import Cardano.Node.Client.UTxOIndexer.IndexerSpec qualified as UTxOIndexerSpec
+import Cardano.Node.Client.UTxOIndexer.ServerSpec qualified as UTxOIndexerServerSpec
 import Cardano.Node.Client.UTxOIndexer.TypesSpec qualified as UTxOIndexerTypesSpec
 import Data.List.SampleFibonacciSpec qualified as SampleFibonacciSpec
 
@@ -17,3 +18,4 @@ main = hspec $ do
     TxBuildGoldenSpec.spec
     UTxOIndexerTypesSpec.spec
     UTxOIndexerSpec.spec
+    UTxOIndexerServerSpec.spec

--- a/test/unit-main.hs
+++ b/test/unit-main.hs
@@ -5,6 +5,7 @@ import Test.Hspec (hspec)
 import Cardano.Node.Client.BalanceSpec qualified as BalanceSpec
 import Cardano.Node.Client.TxBuildGoldenSpec qualified as TxBuildGoldenSpec
 import Cardano.Node.Client.TxBuildSpec qualified as TxBuildSpec
+import Cardano.Node.Client.UTxOIndexer.IndexerSpec qualified as UTxOIndexerSpec
 import Cardano.Node.Client.UTxOIndexer.TypesSpec qualified as UTxOIndexerTypesSpec
 import Data.List.SampleFibonacciSpec qualified as SampleFibonacciSpec
 
@@ -15,3 +16,4 @@ main = hspec $ do
     TxBuildSpec.spec
     TxBuildGoldenSpec.spec
     UTxOIndexerTypesSpec.spec
+    UTxOIndexerSpec.spec


### PR DESCRIPTION
Closes [#78](https://github.com/lambdasistemi/cardano-node-clients/issues/78).

A minimal address→UTxO indexer daemon over the existing N2C ChainSync client. The daemon consumes blocks from a `cardano-node` Unix socket and serves three NDJSON read primitives over its own Unix domain socket: `utxos_at`, `await`, and `ready`. Storage uses the `kv-transactions` abstraction (in-memory backend in v1; RocksDB is a one-line swap).

## Wire surface

```
{"utxos_at":"<hex-of-address-bytes>"} → {"utxos":[{"txin":"<txid>#<ix>","txout":"<base16-cbor>"}, ...]}
{"await":"<txid>#<ix>","timeout_seconds":<int>} → {"slot":N,"blockHash":"<hex>","txout":"<hex>"} | {"timeout":true}
{"ready":null} → {"ready":<bool>,"tipSlot":<int|null>,"processedSlot":<int|null>,"slotsBehind":<int|null>}
```

`ready` mirrors `cardano-utxo-csmt`'s `ReadyResponse` shape so consumers wired against either daemon get the same JSON.

## Storage shape

Three typed columns (`Cardano.Node.Client.UTxOIndexer.Columns`):

- `TxInCol`: `TxIn → Address` — fixed 34-byte key for fast spend resolution.
- `AddressIndex`: `lenByte || addr || txId || ix → TxOut` — length-prefixed composite key keeps prefix scans correct across mixed address shapes (Byron 60-byte, Shelley 29-byte). Same trick `aiken-csmt` uses, generalised to variable-length addresses.
- `RollbackCol`: `SlotNo → [UtxoOp]` — slot-keyed inverse-op log so a `rollBackward` replays the inverses in order.

Block extraction goes through `cardano-ledger-read` (`fromConsensusBlock`/`getEraTransactions`/`applyEraFun`) — the same abstraction `cardano-utxo-csmt` uses — so the daemon never touches era-specific structure directly.

## Patch series

| # | Concern |
|---|---|
| 1 | scaffolding: executable + CLI flag parsing |
| 2 | typed-column GADT + indexer domain types |
| 3 | in-memory backend + `applyOps` + `snapshotAt` |
| 4 | rollback support — slot-tagged inverse-op log |
| 5 | chain-sync block extraction (era-polymorphic, Shelley-family) |
| 6 | NDJSON Unix-socket server — `utxos_at` + `ready` |
| 7 | NDJSON `await` primitive with STM wakeup + `BlockHash` threading |
| 8 | `Daemon` module + `Main` wires chain-sync + indexer + server |
| 9 | devnet E2E test — daemon syncs and serves NDJSON |
| 10 | ci: bump cachix-action v15 → v17 (Node.js 20 deprecation) |

Each commit is bisect-safe (compiles + tests pass on its own).

## Testing

- 113 unit tests (codecs, indexer apply/snapshot/rollback, server wire round-trip, await + timeout) — `cabal test unit-tests`.
- New devnet E2E spec (`Cardano.Node.Client.E2E.UTxOIndexerSpec`) boots `cardano-node`, runs `runDaemon` in-process, polls `ready`, submits a self-transfer through `Submitter`, blocks on `await` for the resulting `TxIn`, and verifies `utxos_at(genesisAddr)` sees its change output.

## Driving consumer

[cardano-foundation/cardano-node-antithesis#69](https://github.com/cardano-foundation/cardano-node-antithesis/issues/69) — moves tx-generator + asteria-player off `cardano-cli query utxo --address`. Spec/plan: [cardano-foundation/cardano-node-antithesis#70](https://github.com/cardano-foundation/cardano-node-antithesis/pull/70).

## Follow-ups (separate tickets, not blocking)

- [#81](https://github.com/lambdasistemi/cardano-node-clients/issues/81) — rollback log finality sweep (cull `RollbackCol` entries older than `tip - k`).