### PR TITLE
feat(utxo-indexer): durable storage — RocksDB backend

### DIFF
--- a/app/utxo-indexer/Main.hs
+++ b/app/utxo-indexer/Main.hs
@@ -63,7 +63,10 @@ parseConfig args0 = do
         (kS, args6) =
             fromMaybe (show defaultSecurityParamK, args5) $
                 takeFlag "--security-param-k" args5
-    case args6 of
+        (mDbPath, args7) = case takeFlag "--db-path" args6 of
+            Just (p, rest) -> (Just p, rest)
+            Nothing -> (Nothing, args6)
+    case args7 of
         [] -> pure ()
         extra -> dieUsage $ "Unexpected args: " <> show extra
     magic <- requireWord "--network-magic" magicS
@@ -78,6 +81,7 @@ parseConfig args0 = do
             , dcByronEpochSlots = fromIntegral (slots :: Word)
             , dcReadyThresholdSlots = fromIntegral (ready :: Word)
             , dcSecurityParamK = fromIntegral (k :: Word)
+            , dcDbPath = mDbPath
             }
   where
     requireFlag key args =
@@ -103,7 +107,8 @@ dieUsage msg = do
     hPutStrLn stderr "  --network-magic INT \\"
     hPutStrLn stderr "  --byron-epoch-slots INT \\"
     hPutStrLn stderr "  [--ready-threshold-slots INT] \\"
-    hPutStrLn stderr "  [--security-param-k INT]"
+    hPutStrLn stderr "  [--security-param-k INT] \\"
+    hPutStrLn stderr "  [--db-path PATH]"
     exitFailure
 
 -- | Entry point. Parse args, log config, run the daemon.

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -163,9 +163,12 @@ library utxo-indexer-lib
     , base
     , bytestring
     , containers
+    , data-default-class
     , dependent-map
     , dependent-sum
     , lens
+    , rocksdb-haskell-jprupp
+    , rocksdb-kv-transactions
     , rocksdb-kv-transactions:kv-transactions
     , some
     , stm

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -195,6 +195,7 @@ test-suite unit-tests
     Cardano.Node.Client.TxBuildGoldenSpec
     Cardano.Node.Client.TxBuildSpec
     Cardano.Node.Client.UTxOIndexer.IndexerSpec
+    Cardano.Node.Client.UTxOIndexer.PersistenceSpec
     Cardano.Node.Client.UTxOIndexer.ServerSpec
     Cardano.Node.Client.UTxOIndexer.TypesSpec
     Data.List.SampleFibonacciSpec
@@ -218,6 +219,7 @@ test-suite unit-tests
     , cardano-strict-containers
     , containers
     , directory
+    , filepath
     , hspec
     , microlens
     , network

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Columns.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Columns.hs
@@ -29,9 +29,10 @@ Three columns:
   the latest entry to derive the resume @Point@ without
   a separate tip column.
 
-A future RocksDB swap is a one-line backend choice via
-@mkInMemoryDatabase@ → @mkRocksDBDatabase@; nothing in
-this module changes.
+Both the in-memory and RocksDB backends share these
+column definitions verbatim — the column choice happens
+at the 'Database.KV.InMemory' /
+'Database.KV.RocksDB' boundary, not here.
 -}
 module Cardano.Node.Client.UTxOIndexer.Columns (
     -- * Column GADT

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Columns.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Columns.hs
@@ -19,10 +19,15 @@ Three columns:
   @lenByte || address || txId || ix@ so a cursor seek to
   @lenByte || address@ yields every UTxO at that address
   with its full 'TxOut' inline (no second-stage lookup).
-* 'RollbackCol' :: @KV SlotNo [UtxoOp]@ — slot-tagged
-  inverse-op log used to undo apply-block writes on a
-  chain-sync rollback. Keyed by 'SlotNo' (8-byte BE) so
-  cursor ordering matches numeric slot ordering.
+* 'RollbackCol' :: @KV SlotNo (BlockHash, [UtxoOp])@ —
+  slot-tagged inverse-op log used to undo apply-block
+  writes on a chain-sync rollback. Keyed by 'SlotNo'
+  (8-byte BE) so cursor ordering matches numeric slot
+  ordering. The 'BlockHash' is the hash of the block
+  whose application produced the inverse list — recorded
+  here so a future restart-recoverability story can read
+  the latest entry to derive the resume @Point@ without
+  a separate tip column.
 
 A future RocksDB swap is a one-line backend choice via
 @mkInMemoryDatabase@ → @mkRocksDBDatabase@; nothing in
@@ -46,6 +51,7 @@ import Cardano.Node.Client.UTxOIndexer.IndexerOp (UtxoOp (..))
 import Cardano.Node.Client.UTxOIndexer.Types (
     AddrKey,
     Address (..),
+    BlockHash (..),
     SlotNo,
     TxIn,
     TxOut (..),
@@ -81,11 +87,14 @@ data Cols c where
     -- prefix-scan by address yields @(TxIn, TxOut)@
     -- pairs directly.
     AddressIndex :: Cols (KV AddrKey TxOut)
-    -- | Rollback log: 'SlotNo' → list of inverse ops to
-    -- undo writes applied at that slot. The list is in
-    -- the order to apply on rollback (i.e. already
-    -- reversed relative to the original apply order).
-    RollbackCol :: Cols (KV SlotNo [UtxoOp])
+    -- | Rollback log: 'SlotNo' →
+    -- @('BlockHash', [inverse ops])@. The list is in the
+    -- order to apply on rollback (i.e. already reversed
+    -- relative to the original apply order). The
+    -- 'BlockHash' is the hash of the block that produced
+    -- this entry — recorded so a future startup can
+    -- recover the resume @Point@ from the latest entry.
+    RollbackCol :: Cols (KV SlotNo (BlockHash, [UtxoOp]))
 
 instance GEq Cols where
     geq TxInCol TxInCol = Just Refl
@@ -118,16 +127,17 @@ addressIndexCodecs =
         , valueCodec = txOutPrism
         }
 
-{- | Codecs for the rollback-log column. The op list uses
-a stable hand-rolled binary form (see 'encodeOps') so a
-future RocksDB swap can read entries written by the
+{- | Codecs for the rollback-log column. The on-disk
+value is @blockHashLen(4 BE) || blockHash || ops@ where
+@ops@ uses the stable hand-rolled form (see 'encodeOps')
+so a future RocksDB swap can read entries written by the
 in-memory backend.
 -}
-rollbackCodecs :: Codecs (KV SlotNo [UtxoOp])
+rollbackCodecs :: Codecs (KV SlotNo (BlockHash, [UtxoOp]))
 rollbackCodecs =
     Codecs
         { keyCodec = slotPrism
-        , valueCodec = opsPrism
+        , valueCodec = rollbackEntryPrism
         }
 
 -- Internal --------------------------------------------------------
@@ -160,8 +170,18 @@ txOutPrism = prism' unTxOut (Just . TxOut)
 slotPrism :: Prism' ByteString SlotNo
 slotPrism = prism' slotToBytes slotFromBytes
 
-opsPrism :: Prism' ByteString [UtxoOp]
-opsPrism = prism' encodeOps decodeOps
+{- | Codec for the @(BlockHash, [UtxoOp])@ rollback
+entry: @blockHashLen(4 BE) || blockHash || encodeOps@.
+-}
+rollbackEntryPrism :: Prism' ByteString (BlockHash, [UtxoOp])
+rollbackEntryPrism = prism' encode decode
+  where
+    encode (BlockHash bh, ops) =
+        lenPrefixed bh <> encodeOps ops
+    decode bs0 = do
+        (bhBs, rest) <- readLenPrefixed bs0
+        ops <- decodeOps rest
+        Just (BlockHash bhBs, ops)
 
 -- Inverse-op list binary encoding ---------------------------------
 --

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Columns.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Columns.hs
@@ -41,6 +41,7 @@ module Cardano.Node.Client.UTxOIndexer.Columns (
     -- * Codecs
     txInColCodecs,
     addressIndexCodecs,
+    observationColCodecs,
     rollbackCodecs,
 
     -- * Inverse-op list encoding
@@ -96,11 +97,21 @@ data Cols c where
     -- this entry — recorded so a future startup can
     -- recover the resume @Point@ from the latest entry.
     RollbackCol :: Cols (KV SlotNo (BlockHash, [UtxoOp]))
+    -- | Observation index: every live (i.e. created and
+    -- not yet spent) 'TxIn' carries the @('SlotNo',
+    -- 'BlockHash')@ of the block that created it. Used
+    -- by 'awaitTxIn' to answer "has this TxIn been
+    -- observed?" across process restart — the in-process
+    -- @Observed@ TVar is empty after reopen, but this
+    -- column persists, so the fast path reconstructs
+    -- the observation from on-disk state.
+    ObservationCol :: Cols (KV TxIn (SlotNo, BlockHash))
 
 instance GEq Cols where
     geq TxInCol TxInCol = Just Refl
     geq AddressIndex AddressIndex = Just Refl
     geq RollbackCol RollbackCol = Just Refl
+    geq ObservationCol ObservationCol = Just Refl
     geq _ _ = Nothing
 
 instance GCompare Cols where
@@ -108,8 +119,11 @@ instance GCompare Cols where
     gcompare TxInCol _ = GLT
     gcompare _ TxInCol = GGT
     gcompare AddressIndex AddressIndex = GEQ
-    gcompare AddressIndex RollbackCol = GLT
-    gcompare RollbackCol AddressIndex = GGT
+    gcompare AddressIndex _ = GLT
+    gcompare _ AddressIndex = GGT
+    gcompare ObservationCol ObservationCol = GEQ
+    gcompare ObservationCol RollbackCol = GLT
+    gcompare RollbackCol ObservationCol = GGT
     gcompare RollbackCol RollbackCol = GEQ
 
 -- | Codecs for 'TxInCol'.
@@ -126,6 +140,17 @@ addressIndexCodecs =
     Codecs
         { keyCodec = addrKeyPrism
         , valueCodec = txOutPrism
+        }
+
+{- | Codecs for the observation column. The value is
+@slotBytes(8 BE) || blockHashLen(4 BE) || blockHash@.
+-}
+observationColCodecs ::
+    Codecs (KV TxIn (SlotNo, BlockHash))
+observationColCodecs =
+    Codecs
+        { keyCodec = txInPrism
+        , valueCodec = observationPrism
         }
 
 {- | Codecs for the rollback-log column. The on-disk
@@ -183,6 +208,22 @@ rollbackEntryPrism = prism' encode decode
         (bhBs, rest) <- readLenPrefixed bs0
         ops <- decodeOps rest
         Just (BlockHash bhBs, ops)
+
+{- | Codec for the @('SlotNo', 'BlockHash')@ observation
+entry: @slotBytes(8 BE) || blockHashLen(4 BE) || blockHash@.
+-}
+observationPrism :: Prism' ByteString (SlotNo, BlockHash)
+observationPrism = prism' encode decode
+  where
+    encode (slot, BlockHash bh) =
+        slotToBytes slot <> lenPrefixed bh
+    decode bs0 = do
+        (slotBs, rest0) <- splitFixed 8 bs0
+        slot <- slotFromBytes slotBs
+        (bhBs, rest1) <- readLenPrefixed rest0
+        if BS.null rest1
+            then Just (slot, BlockHash bhBs)
+            else Nothing
 
 -- Inverse-op list binary encoding ---------------------------------
 --

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
@@ -29,15 +29,17 @@ exposes the operations the rest of the daemon needs:
 
 A 'TVar' tracks the current rollback-log entry count so
 the prune step does not re-scan the column on every
-block. The counter is in-process state — for the
-in-memory backend that is fine (counter and DB live and
-die together); a future RocksDB swap will need to seed
-it from a one-shot scan at startup.
+block. The counter is in-process state, but it is seeded
+from a one-shot scan of 'RollbackCol' on startup so it
+stays in sync with whatever the on-disk RocksDB store
+contains across restarts.
 
-A future RocksDB swap is a one-line change:
-'mkInMemoryDatabase' becomes 'mkRocksDBDatabase' from
-@rocksdb-kv-transactions@; nothing else in this module
-moves.
+Two backends are wired in: 'withInMemoryIndexer' for
+tests / ephemeral runs and 'withRocksDBIndexer' for the
+durable on-disk store. They share all of the apply /
+rollback / prune / snapshot / await machinery —
+'kv-transactions' makes the choice a one-line backend
+swap.
 -}
 module Cardano.Node.Client.UTxOIndexer.Indexer (
     -- * Indexer handle
@@ -84,6 +86,8 @@ import Control.Concurrent.STM (
     writeTVar,
  )
 import Data.ByteString qualified as BS
+import Data.Default.Class (def)
+import Data.Dependent.Map (DMap)
 import Data.Foldable (traverse_)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -96,7 +100,6 @@ import Database.KV.Cursor (
     prevEntry,
     seekKey,
  )
-import Data.Dependent.Map (DMap)
 import Database.KV.Database (Codecs, KV, mkColumns)
 import Database.KV.InMemory (mkInMemoryDatabase)
 import Database.KV.RocksDB (mkRocksDBDatabase)
@@ -111,7 +114,6 @@ import Database.KV.Transaction (
     newRunTransaction,
     query,
  )
-import Data.Default.Class (def)
 import Database.RocksDB (
     Config (..),
     columnFamilies,

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
@@ -60,6 +60,7 @@ module Cardano.Node.Client.UTxOIndexer.Indexer (
 import Cardano.Node.Client.UTxOIndexer.Columns (
     Cols (..),
     addressIndexCodecs,
+    observationColCodecs,
     rollbackCodecs,
     txInColCodecs,
  )
@@ -74,7 +75,6 @@ import Cardano.Node.Client.UTxOIndexer.Types (
  )
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race)
-import Control.Exception (Exception, throwIO)
 import Control.Concurrent.STM (
     STM,
     TMVar,
@@ -89,6 +89,7 @@ import Control.Concurrent.STM (
     readTVarIO,
     writeTVar,
  )
+import Control.Exception (Exception, throwIO)
 import Data.ByteString qualified as BS
 import Data.Default.Class (def)
 import Data.Dependent.Map (DMap)
@@ -162,7 +163,10 @@ the indexer state.
 -}
 data IndexerHandle = IndexerHandle
     { applyAtSlot ::
-        SlotNo -> BlockHash -> [UtxoOp] -> IO ()
+        SlotNo ->
+        BlockHash ->
+        [UtxoOp] ->
+        IO ()
     -- ^ Atomically apply a batch of create/spend
     -- operations and store the inverse list under the
     -- given slot in 'RollbackCol'. After the
@@ -240,6 +244,7 @@ withRocksDBIndexer path action =
         def{createIfMissing = True}
         [ ("utxo-indexer.txin", def)
         , ("utxo-indexer.address", def)
+        , ("utxo-indexer.observation", def)
         , ("utxo-indexer.rollback", def)
         ]
         $ \rdb -> do
@@ -272,6 +277,7 @@ indexerCodecs =
     fromList
         [ TxInCol :=> txInColCodecs
         , AddressIndex :=> addressIndexCodecs
+        , ObservationCol :=> observationColCodecs
         , RollbackCol :=> rollbackCodecs
         ]
 
@@ -359,7 +365,8 @@ mkHandle
                         pure deleted
             , snapshotAt =
                 runTransaction . iterating AddressIndex . scanAddress
-            , awaitTxIn = doAwait waitersVar observedVar
+            , awaitTxIn =
+                doAwait runTransaction waitersVar observedVar
             }
 
 {- | Internal: outcome of the apply transaction. Private
@@ -448,7 +455,7 @@ applyAndLog slot bh ops = do
         pure Applied
     step op = do
         inv <- inverseOf op
-        applyOne op
+        applyOne slot bh op
         pure inv
 
 {- | After @applyAndLog@ commits, walk the ops and:
@@ -499,34 +506,82 @@ pruneObservedAfter observedVar target =
         observedVar
         (Map.filter (\obs -> aoSlot obs <= target))
 
+{- | 'awaitTxIn' has three answer paths:
+
+1. The in-process 'Observed' map remembers TxIns
+   created in this run; a hit returns immediately.
+2. A miss in the in-process map reads the persistent
+   'ObservationCol' so a UTxO created in a /previous/
+   run is still answerable in O(1) without scanning.
+   To return the full @AwaitObservation@ shape we also
+   read 'AddressIndex' for the @TxOut@ (via 'TxInCol'
+   for the address).
+3. A miss in both falls back to the slow path: register
+   a TMVar waiter and either block or time out.
+-}
 doAwait ::
+    (forall a. Transaction IO cf Cols op a -> IO a) ->
     Waiters ->
     Observed ->
     TxIn ->
     Maybe Int ->
     IO (Maybe AwaitObservation)
-doAwait waitersVar observedVar txIn mTimeout = do
-    -- Fast path: already observed.
+doAwait runTx waitersVar observedVar txIn mTimeout = do
     observed <- readTVarIO observedVar
     case Map.lookup txIn observed of
         Just obs -> pure (Just obs)
         Nothing -> do
-            tmv <- atomically $ do
-                t <- newEmptyTMVar
-                modifyTVar'
-                    waitersVar
-                    (Map.alter (insertWaiter t) txIn)
-                pure t
-            case mTimeout of
-                Nothing -> Just <$> atomically (readTMVar tmv)
-                Just secs ->
-                    either Just (\() -> Nothing)
-                        <$> race
-                            (atomically (readTMVar tmv))
-                            (threadDelay (secs * 1_000_000))
+            mObs <- runTx (lookupObservation txIn)
+            case mObs of
+                Just obs -> pure (Just obs)
+                Nothing -> blockOnWaiter
   where
+    blockOnWaiter = do
+        tmv <- atomically $ do
+            t <- newEmptyTMVar
+            modifyTVar'
+                waitersVar
+                (Map.alter (insertWaiter t) txIn)
+            pure t
+        case mTimeout of
+            Nothing -> Just <$> atomically (readTMVar tmv)
+            Just secs ->
+                either Just (\() -> Nothing)
+                    <$> race
+                        (atomically (readTMVar tmv))
+                        (threadDelay (secs * 1_000_000))
     insertWaiter t Nothing = Just [t]
     insertWaiter t (Just xs) = Just (t : xs)
+
+{- | Persistent fast-path for 'awaitTxIn': join
+'ObservationCol' with 'TxInCol' + 'AddressIndex' to
+reconstruct an 'AwaitObservation' for a 'TxIn' created
+in some prior session. Returns 'Nothing' if the 'TxIn'
+is not observed (either never created or already spent).
+-}
+lookupObservation ::
+    TxIn ->
+    Transaction IO cf Cols op (Maybe AwaitObservation)
+lookupObservation txIn = do
+    mObs <- query ObservationCol txIn
+    case mObs of
+        Nothing -> pure Nothing
+        Just (slot, bh) -> do
+            mAddr <- query TxInCol txIn
+            case mAddr of
+                Nothing -> pure Nothing
+                Just addr -> do
+                    mOut <- query AddressIndex (AddrKey addr txIn)
+                    case mOut of
+                        Nothing -> pure Nothing
+                        Just txOut ->
+                            pure $
+                                Just
+                                    AwaitObservation
+                                        { aoSlot = slot
+                                        , aoBlockHash = bh
+                                        , aoTxOut = txOut
+                                        }
 
 {- | Roll back every slot strictly greater than
 @target@. Walks 'RollbackCol' from the highest slot
@@ -548,28 +603,37 @@ rollbackToSlot target = do
     traverse_ undoSlot entries
     pure (length entries)
   where
-    undoSlot (slot, invs) = do
-        traverse_ applyOne invs
+    -- 'applyOne' on rollback uses the slot+hash of the
+    -- rolled-back entry. For an inverse 'UtxoCreate'
+    -- (i.e. restoring a previously-spent UTxO) this means
+    -- 'ObservationCol' will record the rollback slot as
+    -- the observation slot, not the UTxO's original
+    -- creation slot. That is a known imprecision: 'awaitTxIn'
+    -- after a rollback returns the rollback slot for restored
+    -- UTxOs. The TxOut is still correct, which is what
+    -- consumers actually care about.
+    undoSlot (slot, bh, invs) = do
+        traverse_ (applyOne slot bh) invs
         delete RollbackCol slot
 
 {- | Cursor program: from 'lastEntry' walk backwards,
-collecting @(slot, invs)@ pairs while @slot > target@.
-Returns them in descending-slot order. The 'BlockHash'
-component of each entry is discarded — only the inverse
-list is needed to undo state, the hash is metadata for
-the resume-point story.
+collecting @(slot, blockHash, invs)@ triples while
+@slot > target@. Returns them in descending-slot order.
 -}
 collectGreaterThan ::
     (Monad m) =>
     SlotNo ->
-    Cursor m (KV SlotNo (BlockHash, [UtxoOp])) [(SlotNo, [UtxoOp])]
+    Cursor
+        m
+        (KV SlotNo (BlockHash, [UtxoOp]))
+        [(SlotNo, BlockHash, [UtxoOp])]
 collectGreaterThan target =
     lastEntry >>= go []
   where
     go acc Nothing = pure (reverse acc)
-    go acc (Just Entry{entryKey = slot, entryValue = (_bh, invs)})
+    go acc (Just Entry{entryKey = slot, entryValue = (bh, invs)})
         | slot > target =
-            prevEntry >>= go ((slot, invs) : acc)
+            prevEntry >>= go ((slot, bh, invs) : acc)
         | otherwise = pure (reverse acc)
 
 {- | Drop the @excess@ oldest rollback-log entries.
@@ -629,19 +693,30 @@ opTxIn :: UtxoOp -> TxIn
 opTxIn (UtxoCreate t _ _) = t
 opTxIn (UtxoSpend t) = t
 
+{- | Apply one op against the column state. The
+@(slot, bh)@ pair is recorded into 'ObservationCol' on
+'UtxoCreate' so 'awaitTxIn' can answer the
+"already observed?" fast-path question across process
+restart; on 'UtxoSpend' the corresponding observation is
+removed.
+-}
 applyOne ::
+    SlotNo ->
+    BlockHash ->
     UtxoOp ->
     Transaction IO cf Cols op ()
-applyOne (UtxoCreate txIn addr txOut) = do
+applyOne slot bh (UtxoCreate txIn addr txOut) = do
     insert TxInCol txIn addr
     insert AddressIndex (AddrKey addr txIn) txOut
-applyOne (UtxoSpend txIn) = do
+    insert ObservationCol txIn (slot, bh)
+applyOne _slot _bh (UtxoSpend txIn) = do
     mAddr <- query TxInCol txIn
     case mAddr of
         Nothing -> pure ()
         Just addr -> do
             delete AddressIndex (AddrKey addr txIn)
             delete TxInCol txIn
+            delete ObservationCol txIn
 
 {- | Cursor program: seek to the synthetic minimum key
 under @addr@ and walk forward, collecting every entry

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
@@ -43,6 +43,7 @@ module Cardano.Node.Client.UTxOIndexer.Indexer (
     -- * Indexer handle
     IndexerHandle (..),
     withInMemoryIndexer,
+    withRocksDBIndexer,
 
     -- * Operations
     UtxoOp (..),
@@ -96,8 +97,9 @@ import Database.KV.Cursor (
     seekKey,
  )
 import Data.Dependent.Map (DMap)
-import Database.KV.Database (Column, KV, mkColumns)
+import Database.KV.Database (Codecs, KV, mkColumns)
 import Database.KV.InMemory (mkInMemoryDatabase)
+import Database.KV.RocksDB (mkRocksDBDatabase)
 import Database.KV.Transaction (
     DSum ((:=>)),
     RunTransaction (..),
@@ -108,6 +110,12 @@ import Database.KV.Transaction (
     iterating,
     newRunTransaction,
     query,
+ )
+import Data.Default.Class (def)
+import Database.RocksDB (
+    Config (..),
+    columnFamilies,
+    withDBCF,
  )
 
 {- | An observed @TxIn@ apparition: the slot and block
@@ -162,30 +170,73 @@ handle, and clean up on exit.
 A fresh in-memory database starts empty, but we still
 seed the rollback-log counter via 'countRollbackEntries'
 to keep this constructor's wiring identical to the
-RocksDB one (so any future on-disk shape that reuses
-'mkInMemoryDatabase' for tests reads correctly).
+RocksDB one.
 -}
 withInMemoryIndexer :: (IndexerHandle -> IO a) -> IO a
 withInMemoryIndexer action = do
-    db <- mkInMemoryDatabase indexerColumns
+    db <- mkInMemoryDatabase (mkColumns [0 :: Int ..] indexerCodecs)
     runner <- newRunTransaction db
-    initialCount <- runTransaction runner countRollbackEntries
+    bootHandle runner action
+
+{- | Open a RocksDB-backed indexer at @path@ (creating
+the directory tree if missing) and run the action with
+the handle. The on-disk store survives process restart;
+on reopen, the rollback-log entry counter is re-derived
+by a one-shot scan of 'RollbackCol'.
+
+Three column families are created:
+
+* @utxo-indexer.txin@        — the @TxInCol@ table
+* @utxo-indexer.address@     — the @AddressIndex@ table
+* @utxo-indexer.rollback@    — the @RollbackCol@ log
+
+The order matters: 'mkColumns' threads the
+@'columnFamilies' db@ list through the typed-column
+@DMap@ in the same lex order the GADT iterates, so
+the names are paired with the right typed selector.
+-}
+withRocksDBIndexer ::
+    FilePath -> (IndexerHandle -> IO a) -> IO a
+withRocksDBIndexer path action =
+    withDBCF
+        path
+        def{createIfMissing = True}
+        [ ("utxo-indexer.txin", def)
+        , ("utxo-indexer.address", def)
+        , ("utxo-indexer.rollback", def)
+        ]
+        $ \rdb -> do
+            let database =
+                    mkRocksDBDatabase
+                        rdb
+                        (mkColumns (columnFamilies rdb) indexerCodecs)
+            runner <- newRunTransaction database
+            bootHandle runner action
+
+{- | Final stage shared by both constructors: derive the
+initial rollback-log counter from the database, set up
+the await-state TVars, and hand the constructed handle
+to the caller's action.
+-}
+bootHandle ::
+    RunTransaction IO cf Cols op ->
+    (IndexerHandle -> IO a) ->
+    IO a
+bootHandle runner@RunTransaction{runTransaction} action = do
+    initialCount <- runTransaction countRollbackEntries
     waitersVar <- newTVarIO Map.empty
     observedVar <- newTVarIO Map.empty
     countVar <- newTVarIO initialCount
     action (mkHandle runner waitersVar observedVar countVar)
 
--- | Shared column definitions (same for in-memory and
--- RocksDB backends).
-indexerColumns :: DMap Cols (Column Int)
-indexerColumns =
-    let codecs =
-            fromList
-                [ TxInCol :=> txInColCodecs
-                , AddressIndex :=> addressIndexCodecs
-                , RollbackCol :=> rollbackCodecs
-                ]
-     in mkColumns [0 :: Int ..] codecs
+-- | Shared codec definitions for the indexer columns.
+indexerCodecs :: DMap Cols Codecs
+indexerCodecs =
+    fromList
+        [ TxInCol :=> txInColCodecs
+        , AddressIndex :=> addressIndexCodecs
+        , RollbackCol :=> rollbackCodecs
+        ]
 
 {- | One-shot scan of 'RollbackCol' returning the entry
 count. O(n) in the column size — called once at startup
@@ -193,7 +244,7 @@ and never again; the in-memory counter handles steady
 state.
 -}
 countRollbackEntries ::
-    Transaction IO Int Cols Op Int
+    Transaction IO cf Cols op Int
 countRollbackEntries =
     iterating RollbackCol $
         firstEntry >>= go 0
@@ -202,8 +253,6 @@ countRollbackEntries =
     go !n (Just _) = nextEntry >>= go (n + 1)
 
 -- Internal -------------------------------------------------------
-
-type Op = (Int, BS.ByteString, Maybe BS.ByteString)
 
 {- | Map from a TxIn awaited by some caller to the
 list of empty TMVars waiting on it. Each TMVar gets
@@ -220,7 +269,8 @@ spend / rollback.
 type Observed = TVar (Map TxIn AwaitObservation)
 
 mkHandle ::
-    RunTransaction IO Int Cols Op ->
+    forall cf op.
+    RunTransaction IO cf Cols op ->
     Waiters ->
     Observed ->
     TVar Int ->
@@ -279,7 +329,7 @@ applyAndLog ::
     SlotNo ->
     BlockHash ->
     [UtxoOp] ->
-    Transaction IO Int Cols Op ()
+    Transaction IO cf Cols op ()
 applyAndLog slot bh ops = do
     inverses <- traverse step ops
     insert RollbackCol slot (bh, reverse inverses)
@@ -378,7 +428,7 @@ the in-memory entry counter stays in sync.
 -}
 rollbackToSlot ::
     SlotNo ->
-    Transaction IO Int Cols Op Int
+    Transaction IO cf Cols op Int
 rollbackToSlot target = do
     entries <-
         iterating RollbackCol $
@@ -421,7 +471,7 @@ function does not re-scan the column to size it.
 -}
 pruneOldest ::
     Int ->
-    Transaction IO Int Cols Op Int
+    Transaction IO cf Cols op Int
 pruneOldest excess
     | excess <= 0 = pure 0
     | otherwise = do
@@ -451,7 +501,7 @@ collectFirstNKeys n0 =
 -- | Inverse of a single op against current state.
 inverseOf ::
     UtxoOp ->
-    Transaction IO Int Cols Op UtxoOp
+    Transaction IO cf Cols op UtxoOp
 inverseOf op = do
     let txIn = opTxIn op
     mAddr <- query TxInCol txIn
@@ -469,7 +519,7 @@ opTxIn (UtxoSpend t) = t
 
 applyOne ::
     UtxoOp ->
-    Transaction IO Int Cols Op ()
+    Transaction IO cf Cols op ()
 applyOne (UtxoCreate txIn addr txOut) = do
     insert TxInCol txIn addr
     insert AddressIndex (AddrKey addr txIn) txOut

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
@@ -205,7 +205,7 @@ mkHandle
     countVar =
         IndexerHandle
             { applyAtSlot = \slot bh ops -> do
-                runTransaction (applyAndLog slot ops)
+                runTransaction (applyAndLog slot bh ops)
                 atomically $ do
                     modifyTVar' countVar (+ 1)
                     fireWaiters
@@ -250,11 +250,12 @@ its inverse cannot be recovered from a later @query@.
 -}
 applyAndLog ::
     SlotNo ->
+    BlockHash ->
     [UtxoOp] ->
     Transaction IO Int Cols Op ()
-applyAndLog slot ops = do
+applyAndLog slot bh ops = do
     inverses <- traverse step ops
-    insert RollbackCol slot (reverse inverses)
+    insert RollbackCol slot (bh, reverse inverses)
   where
     step op = do
         inv <- inverseOf op
@@ -364,17 +365,20 @@ rollbackToSlot target = do
 
 {- | Cursor program: from 'lastEntry' walk backwards,
 collecting @(slot, invs)@ pairs while @slot > target@.
-Returns them in descending-slot order.
+Returns them in descending-slot order. The 'BlockHash'
+component of each entry is discarded — only the inverse
+list is needed to undo state, the hash is metadata for
+the resume-point story.
 -}
 collectGreaterThan ::
     (Monad m) =>
     SlotNo ->
-    Cursor m (KV SlotNo [UtxoOp]) [(SlotNo, [UtxoOp])]
+    Cursor m (KV SlotNo (BlockHash, [UtxoOp])) [(SlotNo, [UtxoOp])]
 collectGreaterThan target =
     lastEntry >>= go []
   where
     go acc Nothing = pure (reverse acc)
-    go acc (Just Entry{entryKey = slot, entryValue = invs})
+    go acc (Just Entry{entryKey = slot, entryValue = (_bh, invs)})
         | slot > target =
             prevEntry >>= go ((slot, invs) : acc)
         | otherwise = pure (reverse acc)
@@ -406,7 +410,7 @@ collecting up to @n@ keys.
 collectFirstNKeys ::
     (Monad m) =>
     Int ->
-    Cursor m (KV SlotNo [UtxoOp]) [SlotNo]
+    Cursor m (KV SlotNo (BlockHash, [UtxoOp])) [SlotNo]
 collectFirstNKeys n0 =
     firstEntry >>= go [] n0
   where

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
@@ -50,6 +50,9 @@ module Cardano.Node.Client.UTxOIndexer.Indexer (
     -- * Operations
     UtxoOp (..),
 
+    -- * Replay conflict
+    ApplyConflict (..),
+
     -- * Await observations
     AwaitObservation (..),
 ) where
@@ -71,6 +74,7 @@ import Cardano.Node.Client.UTxOIndexer.Types (
  )
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race)
+import Control.Exception (Exception, throwIO)
 import Control.Concurrent.STM (
     STM,
     TMVar,
@@ -120,6 +124,28 @@ import Database.RocksDB (
     withDBCF,
  )
 
+{- | Thrown by 'applyAtSlot' when 'RollbackCol' already
+has an entry at the requested slot whose 'BlockHash'
+differs from the one the caller is trying to apply.
+
+This means the daemon is being driven with a chain that
+diverges from the one already persisted on disk. State
+is left untouched; resolving the conflict by finding an
+older intersection or rebuilding from Origin is the
+recoverability story (#86), not the storage-only #85.
+
+A same-slot, /same/-hash apply is the silent replay
+guard: it returns @()@ without updating any state.
+-}
+data ApplyConflict = ApplyConflict
+    { acSlot :: !SlotNo
+    , acExistingBlockHash :: !BlockHash
+    , acAttemptedBlockHash :: !BlockHash
+    }
+    deriving stock (Eq, Show)
+
+instance Exception ApplyConflict
+
 {- | An observed @TxIn@ apparition: the slot and block
 hash the daemon was at when it processed the
 creating block, plus the @TxOut@ inserted.
@@ -135,12 +161,21 @@ data AwaitObservation = AwaitObservation
 the indexer state.
 -}
 data IndexerHandle = IndexerHandle
-    { applyAtSlot :: SlotNo -> BlockHash -> [UtxoOp] -> IO ()
+    { applyAtSlot ::
+        SlotNo -> BlockHash -> [UtxoOp] -> IO ()
     -- ^ Atomically apply a batch of create/spend
     -- operations and store the inverse list under the
     -- given slot in 'RollbackCol'. After the
     -- transaction commits, fire any 'awaitTxIn'
     -- waiters whose 'TxIn' was just created.
+    --
+    -- Replay-aware: if 'RollbackCol' already has an
+    -- entry at @slot@ with the /same/ 'BlockHash' the
+    -- call is a silent no-op — state, counter, and
+    -- waiters are all left untouched. With a /different/
+    -- 'BlockHash' an 'ApplyConflict' is thrown;
+    -- 'applyAtSlot' never silently overwrites a
+    -- previously-applied row.
     , rollbackTo :: SlotNo -> IO ()
     -- ^ Roll the index back to the given slot by
     -- replaying inverse-op lists for every slot
@@ -284,15 +319,25 @@ mkHandle
     countVar =
         IndexerHandle
             { applyAtSlot = \slot bh ops -> do
-                runTransaction (applyAndLog slot bh ops)
-                atomically $ do
-                    modifyTVar' countVar (+ 1)
-                    fireWaiters
-                        waitersVar
-                        observedVar
-                        slot
-                        bh
-                        ops
+                outcome <- runTransaction (applyAndLog slot bh ops)
+                case outcome of
+                    Applied ->
+                        atomically $ do
+                            modifyTVar' countVar (+ 1)
+                            fireWaiters
+                                waitersVar
+                                observedVar
+                                slot
+                                bh
+                                ops
+                    AlreadyApplied -> pure ()
+                    Conflict existing _attempted ->
+                        throwIO
+                            ApplyConflict
+                                { acSlot = slot
+                                , acExistingBlockHash = existing
+                                , acAttemptedBlockHash = bh
+                                }
             , rollbackTo = \slot -> do
                 deleted <- runTransaction (rollbackToSlot slot)
                 atomically $ do
@@ -317,10 +362,52 @@ mkHandle
             , awaitTxIn = doAwait waitersVar observedVar
             }
 
-{- | Within one transaction: for each op compute its
-inverse against the current state, apply the op, and
-finally store the reversed list of inverses under
-@slot@ in 'RollbackCol'.
+{- | Internal: outcome of the apply transaction. Private
+to this module — the public API surfaces 'Applied' /
+'AlreadyApplied' as an @IO ()@ (with conflict throwing
+'ApplyConflict').
+-}
+data ApplyResult
+    = Applied
+    | AlreadyApplied
+    | Conflict !BlockHash !BlockHash
+
+{- | Within one transaction: decide whether @slot@ has
+already been applied.
+
+The watermark is 'RollbackCol''s @lastEntry@ — the most
+recent applied @(slot, blockHash)@ pair. We rely on
+this rather than @query RollbackCol slot@ alone because
+finality pruning ('pruneRollbacks') drops the rollback
+rows of older finalized slots; their @(slot,
+blockHash)@ pair is gone from the column even though
+the slot is firmly applied.
+
+Decision tree:
+
+* @slot > tipSlot@ (or column empty) — fresh apply.
+  Compute inverses, apply each op, store the reversed
+  inverse list under @slot@, return 'Applied'.
+* @slot ≤ tipSlot@ — the slot is in the past. We have
+  two cases:
+    * 'RollbackCol' still has a row for @slot@: compare
+      hashes (same → 'AlreadyApplied', differs →
+      'Conflict').
+    * Pruned out — return 'AlreadyApplied'. We cannot
+      detect a hash conflict at a slot whose history
+      we no longer have, but we know the slot was
+      applied (by virtue of being below the tip), so
+      replay-from-Origin must skip it. Detecting fork
+      conflicts past the security parameter is out of
+      scope here (it would require keeping every
+      historical @(slot, hash)@ forever).
+
+Without this watermark check the previous implementation
+had a soft-corruption bug: replay-from-Origin against a
+populated, partially-pruned DB would re-apply early
+slots whose rollback row had been pruned but skip later
+slots whose row survived, resurrecting any UTxO that was
+created early and later spent.
 
 Computing the inverse before applying is essential —
 @query@ inside the same transaction sees buffered
@@ -331,11 +418,34 @@ applyAndLog ::
     SlotNo ->
     BlockHash ->
     [UtxoOp] ->
-    Transaction IO cf Cols op ()
+    Transaction IO cf Cols op ApplyResult
 applyAndLog slot bh ops = do
-    inverses <- traverse step ops
-    insert RollbackCol slot (bh, reverse inverses)
+    mTip <-
+        iterating RollbackCol $
+            fmap toTip <$> lastEntry
+    case mTip of
+        Nothing -> applyFresh
+        Just (tipSlot, _)
+            | slot > tipSlot -> applyFresh
+            | otherwise -> do
+                existing <- query RollbackCol slot
+                case existing of
+                    Nothing ->
+                        -- Pruned: we can't compare hashes,
+                        -- but the slot is below the tip so
+                        -- it has been applied.
+                        pure AlreadyApplied
+                    Just (existingBh, _)
+                        | existingBh == bh -> pure AlreadyApplied
+                        | otherwise ->
+                            pure (Conflict existingBh bh)
   where
+    toTip Entry{entryKey, entryValue = (b, _)} =
+        (entryKey, b)
+    applyFresh = do
+        inverses <- traverse step ops
+        insert RollbackCol slot (bh, reverse inverses)
+        pure Applied
     step op = do
         inv <- inverseOf op
         applyOne op

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
@@ -95,7 +95,8 @@ import Database.KV.Cursor (
     prevEntry,
     seekKey,
  )
-import Database.KV.Database (KV, mkColumns)
+import Data.Dependent.Map (DMap)
+import Database.KV.Database (Column, KV, mkColumns)
 import Database.KV.InMemory (mkInMemoryDatabase)
 import Database.KV.Transaction (
     DSum ((:=>)),
@@ -157,22 +158,48 @@ data IndexerHandle = IndexerHandle
 
 {- | Open an in-memory indexer, run the action with the
 handle, and clean up on exit.
+
+A fresh in-memory database starts empty, but we still
+seed the rollback-log counter via 'countRollbackEntries'
+to keep this constructor's wiring identical to the
+RocksDB one (so any future on-disk shape that reuses
+'mkInMemoryDatabase' for tests reads correctly).
 -}
 withInMemoryIndexer :: (IndexerHandle -> IO a) -> IO a
 withInMemoryIndexer action = do
+    db <- mkInMemoryDatabase indexerColumns
+    runner <- newRunTransaction db
+    initialCount <- runTransaction runner countRollbackEntries
+    waitersVar <- newTVarIO Map.empty
+    observedVar <- newTVarIO Map.empty
+    countVar <- newTVarIO initialCount
+    action (mkHandle runner waitersVar observedVar countVar)
+
+-- | Shared column definitions (same for in-memory and
+-- RocksDB backends).
+indexerColumns :: DMap Cols (Column Int)
+indexerColumns =
     let codecs =
             fromList
                 [ TxInCol :=> txInColCodecs
                 , AddressIndex :=> addressIndexCodecs
                 , RollbackCol :=> rollbackCodecs
                 ]
-        columns = mkColumns [0 :: Int ..] codecs
-    db <- mkInMemoryDatabase columns
-    runner <- newRunTransaction db
-    waitersVar <- newTVarIO Map.empty
-    observedVar <- newTVarIO Map.empty
-    countVar <- newTVarIO (0 :: Int)
-    action (mkHandle runner waitersVar observedVar countVar)
+     in mkColumns [0 :: Int ..] codecs
+
+{- | One-shot scan of 'RollbackCol' returning the entry
+count. O(n) in the column size — called once at startup
+and never again; the in-memory counter handles steady
+state.
+-}
+countRollbackEntries ::
+    Transaction IO Int Cols Op Int
+countRollbackEntries =
+    iterating RollbackCol $
+        firstEntry >>= go 0
+  where
+    go !n Nothing = pure n
+    go !n (Just _) = nextEntry >>= go (n + 1)
 
 -- Internal -------------------------------------------------------
 

--- a/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
@@ -35,6 +35,7 @@ import Cardano.Node.Client.UTxOIndexer.BlockExtract (extractBlock)
 import Cardano.Node.Client.UTxOIndexer.Indexer (
     IndexerHandle (..),
     withInMemoryIndexer,
+    withRocksDBIndexer,
  )
 import Cardano.Node.Client.UTxOIndexer.Server (
     ReadyStatus (..),
@@ -81,18 +82,24 @@ data DaemonConfig = DaemonConfig
     -- ^ Cardano security parameter @k@ — the
     -- rollback-log entry count is capped at this many,
     -- and older entries are dropped after each apply.
+    , dcDbPath :: Maybe FilePath
+    -- ^ When 'Just', open the indexer against a RocksDB
+    -- database at this path; state survives process
+    -- restart. When 'Nothing', use the volatile
+    -- in-memory backend (intended for tests).
     }
     deriving stock (Show)
 
-{- | Open an in-memory indexer, start the NDJSON server
-and the chain-sync follower, and block. Returns when
-either side exits (chain-sync disconnect, server crash,
-etc.) — the caller is expected to supervise.
+{- | Open the indexer (RocksDB if @dcDbPath@ is set,
+in-memory otherwise), start the NDJSON server and the
+chain-sync follower, and block. Returns when either side
+exits (chain-sync disconnect, server crash, etc.) — the
+caller is expected to supervise.
 -}
 runDaemon :: DaemonConfig -> IO ()
 runDaemon cfg = do
     readyVar <- newTVarIO initialReady
-    withInMemoryIndexer $ \idx -> do
+    withIndexer (dcDbPath cfg) $ \idx -> do
         let getReady = readTVarIO readyVar
             chainAction =
                 runChainSyncN2C
@@ -115,6 +122,8 @@ runDaemon cfg = do
             , rsProcessedSlot = Nothing
             , rsSlotsBehind = Nothing
             }
+    withIndexer Nothing = withInMemoryIndexer
+    withIndexer (Just path) = withRocksDBIndexer path
 
 mkIntersector ::
     DaemonConfig ->

--- a/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
@@ -152,6 +152,13 @@ mkFollower cfg readyVar idx = self
             { rollForward = \fetched tip -> do
                 let (slot, ops) = extractBlock (fetchedBlock fetched)
                     bh = pointToBlockHash (fetchedPoint fetched)
+                -- 'applyAtSlot' is replay-aware: same slot
+                -- + same blockhash is a silent no-op; same
+                -- slot + different blockhash throws
+                -- 'ApplyConflict'. Phase A surfaces that
+                -- crash to the caller; phase B (#86) replaces
+                -- it with a rollback to an older retained
+                -- point.
                 applyAtSlot idx slot bh ops
                 _ <- pruneRollbacks idx (dcSecurityParamK cfg)
                 updateReady cfg readyVar slot tip

--- a/test/Cardano/Node/Client/E2E/UTxOIndexerSpec.hs
+++ b/test/Cardano/Node/Client/E2E/UTxOIndexerSpec.hs
@@ -140,6 +140,7 @@ runE2E = do
                         , dcByronEpochSlots = 42
                         , dcReadyThresholdSlots = 60
                         , dcSecurityParamK = 2160
+                        , dcDbPath = Nothing
                         }
             withAsync (runDaemon cfg) $ \daemonThread -> do
                 waitForFile daemonSock 600

--- a/test/Cardano/Node/Client/UTxOIndexer/PersistenceSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/PersistenceSpec.hs
@@ -1,0 +1,114 @@
+{- |
+Module      : Cardano.Node.Client.UTxOIndexer.PersistenceSpec
+Description : RocksDB-backed indexer survives close + reopen
+License     : Apache-2.0
+
+Opens an indexer against a RocksDB database in a tempdir,
+applies a few blocks, closes the handle, reopens against
+the same path, and verifies that the state — address
+index, rollback log, and entry counter — is intact.
+-}
+module Cardano.Node.Client.UTxOIndexer.PersistenceSpec (spec) where
+
+import Cardano.Node.Client.UTxOIndexer.Indexer (
+    IndexerHandle (..),
+    UtxoOp (..),
+    withRocksDBIndexer,
+ )
+import Cardano.Node.Client.UTxOIndexer.Types (
+    Address (..),
+    BlockHash (..),
+    SlotNo (..),
+    TxIn (..),
+    TxOut (..),
+ )
+import Data.ByteString qualified as BS
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec =
+    describe "Cardano.Node.Client.UTxOIndexer (RocksDB)" $ do
+        it "address index survives close + reopen" $
+            withTempDB $ \dbPath -> do
+                let addr = Address (BS.replicate 29 0xAA)
+                    txin = TxIn (BS.replicate 32 0x11) 0
+                    txout = TxOut "value-bytes-0"
+                withRocksDBIndexer dbPath $ \h ->
+                    applyAtSlot
+                        h
+                        (SlotNo 1)
+                        testBlockHash
+                        [UtxoCreate txin addr txout]
+                withRocksDBIndexer dbPath $ \h -> do
+                    xs <- snapshotAt h addr
+                    xs `shouldBe` [(txin, txout)]
+
+        it "rollback log survives — rollback after reopen undoes prior apply" $
+            withTempDB $ \dbPath -> do
+                let addr = Address (BS.replicate 29 0xAA)
+                    txin = TxIn (BS.replicate 32 0x11) 0
+                withRocksDBIndexer dbPath $ \h ->
+                    applyAtSlot
+                        h
+                        (SlotNo 5)
+                        testBlockHash
+                        [UtxoCreate txin addr (TxOut "v")]
+                withRocksDBIndexer dbPath $ \h -> do
+                    rollbackTo h (SlotNo 4)
+                    xs <- snapshotAt h addr
+                    xs `shouldBe` []
+
+        it "rollback-log counter is rebuilt on reopen" $
+            withTempDB $ \dbPath -> do
+                let addr = Address (BS.replicate 29 0xAA)
+                    mk tid =
+                        UtxoCreate
+                            (TxIn (BS.replicate 32 tid) 0)
+                            addr
+                            (TxOut (BS.singleton tid))
+                withRocksDBIndexer dbPath $ \h -> do
+                    applyAtSlot h (SlotNo 1) testBlockHash [mk 0x01]
+                    applyAtSlot h (SlotNo 2) testBlockHash [mk 0x02]
+                    applyAtSlot h (SlotNo 3) testBlockHash [mk 0x03]
+                -- Reopen and ask the prune endpoint to keep just
+                -- one. It must report 2 deletions — proving the
+                -- counter was rebuilt to 3 from the on-disk state,
+                -- not reset to 0 on reopen.
+                withRocksDBIndexer dbPath $ \h -> do
+                    deleted <- pruneRollbacks h 1
+                    deleted `shouldBe` 2
+
+        it "spends from a previous session resolve their address" $
+            -- Spending a UTxO inserted in a prior session
+            -- requires reading the (TxIn → Address) mapping from
+            -- on-disk state. If TxInCol weren't persisted, the
+            -- post-reopen UtxoSpend would be silently no-op.
+            withTempDB $ \dbPath -> do
+                let addr = Address (BS.replicate 29 0xAA)
+                    txin = TxIn (BS.replicate 32 0x11) 0
+                withRocksDBIndexer dbPath $ \h ->
+                    applyAtSlot
+                        h
+                        (SlotNo 1)
+                        testBlockHash
+                        [UtxoCreate txin addr (TxOut "v")]
+                withRocksDBIndexer dbPath $ \h -> do
+                    applyAtSlot
+                        h
+                        (SlotNo 2)
+                        testBlockHash
+                        [UtxoSpend txin]
+                    xs <- snapshotAt h addr
+                    xs `shouldBe` []
+
+-- * Test helpers
+
+withTempDB :: (FilePath -> IO a) -> IO a
+withTempDB action =
+    withSystemTempDirectory "utxo-indexer-rocksdb" $ \tmp ->
+        action (tmp </> "db")
+
+testBlockHash :: BlockHash
+testBlockHash = BlockHash (BS.replicate 32 0)

--- a/test/Cardano/Node/Client/UTxOIndexer/PersistenceSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/PersistenceSpec.hs
@@ -12,6 +12,7 @@ module Cardano.Node.Client.UTxOIndexer.PersistenceSpec (spec) where
 
 import Cardano.Node.Client.UTxOIndexer.Indexer (
     ApplyConflict (..),
+    AwaitObservation (..),
     IndexerHandle (..),
     UtxoOp (..),
     withRocksDBIndexer,
@@ -25,6 +26,7 @@ import Cardano.Node.Client.UTxOIndexer.Types (
  )
 import Control.Exception (try)
 import Data.ByteString qualified as BS
+import Data.Word (Word64)
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec (
@@ -128,9 +130,10 @@ spec =
                         , (SlotNo 2, testBlockHash, [mk 0x02])
                         , (SlotNo 3, testBlockHash, [mk 0x03])
                         ]
-                    apply h = mapM_
-                        (\(s, b, o) -> applyAtSlot h s b o)
-                        blocks
+                    apply h =
+                        mapM_
+                            (\(s, b, o) -> applyAtSlot h s b o)
+                            blocks
                 withRocksDBIndexer dbPath $ \h -> apply h
                 -- Reopen and replay the entire stream — every call
                 -- should be a no-op.
@@ -190,6 +193,52 @@ spec =
                     apply h spend
                     snapshotAt h addr >>= (`shouldBe` [])
 
+        it "awaitTxIn returns immediately for an indexed TxIn after reopen" $
+            -- The in-process @observedVar@ is empty after reopen.
+            -- Persistent 'ObservationCol' must fill the gap so
+            -- 'awaitTxIn' on an already-indexed unspent TxIn
+            -- returns immediately rather than timing out.
+            withTempDB $ \dbPath -> do
+                let addr = Address (BS.replicate 29 0xAA)
+                    txin = TxIn (BS.replicate 32 0x77) 0
+                    txout = TxOut "value-await"
+                    bh = BlockHash (BS.replicate 32 0xBB)
+                withRocksDBIndexer dbPath $ \h ->
+                    applyAtSlot
+                        h
+                        (SlotNo 7)
+                        bh
+                        [UtxoCreate txin addr txout]
+                withRocksDBIndexer dbPath $ \h -> do
+                    -- 1-second timeout: if the fast path is broken,
+                    -- this returns Nothing; if it works, the call
+                    -- returns immediately with the observation.
+                    obs <- awaitTxIn h txin (Just 1)
+                    obs `shouldBe` Just (mkObservation 7 bh txout)
+
+        it "awaitTxIn after spend across reopen returns Nothing on timeout" $
+            -- A TxIn that's been spent should not have a persistent
+            -- observation — the spend deleted it. After reopen,
+            -- 'awaitTxIn' falls back to the slow path and times out.
+            withTempDB $ \dbPath -> do
+                let addr = Address (BS.replicate 29 0xAA)
+                    txin = TxIn (BS.replicate 32 0x88) 0
+                    bh = BlockHash (BS.replicate 32 0xBB)
+                withRocksDBIndexer dbPath $ \h -> do
+                    applyAtSlot
+                        h
+                        (SlotNo 1)
+                        bh
+                        [UtxoCreate txin addr (TxOut "v")]
+                    applyAtSlot
+                        h
+                        (SlotNo 2)
+                        (BlockHash (BS.replicate 32 0xCC))
+                        [UtxoSpend txin]
+                withRocksDBIndexer dbPath $ \h -> do
+                    obs <- awaitTxIn h txin (Just 1)
+                    obs `shouldBe` Nothing
+
         it "same slot + different blockhash is rejected" $
             -- Two different blocks claiming the same slot is the
             -- "I'm on a different fork than what's persisted"
@@ -213,7 +262,7 @@ spec =
                                 h
                                 (SlotNo 5)
                                 bh2
-                                [UtxoCreate
+                                [ UtxoCreate
                                     txin
                                     addr
                                     (TxOut "v2")
@@ -236,3 +285,12 @@ withTempDB action =
 
 testBlockHash :: BlockHash
 testBlockHash = BlockHash (BS.replicate 32 0)
+
+mkObservation ::
+    Word64 -> BlockHash -> TxOut -> AwaitObservation
+mkObservation slot bh txOut =
+    AwaitObservation
+        { aoSlot = SlotNo slot
+        , aoBlockHash = bh
+        , aoTxOut = txOut
+        }

--- a/test/Cardano/Node/Client/UTxOIndexer/PersistenceSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/PersistenceSpec.hs
@@ -11,6 +11,7 @@ index, rollback log, and entry counter — is intact.
 module Cardano.Node.Client.UTxOIndexer.PersistenceSpec (spec) where
 
 import Cardano.Node.Client.UTxOIndexer.Indexer (
+    ApplyConflict (..),
     IndexerHandle (..),
     UtxoOp (..),
     withRocksDBIndexer,
@@ -22,10 +23,17 @@ import Cardano.Node.Client.UTxOIndexer.Types (
     TxIn (..),
     TxOut (..),
  )
+import Control.Exception (try)
 import Data.ByteString qualified as BS
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
-import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec (
+    Spec,
+    describe,
+    it,
+    shouldBe,
+    shouldSatisfy,
+ )
 
 spec :: Spec
 spec =
@@ -102,6 +110,122 @@ spec =
                         [UtxoSpend txin]
                     xs <- snapshotAt h addr
                     xs `shouldBe` []
+
+        it "replaying same blocks from Origin is a silent no-op" $
+            -- Mimic the daemon restarting from Origin against a
+            -- populated DB: re-apply the same (slot, blockhash, ops)
+            -- triples and verify the rollback log doesn't grow,
+            -- the counter doesn't drift, and snapshotAt is stable.
+            withTempDB $ \dbPath -> do
+                let addr = Address (BS.replicate 29 0xAA)
+                    mk tid =
+                        UtxoCreate
+                            (TxIn (BS.replicate 32 tid) 0)
+                            addr
+                            (TxOut (BS.singleton tid))
+                    blocks =
+                        [ (SlotNo 1, testBlockHash, [mk 0x01])
+                        , (SlotNo 2, testBlockHash, [mk 0x02])
+                        , (SlotNo 3, testBlockHash, [mk 0x03])
+                        ]
+                    apply h = mapM_
+                        (\(s, b, o) -> applyAtSlot h s b o)
+                        blocks
+                withRocksDBIndexer dbPath $ \h -> apply h
+                -- Reopen and replay the entire stream — every call
+                -- should be a no-op.
+                withRocksDBIndexer dbPath $ \h -> do
+                    apply h
+                    -- Counter unchanged: prune to keep 1 must
+                    -- delete exactly 2, which only holds if the
+                    -- replay didn't bump the in-memory counter.
+                    deleted <- pruneRollbacks h 1
+                    deleted `shouldBe` 2
+                -- Reopen once more and verify the address index
+                -- still has all three entries (replay didn't
+                -- corrupt anything).
+                withRocksDBIndexer dbPath $ \h -> do
+                    xs <- snapshotAt h addr
+                    fmap (txInId . fst) xs
+                        `shouldBe` [ BS.replicate 32 0x01
+                                   , BS.replicate 32 0x02
+                                   , BS.replicate 32 0x03
+                                   ]
+
+        it "replaying from Origin after rollback-log prune does not resurrect spent UTxOs" $
+            -- The replay guard cannot trust 'RollbackCol[slot]'
+            -- in isolation: finality pruning (#83) drops the
+            -- rollback rows of older finalized slots, so a
+            -- daemon that restarted from Origin against a
+            -- partially-pruned DB would re-apply the create
+            -- whose row was pruned but skip the spend whose row
+            -- survived, resurrecting the spent UTxO.
+            --
+            -- The guard uses 'RollbackCol''s @lastEntry@ as the
+            -- watermark instead — anything @<= tipSlot@ counts
+            -- as already applied even when its rollback row has
+            -- been pruned.
+            withTempDB $ \dbPath -> do
+                let addr = Address (BS.replicate 29 0xAA)
+                    txin = TxIn (BS.replicate 32 0x42) 0
+                    create =
+                        ( SlotNo 1
+                        , BlockHash (BS.replicate 32 0x01)
+                        , [UtxoCreate txin addr (TxOut "created")]
+                        )
+                    spend =
+                        ( SlotNo 2
+                        , BlockHash (BS.replicate 32 0x02)
+                        , [UtxoSpend txin]
+                        )
+                    apply h (s, b, ops) = applyAtSlot h s b ops
+                withRocksDBIndexer dbPath $ \h -> do
+                    apply h create
+                    apply h spend
+                    snapshotAt h addr >>= (`shouldBe` [])
+                    deleted <- pruneRollbacks h 1
+                    deleted `shouldBe` 1
+                withRocksDBIndexer dbPath $ \h -> do
+                    apply h create
+                    apply h spend
+                    snapshotAt h addr >>= (`shouldBe` [])
+
+        it "same slot + different blockhash is rejected" $
+            -- Two different blocks claiming the same slot is the
+            -- "I'm on a different fork than what's persisted"
+            -- signal. 'applyAtSlot' must throw 'ApplyConflict' and
+            -- not corrupt state.
+            withTempDB $ \dbPath -> do
+                let addr = Address (BS.replicate 29 0xAA)
+                    txin = TxIn (BS.replicate 32 0x11) 0
+                    bh1 = BlockHash (BS.replicate 32 0xAA)
+                    bh2 = BlockHash (BS.replicate 32 0xBB)
+                withRocksDBIndexer dbPath $ \h ->
+                    applyAtSlot
+                        h
+                        (SlotNo 5)
+                        bh1
+                        [UtxoCreate txin addr (TxOut "v1")]
+                withRocksDBIndexer dbPath $ \h -> do
+                    result <-
+                        try @ApplyConflict $
+                            applyAtSlot
+                                h
+                                (SlotNo 5)
+                                bh2
+                                [UtxoCreate
+                                    txin
+                                    addr
+                                    (TxOut "v2")
+                                ]
+                    result `shouldSatisfy` isApplyConflict
+                    -- State at @addr@ must reflect the original
+                    -- bh1 apply, not the rejected bh2 apply.
+                    xs <- snapshotAt h addr
+                    xs `shouldBe` [(txin, TxOut "v1")]
+  where
+    isApplyConflict (Left ApplyConflict{acSlot = SlotNo 5}) = True
+    isApplyConflict _ = False
 
 -- * Test helpers
 

--- a/test/unit-main.hs
+++ b/test/unit-main.hs
@@ -6,6 +6,7 @@ import Cardano.Node.Client.BalanceSpec qualified as BalanceSpec
 import Cardano.Node.Client.TxBuildGoldenSpec qualified as TxBuildGoldenSpec
 import Cardano.Node.Client.TxBuildSpec qualified as TxBuildSpec
 import Cardano.Node.Client.UTxOIndexer.IndexerSpec qualified as UTxOIndexerSpec
+import Cardano.Node.Client.UTxOIndexer.PersistenceSpec qualified as UTxOIndexerPersistenceSpec
 import Cardano.Node.Client.UTxOIndexer.ServerSpec qualified as UTxOIndexerServerSpec
 import Cardano.Node.Client.UTxOIndexer.TypesSpec qualified as UTxOIndexerTypesSpec
 import Data.List.SampleFibonacciSpec qualified as SampleFibonacciSpec
@@ -19,3 +20,4 @@ main = hspec $ do
     UTxOIndexerTypesSpec.spec
     UTxOIndexerSpec.spec
     UTxOIndexerServerSpec.spec
+    UTxOIndexerPersistenceSpec.spec


### PR DESCRIPTION
Closes [#85](https://github.com/lambdasistemi/cardano-node-clients/issues/85).

Phase A of the persistence story. Swaps the in-memory backend for RocksDB so the address index, rollback log, observation index, and entry counter all survive process restart. Phase B (resume chain-sync from the saved tip rather than re-syncing from Origin) is [#86](https://github.com/lambdasistemi/cardano-node-clients/issues/86) and lands in a follow-up PR.

The amended #85 calls out that "persistent storage is not automatically safe if the daemon restarts from Origin against a populated DB". This PR makes `applyAtSlot` replay-aware so origin-replays are correct, and adds a persistent `ObservationCol` so `awaitTxIn` keeps its fast-path semantics across reopen.

## API change

A new constructor sits next to the in-memory one:

```haskell
withInMemoryIndexer  :: (IndexerHandle -> IO a) -> IO a
withRocksDBIndexer   :: FilePath -> (IndexerHandle -> IO a) -> IO a
```

`Daemon.DaemonConfig` gains `dcDbPath :: Maybe FilePath`. `Main` exposes it as `--db-path PATH`. Omitted ⇒ in-memory (intended for tests / ephemeral demos); supplied ⇒ RocksDB at that path.

`applyAtSlot` is now replay-aware:
- Same slot + same blockhash → silent no-op (state, counter, waiters all untouched).
- Same slot + different blockhash → throws `ApplyConflict { acSlot, acExistingBlockHash, acAttemptedBlockHash }`. State is left untouched. The daemon panics on this for now; #86 replaces the panic with a rollback to an older retained point.

`IndexerHandle.awaitTxIn` keeps its `Maybe AwaitObservation` shape and gains a persistent fast path: a miss in the in-process map falls back to a join of `ObservationCol`, `TxInCol`, and `AddressIndex`, so a UTxO created in a prior session is answerable in O(1) after reopen.

## Schema

Two column changes:

1. `RollbackCol` value goes from `[UtxoOp]` to `(BlockHash, [UtxoOp])`. Drives both the replay guard and #86's resume tip.
2. New `ObservationCol :: KV TxIn (SlotNo, BlockHash)`, written on every `UtxoCreate` and deleted on every `UtxoSpend`. Keeps `awaitTxIn`'s fast path persistent.

Total RocksDB column families: 4 — `utxo-indexer.txin`, `utxo-indexer.address`, `utxo-indexer.observation`, `utxo-indexer.rollback`.

## Patch series

| # | Concern |
|---|---|
| 1 | `RollbackCol` value carries `BlockHash` |
| 2 | seed rollback counter from on-disk scan on startup |
| 3 | `withRocksDBIndexer` constructor (`Cols` + helpers `cf`/`op`-polymorphic) |
| 4 | persistence unit test — close + reopen survives address index, rollback log, counter, TxIn→Address |
| 5 | `Daemon` `--db-path` flag + Main wiring |
| 6 | replay guard + typed `ApplyConflict` on `applyAtSlot` (replay-same is no-op, replay-different throws) |
| 7 | persistent `ObservationCol` so `awaitTxIn` fast-path survives reopen |

Each commit compiles + tests on its own.

## Testing

- 8 new unit tests under `Cardano.Node.Client.UTxOIndexer.PersistenceSpec` (127 unit total, was 119):
  - address index survives close + reopen
  - rollback log survives — rollback after reopen undoes prior apply
  - rollback-log counter is rebuilt on reopen
  - spends from a previous session resolve their address (TxInCol persistence)
  - replaying same blocks from Origin is a silent no-op (replay guard)
  - same slot + different blockhash is rejected with `ApplyConflict` (replay conflict)
  - `awaitTxIn` returns immediately for an indexed TxIn after reopen (ObservationCol)
  - `awaitTxIn` after spend across reopen returns Nothing on timeout (ObservationCol delete)
- Existing 12 / 12 e2e suite still green; in-memory backend path is unchanged.

`just ci` is green: 127 / 127 unit, 12 / 12 e2e, fourmolu, cabal-fmt, hlint.

## Known limitation (carried into #86)

A rollback that restores a previously-spent UTxO repopulates `ObservationCol` with the rolled-back slot's `(SlotNo, BlockHash)` rather than the UTxO's original creation slot. The TxOut is still correct — only the observation slot/hash drifts. This is acceptable for #85's contract ("returns immediately with the same `AwaitObservation` shape") but worth noting; tightening the post-rollback observation precision would require carrying original-slot metadata in the inverse-op log, which is out of scope for this patch.