### PR TITLE
ci: stub publish-images workflow to populate GHCR package

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -1,0 +1,79 @@
+name: "Publish docker images"
+
+# Stub workflow that publishes a placeholder image to
+# GHCR so the package exists on the registry and can be
+# made public. Real per-component publishing replaces
+# the body once a real cardano-tx-generator-image flake
+# output lands on main (PR #94).
+#
+# Triggers: manual dispatch from any branch, plus push
+# to main. workflow_dispatch requires the workflow to
+# exist on the default branch first — which is the whole
+# point of merging this stub.
+
+env:
+  REGISTRY: ghcr.io/lambdasistemi/cardano-node-clients
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Image short-name to publish"
+        required: true
+        default: "cardano-tx-generator"
+      tag:
+        description: "Override tag (default = git short SHA)"
+        required: false
+        default: ""
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-stub:
+    name: publish placeholder image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          TAG="${{ inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            TAG="${GITHUB_SHA::7}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve image short-name
+        id: image
+        run: |
+          NAME="${{ inputs.image }}"
+          if [ -z "$NAME" ]; then
+            NAME="cardano-tx-generator"
+          fi
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull placeholder, retag, push
+        run: |
+          docker pull alpine:3.20
+          docker tag alpine:3.20 \
+            ${REGISTRY}/${{ steps.image.outputs.name }}:${{ steps.tag.outputs.tag }}
+          docker push \
+            ${REGISTRY}/${{ steps.image.outputs.name }}:${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
Adds a minimal `publish-images.yaml` so the GHCR package gets created and `workflow_dispatch` becomes available from any branch.

## Why a stub

GitHub Actions `workflow_dispatch` requires the workflow to exist on the default branch. To populate the package on GHCR — a prerequisite for flipping its visibility to public — we land this skeleton first, then dispatch it to push a placeholder image. Once the package is registered + public, [#94](https://github.com/lambdasistemi/cardano-node-clients/pull/94) supplies the real per-image build (`nix build .#cardano-tx-generator-image`) that replaces this body.

## What it does

- Triggers: `workflow_dispatch` (with `image` and `tag` inputs), `push` to `main`.
- Pulls `alpine:3.20` and re-tags it as `ghcr.io/lambdasistemi/cardano-node-clients/<image>:<tag>`.
- Pushes to GHCR using the workflow's `GITHUB_TOKEN` with `packages: write`.

## After merge

1. Visit Actions → Publish docker images → Run workflow on `main`.
2. Wait for the run to finish — the placeholder image lands at `ghcr.io/lambdasistemi/cardano-node-clients/cardano-tx-generator`.
3. Visit https://github.com/orgs/lambdasistemi/packages/container/cardano-node-clients%2Fcardano-tx-generator/settings and toggle visibility to **Public**.
4. Once [#94](https://github.com/lambdasistemi/cardano-node-clients/pull/94) merges, the same workflow path will publish the real `cardano-tx-generator-image` (per-commit closure-resolved binary) over the placeholder.