### PR TITLE
feat(utxo-indexer): rollback log finality sweep — count-based, k-deep

### DIFF
--- a/app/utxo-indexer/Main.hs
+++ b/app/utxo-indexer/Main.hs
@@ -28,6 +28,14 @@ import Text.Read (readMaybe)
 defaultReadyThreshold :: Word
 defaultReadyThreshold = 60
 
+{- | Default Cardano security parameter @k@ — the
+rollback log is capped at this many of the most-recent
+entries (per-block, not per-slot). Mainnet/preprod/
+preview all use 2160; devnets typically override.
+-}
+defaultSecurityParamK :: Word
+defaultSecurityParamK = 2160
+
 {- | Parse a single @--key value@ pair from the argument
 list. Returns the value and the remaining args.
 -}
@@ -52,12 +60,16 @@ parseConfig args0 = do
     let (readyS, args5) =
             fromMaybe (show defaultReadyThreshold, args4) $
                 takeFlag "--ready-threshold-slots" args4
-    case args5 of
+        (kS, args6) =
+            fromMaybe (show defaultSecurityParamK, args5) $
+                takeFlag "--security-param-k" args5
+    case args6 of
         [] -> pure ()
         extra -> dieUsage $ "Unexpected args: " <> show extra
     magic <- requireWord "--network-magic" magicS
     slots <- requireWord "--byron-epoch-slots" slotsS
     ready <- requireWord "--ready-threshold-slots" readyS
+    k <- requireWord "--security-param-k" kS
     pure
         DaemonConfig
             { dcRelaySocket = relay
@@ -65,6 +77,7 @@ parseConfig args0 = do
             , dcNetworkMagic = fromIntegral (magic :: Word)
             , dcByronEpochSlots = fromIntegral (slots :: Word)
             , dcReadyThresholdSlots = fromIntegral (ready :: Word)
+            , dcSecurityParamK = fromIntegral (k :: Word)
             }
   where
     requireFlag key args =
@@ -89,7 +102,8 @@ dieUsage msg = do
     hPutStrLn stderr "  --listen PATH \\"
     hPutStrLn stderr "  --network-magic INT \\"
     hPutStrLn stderr "  --byron-epoch-slots INT \\"
-    hPutStrLn stderr "  [--ready-threshold-slots INT]"
+    hPutStrLn stderr "  [--ready-threshold-slots INT] \\"
+    hPutStrLn stderr "  [--security-param-k INT]"
     exitFailure
 
 -- | Entry point. Parse args, log config, run the daemon.

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
@@ -17,10 +17,22 @@ exposes the operations the rest of the daemon needs:
   observed 'TxIn' gets rolled back stay closed (the
   observation has already been reported); awaiters still
   pending stay pending.
+* 'pruneRollbacks' caps the rollback log at the most
+  recent @maxKeep@ entries — the oldest are dropped. This
+  is the count-based finality cull (Cardano's @k@-deep
+  rule applies per /block/, not per slot, so a count-based
+  bound is what consumers actually want).
 * 'snapshotAt' prefix-scans every UTxO at a given address
   using a 'Cursor'.
 * 'awaitTxIn' blocks until a given 'TxIn' is observed in
   the index (or the optional timeout fires).
+
+A 'TVar' tracks the current rollback-log entry count so
+the prune step does not re-scan the column on every
+block. The counter is in-process state — for the
+in-memory backend that is fine (counter and DB live and
+die together); a future RocksDB swap will need to seed
+it from a one-shot scan at startup.
 
 A future RocksDB swap is a one-line change:
 'mkInMemoryDatabase' becomes 'mkRocksDBDatabase' from
@@ -77,6 +89,7 @@ import Data.Map.Strict qualified as Map
 import Database.KV.Cursor (
     Cursor,
     Entry (..),
+    firstEntry,
     lastEntry,
     nextEntry,
     prevEntry,
@@ -121,6 +134,15 @@ data IndexerHandle = IndexerHandle
     -- ^ Roll the index back to the given slot by
     -- replaying inverse-op lists for every slot
     -- @> target@, in descending slot order.
+    , pruneRollbacks :: Int -> IO Int
+    -- ^ Keep at most @maxKeep@ rollback-log entries
+    -- (the most-recent ones); drop the oldest. Returns
+    -- the number of entries deleted. Idempotent.
+    --
+    -- Implements the count-based finality cull: a block
+    -- is final once @k@ later blocks have been applied,
+    -- so the inverse-op list keyed at any of the
+    -- now-irrelevant earlier blocks is dead weight.
     , snapshotAt :: Address -> IO [(TxIn, TxOut)]
     -- ^ Snapshot every UTxO currently at the given
     -- address, in ascending @TxIn@ order.
@@ -149,7 +171,8 @@ withInMemoryIndexer action = do
     runner <- newRunTransaction db
     waitersVar <- newTVarIO Map.empty
     observedVar <- newTVarIO Map.empty
-    action (mkHandle runner waitersVar observedVar)
+    countVar <- newTVarIO (0 :: Int)
+    action (mkHandle runner waitersVar observedVar countVar)
 
 -- Internal -------------------------------------------------------
 
@@ -173,25 +196,47 @@ mkHandle ::
     RunTransaction IO Int Cols Op ->
     Waiters ->
     Observed ->
+    TVar Int ->
     IndexerHandle
-mkHandle RunTransaction{runTransaction} waitersVar observedVar =
-    IndexerHandle
-        { applyAtSlot = \slot bh ops -> do
-            runTransaction (applyAndLog slot ops)
-            atomically $
-                fireWaiters
-                    waitersVar
-                    observedVar
-                    slot
-                    bh
-                    ops
-        , rollbackTo = \slot -> do
-            runTransaction (rollbackToSlot slot)
-            atomically (pruneObservedAfter observedVar slot)
-        , snapshotAt =
-            runTransaction . iterating AddressIndex . scanAddress
-        , awaitTxIn = doAwait waitersVar observedVar
-        }
+mkHandle
+    RunTransaction{runTransaction}
+    waitersVar
+    observedVar
+    countVar =
+        IndexerHandle
+            { applyAtSlot = \slot bh ops -> do
+                runTransaction (applyAndLog slot ops)
+                atomically $ do
+                    modifyTVar' countVar (+ 1)
+                    fireWaiters
+                        waitersVar
+                        observedVar
+                        slot
+                        bh
+                        ops
+            , rollbackTo = \slot -> do
+                deleted <- runTransaction (rollbackToSlot slot)
+                atomically $ do
+                    modifyTVar' countVar (subtract deleted)
+                    pruneObservedAfter observedVar slot
+            , pruneRollbacks = \maxKeep -> do
+                count <- readTVarIO countVar
+                let excess = count - maxKeep
+                if excess <= 0
+                    then pure 0
+                    else do
+                        deleted <-
+                            runTransaction
+                                (pruneOldest excess)
+                        atomically $
+                            modifyTVar'
+                                countVar
+                                (subtract deleted)
+                        pure deleted
+            , snapshotAt =
+                runTransaction . iterating AddressIndex . scanAddress
+            , awaitTxIn = doAwait waitersVar observedVar
+            }
 
 {- | Within one transaction: for each op compute its
 inverse against the current state, apply the op, and
@@ -299,15 +344,19 @@ down via 'lastEntry'/'prevEntry', collecting entries
 @> target@, then in a second pass replays each
 inverse-op list and deletes the corresponding rollback
 entry — both inside the same transaction.
+
+Returns the number of rollback-log entries removed so
+the in-memory entry counter stays in sync.
 -}
 rollbackToSlot ::
     SlotNo ->
-    Transaction IO Int Cols Op ()
+    Transaction IO Int Cols Op Int
 rollbackToSlot target = do
     entries <-
         iterating RollbackCol $
             collectGreaterThan target
     traverse_ undoSlot entries
+    pure (length entries)
   where
     undoSlot (slot, invs) = do
         traverse_ applyOne invs
@@ -328,6 +377,44 @@ collectGreaterThan target =
     go acc (Just Entry{entryKey = slot, entryValue = invs})
         | slot > target =
             prevEntry >>= go ((slot, invs) : acc)
+        | otherwise = pure (reverse acc)
+
+{- | Drop the @excess@ oldest rollback-log entries.
+Walks 'RollbackCol' from 'firstEntry' forward up to
+@excess@ steps and deletes each visited key. Returns
+the number of entries actually deleted (≤ @excess@;
+fewer if the column has fewer than @excess@ entries).
+
+Caller maintains the entry count externally — this
+function does not re-scan the column to size it.
+-}
+pruneOldest ::
+    Int ->
+    Transaction IO Int Cols Op Int
+pruneOldest excess
+    | excess <= 0 = pure 0
+    | otherwise = do
+        keys <-
+            iterating RollbackCol $
+                collectFirstNKeys excess
+        traverse_ (delete RollbackCol) keys
+        pure (length keys)
+
+{- | Cursor program: from 'firstEntry' walk forward,
+collecting up to @n@ keys.
+-}
+collectFirstNKeys ::
+    (Monad m) =>
+    Int ->
+    Cursor m (KV SlotNo [UtxoOp]) [SlotNo]
+collectFirstNKeys n0 =
+    firstEntry >>= go [] n0
+  where
+    go acc 0 _ = pure (reverse acc)
+    go acc _ Nothing = pure (reverse acc)
+    go acc n (Just Entry{entryKey})
+        | n > 0 =
+            nextEntry >>= go (entryKey : acc) (n - 1)
         | otherwise = pure (reverse acc)
 
 -- | Inverse of a single op against current state.

--- a/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
@@ -77,6 +77,10 @@ data DaemonConfig = DaemonConfig
     , dcNetworkMagic :: Word32
     , dcByronEpochSlots :: Word64
     , dcReadyThresholdSlots :: Word64
+    , dcSecurityParamK :: Int
+    -- ^ Cardano security parameter @k@ — the
+    -- rollback-log entry count is capped at this many,
+    -- and older entries are dropped after each apply.
     }
     deriving stock (Show)
 
@@ -140,6 +144,7 @@ mkFollower cfg readyVar idx = self
                 let (slot, ops) = extractBlock (fetchedBlock fetched)
                     bh = pointToBlockHash (fetchedPoint fetched)
                 applyAtSlot idx slot bh ops
+                _ <- pruneRollbacks idx (dcSecurityParamK cfg)
                 updateReady cfg readyVar slot tip
                 pure self
             , rollBackward = \point -> do

--- a/test/Cardano/Node/Client/E2E/UTxOIndexerSpec.hs
+++ b/test/Cardano/Node/Client/E2E/UTxOIndexerSpec.hs
@@ -139,6 +139,7 @@ runE2E = do
                         , dcNetworkMagic = 42
                         , dcByronEpochSlots = 42
                         , dcReadyThresholdSlots = 60
+                        , dcSecurityParamK = 2160
                         }
             withAsync (runDaemon cfg) $ \daemonThread -> do
                 waitForFile daemonSock 600

--- a/test/Cardano/Node/Client/UTxOIndexer/IndexerSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/IndexerSpec.hs
@@ -198,6 +198,108 @@ spec = describe "Cardano.Node.Client.UTxOIndexer.Indexer" $ do
                 xs <- snapshotAt h addr
                 xs `shouldBe` []
 
+    describe "pruneRollbacks (count-based finality cull)" $ do
+        it "is a no-op on an empty rollback log" $
+            withInMemoryIndexer $ \h -> do
+                deleted <- pruneRollbacks h 100
+                deleted `shouldBe` 0
+
+        it "is a no-op while count <= maxKeep" $
+            withInMemoryIndexer $ \h -> do
+                let addr = mkAddr 0xAA 29
+                    mk tid =
+                        UtxoCreate
+                            (TxIn (BS.replicate 32 tid) 0)
+                            addr
+                            (TxOut (BS.singleton tid))
+                applyAtSlot h (SlotNo 1) testBlockHash [mk 0x01]
+                applyAtSlot h (SlotNo 2) testBlockHash [mk 0x02]
+                applyAtSlot h (SlotNo 3) testBlockHash [mk 0x03]
+                deleted <- pruneRollbacks h 3
+                deleted `shouldBe` 0
+
+        it "drops the oldest entries down to maxKeep" $
+            withInMemoryIndexer $ \h -> do
+                let addr = mkAddr 0xAA 29
+                    mk tid =
+                        UtxoCreate
+                            (TxIn (BS.replicate 32 tid) 0)
+                            addr
+                            (TxOut (BS.singleton tid))
+                applyAtSlot h (SlotNo 1) testBlockHash [mk 0x01]
+                applyAtSlot h (SlotNo 2) testBlockHash [mk 0x02]
+                applyAtSlot h (SlotNo 3) testBlockHash [mk 0x03]
+                applyAtSlot h (SlotNo 4) testBlockHash [mk 0x04]
+                applyAtSlot h (SlotNo 5) testBlockHash [mk 0x05]
+                deleted <- pruneRollbacks h 2
+                deleted `shouldBe` 3
+                -- Surviving rollback entries cover slots 4..5
+                -- only — anything older is now unreachable, so a
+                -- rollback to slot 0 only undoes the last two.
+                rollbackTo h (SlotNo 0)
+                xs <- snapshotAt h addr
+                fmap (txInId . fst) xs
+                    `shouldBe` [ BS.replicate 32 0x01
+                               , BS.replicate 32 0x02
+                               , BS.replicate 32 0x03
+                               ]
+
+        it "is idempotent (second call deletes nothing)" $
+            withInMemoryIndexer $ \h -> do
+                let addr = mkAddr 0xAA 29
+                    mk tid =
+                        UtxoCreate
+                            (TxIn (BS.replicate 32 tid) 0)
+                            addr
+                            (TxOut (BS.singleton tid))
+                applyAtSlot h (SlotNo 1) testBlockHash [mk 0x01]
+                applyAtSlot h (SlotNo 2) testBlockHash [mk 0x02]
+                applyAtSlot h (SlotNo 3) testBlockHash [mk 0x03]
+                first <- pruneRollbacks h 1
+                second <- pruneRollbacks h 1
+                first `shouldBe` 2
+                second `shouldBe` 0
+
+        it "leaves the address index untouched" $
+            withInMemoryIndexer $ \h -> do
+                let addr = mkAddr 0xAA 29
+                    mk tid =
+                        UtxoCreate
+                            (TxIn (BS.replicate 32 tid) 0)
+                            addr
+                            (TxOut (BS.singleton tid))
+                applyAtSlot h (SlotNo 1) testBlockHash [mk 0x01]
+                applyAtSlot h (SlotNo 2) testBlockHash [mk 0x02]
+                applyAtSlot h (SlotNo 3) testBlockHash [mk 0x03]
+                _ <- pruneRollbacks h 1
+                xs <- snapshotAt h addr
+                fmap (txInId . fst) xs
+                    `shouldBe` [ BS.replicate 32 0x01
+                               , BS.replicate 32 0x02
+                               , BS.replicate 32 0x03
+                               ]
+
+        it "stays consistent across rollback + prune" $
+            withInMemoryIndexer $ \h -> do
+                let addr = mkAddr 0xAA 29
+                    mk tid =
+                        UtxoCreate
+                            (TxIn (BS.replicate 32 tid) 0)
+                            addr
+                            (TxOut (BS.singleton tid))
+                applyAtSlot h (SlotNo 1) testBlockHash [mk 0x01]
+                applyAtSlot h (SlotNo 2) testBlockHash [mk 0x02]
+                applyAtSlot h (SlotNo 3) testBlockHash [mk 0x03]
+                rollbackTo h (SlotNo 1)
+                applyAtSlot h (SlotNo 2) testBlockHash [mk 0x12]
+                applyAtSlot h (SlotNo 3) testBlockHash [mk 0x13]
+                applyAtSlot h (SlotNo 4) testBlockHash [mk 0x14]
+                -- Three apply + one rollback removed two from the
+                -- log; a fourth-keep prune now sees count = 4
+                -- and is a no-op.
+                deleted <- pruneRollbacks h 4
+                deleted `shouldBe` 0
+
 {- | Build a synthetic 'Address' of the given length with
 a fixed body byte. Lets tests construct Shelley-shaped
 (29-byte) and Byron-shaped (60-byte) addresses without


### PR DESCRIPTION
Closes [#81](https://github.com/lambdasistemi/cardano-node-clients/issues/81).

Adds the count-based finality cull to the utxo-indexer's rollback log. After every \`applyAtSlot\` the daemon caps the log at the most-recent \`k\` entries (default 2160, matching mainnet \`securityParam\`); older entries are dropped. This bounds the log size in steady-state — without it, every block applied appends a row that is never collected.

## Why count, not slot

Cardano's \`k\`-deep finality is a per-/block/ rule, not a per-/slot/ rule. A purely slot-based bound (\`tip - k\`) is wrong: a network stall keeps slots ticking but holds blocks back, so the cutoff drifts past genuinely-still-rollback-able blocks.

This patch follows the pattern established in [chain-follower's \`Rollbacks.Store.pruneExcess\`](https://github.com/cardano-scaling/chain-follower) and [cardano-utxo-csmt's \`pruneByCount\`](https://github.com/cardano-foundation/cardano-utxo-csmt) — the canonical count-based cull every downstream of chain-follower already uses.

## API change

\`IndexerHandle\` gains one field:

\`\`\`haskell
pruneRollbacks :: Int -> IO Int
\`\`\`

Keep at most \`maxKeep\` rollback-log entries; drop the oldest. Returns the number of entries deleted. Idempotent.

\`Cardano.Node.Client.UTxOIndexer.Daemon.DaemonConfig\` gains \`dcSecurityParamK :: Int\`. \`Main\` exposes it as \`--security-param-k INT\` (default 2160). The follower calls \`pruneRollbacks dcSecurityParamK\` after every successful apply.

## Implementation

The handle keeps an internal \`TVar Int\` tracking the current row count of \`RollbackCol\`. \`applyAtSlot\` increments it; \`rollbackTo\` decrements by the number of entries removed (now plumbed through the inner transaction); \`pruneRollbacks\` reads it, decides how many to drop, walks \`RollbackCol\` from \`firstEntry\` forward up to \`excess\` steps, deletes those keys, and decrements the counter by the number actually removed.

The counter is in-process state. For the in-memory backend that is fine — counter and DB live and die together. A future RocksDB swap will need a one-shot startup scan to seed it; that lands with the persistence work, not here.

## Testing

Six new unit tests under \`Cardano.Node.Client.UTxOIndexer.IndexerSpec\` (119 total, was 113):

- no-op on empty log
- no-op while count ≤ maxKeep
- drops oldest down to maxKeep, then a rollback to slot 0 only undoes the surviving entries
- idempotent (second prune returns 0)
- leaves the address index untouched
- count stays consistent across rollback + prune

The existing devnet E2E (\`Cardano.Node.Client.E2E.UTxOIndexerSpec\`) is updated to thread the new \`dcSecurityParamK\` field; behaviour unchanged because the test runs for ~9 s and never produces 2160 blocks.

\`just ci\` is green: 12 / 12 e2e, 119 / 119 unit, fourmolu, cabal-fmt, hlint.