### PR TITLE
refactor(utxo-indexer): use chain-follower's Rollbacks library

### DIFF
--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -162,6 +162,7 @@ library utxo-indexer-lib
     , async
     , base
     , bytestring
+    , chain-follower
     , containers
     , data-default-class
     , dependent-map

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Columns.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Columns.hs
@@ -19,15 +19,16 @@ Three columns:
   @lenByte || address || txId || ix@ so a cursor seek to
   @lenByte || address@ yields every UTxO at that address
   with its full 'TxOut' inline (no second-stage lookup).
-* 'RollbackCol' :: @KV SlotNo (BlockHash, [UtxoOp])@ —
-  slot-tagged inverse-op log used to undo apply-block
-  writes on a chain-sync rollback. Keyed by 'SlotNo'
-  (8-byte BE) so cursor ordering matches numeric slot
-  ordering. The 'BlockHash' is the hash of the block
-  whose application produced the inverse list — recorded
-  here so a future restart-recoverability story can read
-  the latest entry to derive the resume @Point@ without
-  a separate tip column.
+* 'RollbackCol' :: @KV SlotNo ('RollbackPoint' 'UtxoOp'
+  'BlockHash')@ — slot-tagged inverse-op log used to
+  undo apply-block writes on a chain-sync rollback.
+  Keyed by 'SlotNo' (8-byte BE) so cursor ordering
+  matches numeric slot ordering. The value uses
+  @chain-follower@'s canonical 'RollbackPoint' shape —
+  @rpInverses@ holds the reverse-ordered op list to
+  replay, @rpMeta@ holds the block hash so a startup
+  can read the latest entry to derive the resume
+  @Point@ without a separate tip column.
 
 Both the in-memory and RocksDB backends share these
 column definitions verbatim — the column choice happens
@@ -64,6 +65,7 @@ import Cardano.Node.Client.UTxOIndexer.Types (
     txInFromBytes,
     txInToBytes,
  )
+import ChainFollower.Rollbacks.Types (RollbackPoint (..))
 import Control.Lens (Prism', prism')
 import Data.Bits (shiftL, shiftR, (.&.), (.|.))
 import Data.ByteString (ByteString)
@@ -90,13 +92,13 @@ data Cols c where
     -- pairs directly.
     AddressIndex :: Cols (KV AddrKey TxOut)
     -- | Rollback log: 'SlotNo' →
-    -- @('BlockHash', [inverse ops])@. The list is in the
-    -- order to apply on rollback (i.e. already reversed
-    -- relative to the original apply order). The
-    -- 'BlockHash' is the hash of the block that produced
-    -- this entry — recorded so a future startup can
-    -- recover the resume @Point@ from the latest entry.
-    RollbackCol :: Cols (KV SlotNo (BlockHash, [UtxoOp]))
+    -- @'RollbackPoint' 'UtxoOp' 'BlockHash'@. Uses
+    -- @chain-follower@'s canonical shape: @rpInverses@
+    -- is the reverse-ordered op list (already in apply
+    -- order on rollback), @rpMeta@ holds the block hash
+    -- so a future startup can recover the resume
+    -- @Point@ from the latest entry.
+    RollbackCol :: Cols (KV SlotNo (RollbackPoint UtxoOp BlockHash))
     -- | Observation index: every live (i.e. created and
     -- not yet spent) 'TxIn' carries the @('SlotNo',
     -- 'BlockHash')@ of the block that created it. Used
@@ -155,11 +157,12 @@ observationColCodecs =
 
 {- | Codecs for the rollback-log column. The on-disk
 value is @blockHashLen(4 BE) || blockHash || ops@ where
-@ops@ uses the stable hand-rolled form (see 'encodeOps')
-so a future RocksDB swap can read entries written by the
-in-memory backend.
+@ops@ uses the stable hand-rolled form (see 'encodeOps').
+Decoded into @chain-follower@'s 'RollbackPoint' shape so
+the @Rollbacks.*@ library functions accept it directly.
 -}
-rollbackCodecs :: Codecs (KV SlotNo (BlockHash, [UtxoOp]))
+rollbackCodecs ::
+    Codecs (KV SlotNo (RollbackPoint UtxoOp BlockHash))
 rollbackCodecs =
     Codecs
         { keyCodec = slotPrism
@@ -196,18 +199,34 @@ txOutPrism = prism' unTxOut (Just . TxOut)
 slotPrism :: Prism' ByteString SlotNo
 slotPrism = prism' slotToBytes slotFromBytes
 
-{- | Codec for the @(BlockHash, [UtxoOp])@ rollback
-entry: @blockHashLen(4 BE) || blockHash || encodeOps@.
+{- | Codec for the rollback entry. On-disk shape stays
+@blockHashLen(4 BE) || blockHash || encodeOps@; we just
+wrap/unwrap @chain-follower@'s 'RollbackPoint'. The
+'BlockHash' lives in @rpMeta@ as @Just bh@ — the indexer
+always records a hash, so we never produce or accept
+@Nothing@ on disk.
 -}
-rollbackEntryPrism :: Prism' ByteString (BlockHash, [UtxoOp])
+rollbackEntryPrism ::
+    Prism' ByteString (RollbackPoint UtxoOp BlockHash)
 rollbackEntryPrism = prism' encode decode
   where
-    encode (BlockHash bh, ops) =
-        lenPrefixed bh <> encodeOps ops
+    encode RollbackPoint{rpInverses, rpMeta} =
+        case rpMeta of
+            Just (BlockHash bh) ->
+                lenPrefixed bh <> encodeOps rpInverses
+            Nothing ->
+                error
+                    "rollbackEntryPrism: encountered \
+                    \RollbackPoint with rpMeta = Nothing; \
+                    \indexer always records a block hash."
     decode bs0 = do
         (bhBs, rest) <- readLenPrefixed bs0
         ops <- decodeOps rest
-        Just (BlockHash bhBs, ops)
+        Just
+            RollbackPoint
+                { rpInverses = ops
+                , rpMeta = Just (BlockHash bhBs)
+                }
 
 {- | Codec for the @('SlotNo', 'BlockHash')@ observation
 entry: @slotBytes(8 BE) || blockHashLen(4 BE) || blockHash@.

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
@@ -73,6 +73,10 @@ import Cardano.Node.Client.UTxOIndexer.Types (
     TxIn (..),
     TxOut,
  )
+import ChainFollower.Rollbacks.Store qualified as Rollbacks
+import ChainFollower.Rollbacks.Types (
+    RollbackPoint (..),
+ )
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race)
 import Control.Concurrent.STM (
@@ -351,18 +355,15 @@ mkHandle
                     pruneObservedAfter observedVar slot
             , pruneRollbacks = \maxKeep -> do
                 count <- readTVarIO countVar
-                let excess = count - maxKeep
-                if excess <= 0
-                    then pure 0
-                    else do
-                        deleted <-
-                            runTransaction
-                                (pruneOldest excess)
-                        atomically $
-                            modifyTVar'
-                                countVar
-                                (subtract deleted)
-                        pure deleted
+                deleted <-
+                    runTransaction $
+                        Rollbacks.pruneExcess
+                            RollbackCol
+                            count
+                            maxKeep
+                atomically $
+                    modifyTVar' countVar (subtract deleted)
+                pure deleted
             , snapshotAt =
                 runTransaction . iterating AddressIndex . scanAddress
             , awaitTxIn =
@@ -427,12 +428,10 @@ applyAndLog ::
     [UtxoOp] ->
     Transaction IO cf Cols op ApplyResult
 applyAndLog slot bh ops = do
-    mTip <-
-        iterating RollbackCol $
-            fmap toTip <$> lastEntry
-    case mTip of
+    mTipSlot <- Rollbacks.queryTip RollbackCol
+    case mTipSlot of
         Nothing -> applyFresh
-        Just (tipSlot, _)
+        Just tipSlot
             | slot > tipSlot -> applyFresh
             | otherwise -> do
                 existing <- query RollbackCol slot
@@ -442,16 +441,27 @@ applyAndLog slot bh ops = do
                         -- but the slot is below the tip so
                         -- it has been applied.
                         pure AlreadyApplied
-                    Just (existingBh, _)
+                    Just RollbackPoint{rpMeta = Just existingBh}
                         | existingBh == bh -> pure AlreadyApplied
                         | otherwise ->
                             pure (Conflict existingBh bh)
+                    Just RollbackPoint{rpMeta = Nothing} ->
+                        -- Indexer always records rpMeta = Just bh;
+                        -- a Nothing here is a corruption / schema
+                        -- drift signal, not a normal state.
+                        error
+                            "applyAndLog: RollbackPoint with rpMeta \
+                            \= Nothing — schema drift"
   where
-    toTip Entry{entryKey, entryValue = (b, _)} =
-        (entryKey, b)
     applyFresh = do
         inverses <- traverse step ops
-        insert RollbackCol slot (bh, reverse inverses)
+        Rollbacks.storeRollbackPoint
+            RollbackCol
+            slot
+            RollbackPoint
+                { rpInverses = reverse inverses
+                , rpMeta = Just bh
+                }
         pure Applied
     step op = do
         inv <- inverseOf op
@@ -625,53 +635,23 @@ collectGreaterThan ::
     SlotNo ->
     Cursor
         m
-        (KV SlotNo (BlockHash, [UtxoOp]))
+        (KV SlotNo (RollbackPoint UtxoOp BlockHash))
         [(SlotNo, BlockHash, [UtxoOp])]
 collectGreaterThan target =
     lastEntry >>= go []
   where
     go acc Nothing = pure (reverse acc)
-    go acc (Just Entry{entryKey = slot, entryValue = (bh, invs)})
+    go acc (Just Entry{entryKey = slot, entryValue = rp})
         | slot > target =
-            prevEntry >>= go ((slot, bh, invs) : acc)
-        | otherwise = pure (reverse acc)
-
-{- | Drop the @excess@ oldest rollback-log entries.
-Walks 'RollbackCol' from 'firstEntry' forward up to
-@excess@ steps and deletes each visited key. Returns
-the number of entries actually deleted (≤ @excess@;
-fewer if the column has fewer than @excess@ entries).
-
-Caller maintains the entry count externally — this
-function does not re-scan the column to size it.
--}
-pruneOldest ::
-    Int ->
-    Transaction IO cf Cols op Int
-pruneOldest excess
-    | excess <= 0 = pure 0
-    | otherwise = do
-        keys <-
-            iterating RollbackCol $
-                collectFirstNKeys excess
-        traverse_ (delete RollbackCol) keys
-        pure (length keys)
-
-{- | Cursor program: from 'firstEntry' walk forward,
-collecting up to @n@ keys.
--}
-collectFirstNKeys ::
-    (Monad m) =>
-    Int ->
-    Cursor m (KV SlotNo (BlockHash, [UtxoOp])) [SlotNo]
-collectFirstNKeys n0 =
-    firstEntry >>= go [] n0
-  where
-    go acc 0 _ = pure (reverse acc)
-    go acc _ Nothing = pure (reverse acc)
-    go acc n (Just Entry{entryKey})
-        | n > 0 =
-            nextEntry >>= go (entryKey : acc) (n - 1)
+            let bh = case rpMeta rp of
+                    Just b -> b
+                    Nothing ->
+                        error
+                            "collectGreaterThan: \
+                            \RollbackPoint with rpMeta \
+                            \= Nothing — schema drift"
+                invs = rpInverses rp
+             in prevEntry >>= go ((slot, bh, invs) : acc)
         | otherwise = pure (reverse acc)
 
 -- | Inverse of a single op against current state.


### PR DESCRIPTION
Closes [#88](https://github.com/lambdasistemi/cardano-node-clients/issues/88).

Pure refactor — no behavior change. The utxo-indexer's `RollbackCol` and the apply / rollback / prune machinery were hand-rolled instead of reusing [`chain-follower`](https://github.com/cardano-scaling/chain-follower)'s `ChainFollower.Rollbacks.{Column,Store,Types}` library that MPFS / cardano-utxo-csmt already depend on. This PR flips the indexer onto the library so [#86](https://github.com/lambdasistemi/cardano-node-clients/issues/86) (recoverability) can build on `Rollbacks.armageddonCleanup` and `queryHistory` rather than carrying its own copies.

## Schema change

`RollbackCol`'s value type goes from `(BlockHash, [UtxoOp])` to chain-follower's canonical `RollbackPoint UtxoOp BlockHash`:

```haskell
data RollbackPoint inv meta = RollbackPoint
    { rpInverses :: [inv]
    , rpMeta :: Maybe meta
    }
```

The on-disk byte form is unchanged (`blockHashLen(4 BE) || blockHash || encodeOps`). `rollbackEntryPrism` just wraps/unwraps `RollbackPoint`. The indexer's invariant is `rpMeta = Just bh` (we always record a hash); the codec and the consumers treat `rpMeta = Nothing` as a corruption / schema-drift signal.

## Delegations

- `applyAtSlot`'s replay-guard reads `Rollbacks.queryTip RollbackCol` instead of a custom `lastEntry` walk.
- `applyAtSlot`'s fresh-apply path calls `Rollbacks.storeRollbackPoint` (a thin alias for `insert`) instead of writing the tuple directly.
- `pruneRollbacks` calls `Rollbacks.pruneExcess` directly. Local `pruneOldest` + `collectFirstNKeys` deleted.

`rollbackToSlot` keeps its custom walk for now: chain-follower's `Rollbacks.rollbackTo` callback receives only `RollbackPoint` (no key), but the indexer's `applyOne` needs `(slot, blockhash)` to keep `ObservationCol` consistent on inverse-create restoration. Migrating that path is an internal-API question for chain-follower, out of scope here.

## Why not also adopt `Runner.Phase`

`ChainFollower.Runner.Phase` (Restoring/Following + auto-prune state machine) is the next layer up. It would be a meaningful follow-up — but it changes how `Daemon.runDaemon` interacts with chain-sync, which is more naturally folded into [#86](https://github.com/lambdasistemi/cardano-node-clients/issues/86)'s recoverability work. Filing as a separate consideration for that PR.

## Testing

`just ci` is green: 127 / 127 unit, 12 / 12 e2e, fourmolu, cabal-fmt, hlint. No test changes — the refactor is structural and the on-disk shape is identical, so existing coverage exercises the new code paths transparently.