### PR TITLE
test(regression): bearer-closed escape on relay restart (#97)

### DIFF
--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -268,6 +268,7 @@ test-suite e2e-tests
     Cardano.Node.Client.E2E.BalanceSpec
     Cardano.Node.Client.E2E.ChainPopulatorSpec
     Cardano.Node.Client.E2E.ChainSyncSpec
+    Cardano.Node.Client.E2E.Issue97ReproSpec
     Cardano.Node.Client.E2E.MultiAssetChangeSpec
     Cardano.Node.Client.E2E.N2CFullSpec
     Cardano.Node.Client.E2E.ProviderSpec

--- a/e2e-test/Cardano/Node/Client/E2E/Devnet.hs
+++ b/e2e-test/Cardano/Node/Client/E2E/Devnet.hs
@@ -8,6 +8,7 @@ License     : Apache-2.0
 -}
 module Cardano.Node.Client.E2E.Devnet (
     withCardanoNode,
+    withRestartableCardanoNode,
 ) where
 
 import Control.Concurrent (threadDelay)
@@ -18,6 +19,12 @@ import Control.Exception (
 import Control.Monad (unless, void)
 import Data.ByteString qualified as BS
 import Data.ByteString.Char8 qualified as BS8
+import Data.IORef (
+    IORef,
+    newIORef,
+    readIORef,
+    writeIORef,
+ )
 import Data.Time.Clock (
     NominalDiffTime,
     UTCTime,
@@ -69,30 +76,70 @@ withCardanoNode ::
     FilePath ->
     (FilePath -> Integer -> IO a) ->
     IO a
-withCardanoNode srcGenesis action = do
+withCardanoNode srcGenesis action =
+    withRestartableCardanoNode srcGenesis $ \sock t _ ->
+        action sock t
+
+{- | Like 'withCardanoNode' but exposes a third argument:
+a @restart :: IO ()@ action that terminates the running
+cardano-node and spawns a new one against the same
+database, socket path, and genesis. Used by the issue-97
+reproducer to drive a relay-process restart against an
+indexer running in the same process.
+-}
+withRestartableCardanoNode ::
+    FilePath ->
+    (FilePath -> Integer -> IO () -> IO a) ->
+    IO a
+withRestartableCardanoNode srcGenesis action = do
     now <- getCurrentTime
     let startTime = addUTCTime startOffset now
-        -- Truncate to whole seconds to match the
-        -- genesis file format (%H:%M:%SZ — no
-        -- fractional seconds).
         startMs =
             floor (utcTimeToPOSIXSeconds startTime)
                 * 1000
     tmpDir <- prepareTmpDir srcGenesis startTime
-    logH <- openFile (tmpDir </> "node.log") WriteMode
-    hSetBuffering logH LineBuffering
+    let logPath = tmpDir </> "node.log"
+        sock = tmpDir </> "node.sock"
+        spawnNode = do
+            logH <- openFile logPath AppendMode
+            hSetBuffering logH LineBuffering
+            ph <- launchNode tmpDir logH
+            pure (ph, logH)
+        cleanupNode (ph, logH) = do
+            terminateProcess ph
+            void (waitForProcess ph)
+            hClose logH
     bracket
-        (launchNode tmpDir logH)
-        (cleanup tmpDir logH)
-        $ \_ -> do
-            let sock = tmpDir </> "node.sock"
+        ( do
+            np <- spawnNode
+            newIORef np
+        )
+        ( \npRef -> do
+            np <- readIORef npRef
+            cleanupNode np
+            removePathForcibly tmpDir `onException` pure ()
+        )
+        $ \npRef -> do
             waitForSocket sock 300
-            -- cardano-node 10.7.0 can create the socket
-            -- before the local server is ready to accept.
             threadDelay 1_000_000
-            action sock startMs
-                `onException` dumpNodeLog
-                    (tmpDir </> "node.log")
+            let restart = restartNode npRef sock spawnNode cleanupNode
+            action sock startMs restart
+                `onException` dumpNodeLog logPath
+
+restartNode ::
+    IORef (ProcessHandle, Handle) ->
+    FilePath ->
+    IO (ProcessHandle, Handle) ->
+    ((ProcessHandle, Handle) -> IO ()) ->
+    IO ()
+restartNode npRef sock spawnNode cleanupNode = do
+    oldNp <- readIORef npRef
+    cleanupNode oldNp
+    removePathForcibly sock `onException` pure ()
+    newNp <- spawnNode
+    writeIORef npRef newNp
+    waitForSocket sock 300
+    threadDelay 1_000_000
 
 {- | Prepare a temporary directory with patched
 genesis files and delegate keys.
@@ -236,19 +283,6 @@ launchNode tmpDir logH = do
                 }
     (_, _, _, ph) <- createProcess cp
     pure ph
-
--- | Terminate the node process and clean up.
-cleanup ::
-    FilePath ->
-    Handle ->
-    ProcessHandle ->
-    IO ()
-cleanup tmpDir logH ph = do
-    terminateProcess ph
-    void $ waitForProcess ph
-    hClose logH
-    removePathForcibly tmpDir
-        `onException` pure ()
 
 -- | Print the last 50 lines of the node log.
 dumpNodeLog :: FilePath -> IO ()

--- a/test/Cardano/Node/Client/E2E/Issue97ReproSpec.hs
+++ b/test/Cardano/Node/Client/E2E/Issue97ReproSpec.hs
@@ -1,0 +1,165 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Cardano.Node.Client.E2E.Issue97ReproSpec
+Description : Regression for issue #97 (bearer-closed escape)
+License     : Apache-2.0
+
+Locks down the upstream behaviour that motivates the
+in-process reconnect supervisor described in
+<https://github.com/lambdasistemi/cardano-node-clients/issues/97>:
+
+> An unhandled @network-mux@ @BearerClosed@ exception
+> escapes 'runChainSyncN2C' when its peer (the relay
+> it's chain-synced to) closes the socket.
+
+The test spawns 'runChainSyncN2C' with a minimal no-op
+'Follower' against a real devnet relay, asks the test
+harness to terminate-and-respawn that relay, and asserts
+that the chain-sync 'Async' resolves to a 'Left' carrying
+a @BearerClosed@ exception. This is the contract that
+justifies layering a supervisor (sync-exception catch +
+backoff retry) on top.
+
+If the supervisor is added later to 'runChainSyncN2C'
+itself (rather than as an external wrapper), this test
+will need updating; that is the intended signal.
+-}
+module Cardano.Node.Client.E2E.Issue97ReproSpec (spec) where
+
+import Cardano.Chain.Slotting (EpochSlots (..))
+import Cardano.Node.Client.E2E.Devnet (withRestartableCardanoNode)
+import Cardano.Node.Client.E2E.Setup (genesisDir)
+import Cardano.Node.Client.N2C.ChainSync (
+    Fetched,
+    HeaderPoint,
+    mkChainSyncN2C,
+    runChainSyncN2C,
+ )
+import ChainFollower (
+    Follower (..),
+    Intersector (..),
+    ProgressOrRewind (..),
+ )
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (
+    poll,
+    waitCatch,
+    withAsync,
+ )
+import Control.Exception (SomeException)
+import Control.Tracer (nullTracer)
+import Data.Char (isAsciiUpper)
+import Data.List (isInfixOf)
+import Ouroboros.Network.Block qualified as Network
+import Ouroboros.Network.Magic (NetworkMagic (..))
+import Ouroboros.Network.Point qualified as Network.Point
+import System.IO (hPutStrLn, stderr)
+import Test.Hspec (
+    Spec,
+    describe,
+    expectationFailure,
+    it,
+    shouldSatisfy,
+ )
+
+spec :: Spec
+spec =
+    describe "issue #97 — BearerClosed escape from runChainSyncN2C" $
+        it
+            "runChainSyncN2C terminates with a BearerClosed-like \
+            \exception when the upstream relay restarts"
+            runRepro
+
+runRepro :: IO ()
+runRepro = do
+    gDir <- genesisDir
+    withRestartableCardanoNode gDir $ \nodeSock _startMs restart -> do
+        let chainSync =
+                runChainSyncN2C
+                    (EpochSlots 42)
+                    (NetworkMagic 42)
+                    nodeSock
+                    ( mkChainSyncN2C
+                        nullTracer
+                        nullTracer
+                        noopIntersector
+                        [Network.Point Network.Point.Origin]
+                    )
+        withAsync chainSync $ \chainAsync -> do
+            -- Let chain-sync settle into a normal
+            -- roll-forward stream before the disturbance.
+            threadDelay 3_000_000
+            poll chainAsync >>= \case
+                Just outcome ->
+                    expectationFailure $
+                        "chain-sync exited prematurely (before \
+                        \restart) with: "
+                            <> show outcome
+                Nothing -> pure ()
+            hPutStrLn
+                stderr
+                "[issue97-regression] restarting relay..."
+            restart
+            -- Give the chain-sync thread time to observe
+            -- the bearer close. In practice the exception
+            -- arrives within milliseconds; the 5 s budget
+            -- keeps the test robust on slow machines.
+            threadDelay 5_000_000
+            outcome <- waitCatch chainAsync
+            outcome `shouldSatisfy` isBearerClosedFailure
+
+{- | A no-op intersector + follower. Accepts every roll-forward
+and rolls back to whatever point the server proposes.
+-}
+noopIntersector :: Intersector HeaderPoint Network.SlotNo Fetched
+noopIntersector =
+    Intersector
+        { intersectFound = const (pure noopFollower)
+        , intersectNotFound =
+            pure (noopIntersector, [Network.Point Network.Point.Origin])
+        }
+
+noopFollower :: Follower HeaderPoint Network.SlotNo Fetched
+noopFollower = self
+  where
+    self =
+        Follower
+            { rollForward = \_ _ -> pure self
+            , rollBackward = const (pure (Progress self))
+            }
+
+{- | Predicate matching the failure mode in issue #97. We don't
+pin the concrete exception type (network-mux's internal
+constructors aren't exported in a stable way), but we do require:
+
+  * the chain-sync 'Async' resolved with a 'Left' (i.e.
+    the exception escaped 'runChainSyncN2C''s own catch path), and
+
+  * the rendered exception text contains @"bearer closed"@ or
+    @"BearerClosed"@.
+-}
+isBearerClosedFailure :: Either SomeException a -> Bool
+isBearerClosedFailure (Right _) = False
+isBearerClosedFailure (Left e) =
+    let s = show e
+        cleaned =
+            -- Don't depend on case in the exception text.
+            map toLowerAscii s
+     in "bearer closed" `isInfixOf` cleaned
+            || "bearerclosed" `isInfixOf` cleaned
+            || hasMuxRuntime e
+  where
+    toLowerAscii c
+        | isAsciiUpper c = toEnum (fromEnum c + 32)
+        | otherwise = c
+
+{- | Treat any 'SomeException' whose rendered text mentions
+@network-mux@ as a positive match for the issue-97 failure
+mode. Guards against the BearerClosed constructor being
+renamed in a future @ouroboros-network@ release.
+-}
+hasMuxRuntime :: SomeException -> Bool
+hasMuxRuntime e = "network-mux" `isInfixOf` show e

--- a/test/main.hs
+++ b/test/main.hs
@@ -5,6 +5,7 @@ import Test.Hspec (hspec)
 import Cardano.Node.Client.E2E.BalanceSpec qualified as BalanceSpec
 import Cardano.Node.Client.E2E.ChainPopulatorSpec qualified as ChainPopulatorSpec
 import Cardano.Node.Client.E2E.ChainSyncSpec qualified as ChainSyncSpec
+import Cardano.Node.Client.E2E.Issue97ReproSpec qualified as Issue97ReproSpec
 import Cardano.Node.Client.E2E.MultiAssetChangeSpec qualified as MultiAssetChangeSpec
 import Cardano.Node.Client.E2E.N2CFullSpec qualified as N2CFullSpec
 import Cardano.Node.Client.E2E.ProviderSpec qualified as ProviderSpec
@@ -28,6 +29,7 @@ main = hspec $ do
     N2CFullSpec.spec
     ChainPopulatorSpec.spec
     UTxOIndexerSpec.spec
+    Issue97ReproSpec.spec
     TxGeneratorReadySpec.spec
     TxGeneratorRefillSpec.spec
     TxGeneratorTransactSpec.spec


### PR DESCRIPTION
Locks down the upstream contract behind https://github.com/lambdasistemi/cardano-node-clients/issues/97.

## Premise

The fix proposed in https://github.com/lambdasistemi/cardano-node-clients/pull/98 (in-process reconnect supervisor) only makes sense if the upstream chain-sync client really does let a \`network-mux\` \`BearerClosed\` exception escape its own catch path on relay disconnect. This regression PR demonstrates that experimentally and locks it down so the assumption can't silently change.

## What

Two test-infra additions, no library changes:

- \`withRestartableCardanoNode\` (in \`e2e-test/Cardano/Node/Client/E2E/Devnet.hs\`) — exposes a \`restart :: IO ()\` action to the inner callback that terminates the running \`cardano-node\` and spawns a fresh one against the same database, socket path, and genesis. \`withCardanoNode\` is now defined in terms of it (ignoring the restart action), so existing E2E specs are unchanged.

- \`Issue97ReproSpec\` — boots a devnet, drives \`runChainSyncN2C\` directly with a no-op \`Intersector\` / \`Follower\`, lets it stream blocks for 3 s, asks the helper to restart the relay, then asserts the chain-sync \`Async\` resolves with a \`Left\` whose rendered text contains \"bearer closed\" / \"BearerClosed\" / \"network-mux\".

The predicate is intentionally tolerant of constructor renames in future \`ouroboros-network\` releases.

## What this locks in

If anyone in the future:

- adds a catch-and-rethrow inside our \`runChainSyncN2C\` that swallows the mux exception, or
- upstream \`ouroboros-network\` starts trapping \`BearerClosed\` itself,

this test will fail and expose the change. At that point either we no longer need the supervisor in https://github.com/lambdasistemi/cardano-node-clients/pull/98 (and the assertion should be inverted), or the upstream contract has broken in a different way and we want to know.

## Test plan

- \`nix develop -c cabal test e2e-tests -O0 --test-options='--match \"issue #97\"'\` passes locally:

  \`\`\`
  issue #97 — BearerClosed escape from runChainSyncN2C
    runChainSyncN2C terminates with a BearerClosed-like exception when the upstream relay restarts [✔]
  \`\`\`

- Existing E2E suite unchanged (only test-infra extension to \`Devnet.hs\`).

## Related

- Issue: https://github.com/lambdasistemi/cardano-node-clients/issues/97
- Fix PR (depends on this regression to justify its design): https://github.com/lambdasistemi/cardano-node-clients/pull/98