### PR TITLE
feat(cardano-adversary): scaffold spec + wire (PR B)

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -67,3 +67,54 @@ jobs:
             ${{ env.REGISTRY }}/cardano-tx-generator:${{ steps.tag.outputs.tag }} \
             ${{ env.REGISTRY }}/cardano-tx-generator:latest
           docker push ${{ env.REGISTRY }}/cardano-tx-generator:latest
+
+  cardano-adversary:
+    name: cardano-adversary
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - uses: paolino/dev-assets/setup-nix@v0.0.1
+        with:
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image tag
+        id: tag
+        run: |
+          TAG=$(nix eval --raw .#imageTag)
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Image tag: $TAG"
+
+      - name: Build image (nix closure → OCI tarball)
+        run: nix build --quiet .#cardano-adversary-image
+
+      - name: Load image into docker
+        run: docker load < result
+
+      - name: Push image (commit-tagged)
+        run: |
+          docker push \
+            ${{ env.REGISTRY }}/cardano-adversary:${{ steps.tag.outputs.tag }}
+
+      - name: Push image (latest, on main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          docker tag \
+            ${{ env.REGISTRY }}/cardano-adversary:${{ steps.tag.outputs.tag }} \
+            ${{ env.REGISTRY }}/cardano-adversary:latest
+          docker push ${{ env.REGISTRY }}/cardano-adversary:latest

--- a/app/cardano-adversary/Main.hs
+++ b/app/cardano-adversary/Main.hs
@@ -1,20 +1,136 @@
 {- |
 Module      : Main
-Description : cardano-adversary daemon entry point (PR B scaffold)
+Description : cardano-adversary daemon entry point
 License     : Apache-2.0
 
 CLI parsing only; everything else lives in
-'Cardano.Node.Client.Adversary.Daemon.runDaemon'. CLI shape mirrors
-@specs/036-cardano-adversary/spec.md@ and is the same idiom as
-@cardano-tx-generator@.
+'Cardano.Node.Client.Adversary.Daemon.runDaemon'. CLI shape is
+documented in @specs/036-cardano-adversary/spec.md@ and follows the
+same idiom as @cardano-tx-generator@.
 
-Real flag parsing arrives with T006. T001 only ships a placeholder
-that prints a usage line and exits 0 so the executable is buildable
-end-to-end as soon as the cabal target lands.
+Required flags: @--control-socket@ and @--network-magic@.
+Optional, repeatable: @--producer-host@. Optional:
+@--producer-port@ (defaults to 3001).
 -}
 module Main (main) where
 
+import Cardano.Node.Client.Adversary.Daemon (
+    DaemonConfig (..),
+    runDaemon,
+ )
+import Data.Word (Word32)
+import Network.Socket (PortNumber)
+import Ouroboros.Network.Magic (NetworkMagic (..))
+import System.Environment (getArgs, getProgName)
+import System.Exit (exitFailure)
 import System.IO (hPutStrLn, stderr)
+import Text.Read (readMaybe)
+
+defaultProducerPort :: PortNumber
+defaultProducerPort = 3001
+
+{- | Parse the first @--key value@ pair from the argument list,
+returning the value and the remaining args. Repeated flags are
+handled separately by 'takeAllFlags'.
+-}
+takeFlag :: String -> [String] -> Maybe (String, [String])
+takeFlag _ [] = Nothing
+takeFlag key args = go [] args
+  where
+    go _ [] = Nothing
+    go seen (k : v : rest)
+        | k == key = Just (v, reverse seen ++ rest)
+    go seen (x : rest) = go (x : seen) rest
+
+{- | Pull every @--key value@ pair for the given key out of the
+argument list, preserving order, and return the residual args.
+-}
+takeAllFlags :: String -> [String] -> ([String], [String])
+takeAllFlags key = go [] []
+  where
+    go vs rest [] = (reverse vs, reverse rest)
+    go vs rest (k : v : xs) | k == key = go (v : vs) rest xs
+    go vs rest (x : xs) = go vs (x : rest) xs
+
+parseConfig :: [String] -> IO DaemonConfig
+parseConfig args0 = do
+    (control, args1) <- requireFlag "--control-socket" args0
+    (magicS, args2) <- requireFlag "--network-magic" args1
+    let (hosts, args3) = takeAllFlags "--producer-host" args2
+        (mPortS, args4) = case takeFlag "--producer-port" args3 of
+            Just (p, rest) -> (Just p, rest)
+            Nothing -> (Nothing, args3)
+    case args4 of
+        [] -> pure ()
+        extra -> dieUsage $ "Unexpected args: " <> show extra
+    magic <- requireWord32 "--network-magic" magicS
+    port <- maybe (pure defaultProducerPort) (parsePort "--producer-port") mPortS
+    pure
+        DaemonConfig
+            { daemonControlSocket = control
+            , daemonProducerHosts = hosts
+            , daemonProducerPort = port
+            , daemonNetworkMagic = NetworkMagic magic
+            }
+  where
+    requireFlag key args =
+        maybe
+            (dieUsage $ "Missing required flag: " <> key)
+            pure
+            (takeFlag key args)
+    requireWord32 key s =
+        maybe
+            ( dieUsage $
+                key
+                    <> " expects a non-negative 32-bit integer, got: "
+                    <> s
+            )
+            pure
+            (readMaybe s :: Maybe Word32)
+    parsePort key s =
+        maybe
+            ( dieUsage $
+                key
+                    <> " expects a port number 1..65535, got: "
+                    <> s
+            )
+            pure
+            (readMaybe s :: Maybe PortNumber)
+
+dieUsage :: String -> IO a
+dieUsage msg = do
+    prog <- getProgName
+    hPutStrLn stderr msg
+    hPutStrLn stderr ""
+    hPutStrLn stderr $ "Usage: " <> prog <> " \\"
+    hPutStrLn stderr "  --control-socket PATH \\"
+    hPutStrLn stderr "  --network-magic INT \\"
+    hPutStrLn stderr "  [--producer-host HOST]... \\"
+    hPutStrLn stderr "  [--producer-port INT]"
+    exitFailure
 
 main :: IO ()
-main = hPutStrLn stderr "cardano-adversary: scaffold (see specs/036-cardano-adversary)"
+main = do
+    args <- getArgs
+    case args of
+        ["--help"] -> printHelp
+        ["-h"] -> printHelp
+        _ -> do
+            cfg <- parseConfig args
+            runDaemon cfg
+
+printHelp :: IO ()
+printHelp = do
+    prog <- getProgName
+    putStrLn $ prog <> " — cardano-adversary daemon (PR B scaffold)"
+    putStrLn ""
+    putStrLn "Listens on a UNIX SOCK_STREAM control socket and answers one"
+    putStrLn "NDJSON request per connection per the wire spec at"
+    putStrLn "specs/036-cardano-adversary/contracts/control-wire.md."
+    putStrLn ""
+    putStrLn "Flags:"
+    putStrLn "  --control-socket PATH    Bind path for the control socket. Required."
+    putStrLn "  --network-magic INT      Cardano network magic. Required."
+    putStrLn "  --producer-host HOST     Producer hostname (repeatable, optional)."
+    putStrLn "  --producer-port INT      N2N port (default 3001)."
+    putStrLn "  --help, -h               Print this help and exit 0."

--- a/app/cardano-adversary/Main.hs
+++ b/app/cardano-adversary/Main.hs
@@ -1,0 +1,20 @@
+{- |
+Module      : Main
+Description : cardano-adversary daemon entry point (PR B scaffold)
+License     : Apache-2.0
+
+CLI parsing only; everything else lives in
+'Cardano.Node.Client.Adversary.Daemon.runDaemon'. CLI shape mirrors
+@specs/036-cardano-adversary/spec.md@ and is the same idiom as
+@cardano-tx-generator@.
+
+Real flag parsing arrives with T006. T001 only ships a placeholder
+that prints a usage line and exits 0 so the executable is buildable
+end-to-end as soon as the cabal target lands.
+-}
+module Main (main) where
+
+import System.IO (hPutStrLn, stderr)
+
+main :: IO ()
+main = hPutStrLn stderr "cardano-adversary: scaffold (see specs/036-cardano-adversary)"

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -41,6 +41,10 @@ library
   hs-source-dirs:   lib
   default-language: GHC2021
   exposed-modules:
+    Cardano.Node.Client.Adversary.Daemon
+    Cardano.Node.Client.Adversary.RandomSource
+    Cardano.Node.Client.Adversary.Server
+    Cardano.Node.Client.Adversary.Types
     Cardano.Node.Client.Balance
     Cardano.Node.Client.Evaluate
     Cardano.Node.Client.Ledger
@@ -198,6 +202,16 @@ executable utxo-indexer
 executable cardano-tx-generator
   import:           warnings
   hs-source-dirs:   app/cardano-tx-generator
+  main-is:          Main.hs
+  default-language: GHC2021
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+    , base
+    , cardano-node-clients
+
+executable cardano-adversary
+  import:           warnings
+  hs-source-dirs:   app/cardano-adversary
   main-is:          Main.hs
   default-language: GHC2021
   ghc-options:      -threaded -rtsopts -with-rtsopts=-N

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -220,6 +220,8 @@ executable cardano-adversary
   build-depends:
     , base
     , cardano-node-clients
+    , network
+    , ouroboros-network
 
 test-suite unit-tests
   import:           warnings

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -117,6 +117,7 @@ library
     , ouroboros-network:protocols
     , plutus-core
     , plutus-tx
+    , process
     , random
     , serialise
     , stm

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -230,6 +230,7 @@ test-suite unit-tests
   main-is:          unit-main.hs
   default-language: GHC2021
   other-modules:
+    Cardano.Node.Client.Adversary.ServerSpec
     Cardano.Node.Client.BalanceSpec
     Cardano.Node.Client.TxBuildGoldenSpec
     Cardano.Node.Client.TxBuildSpec

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -125,6 +125,7 @@ library
     , time
     , transformers
     , typed-protocols
+    , unix
 
 library devnet
   import:           warnings

--- a/flake.nix
+++ b/flake.nix
@@ -123,8 +123,14 @@
             cardano-tx-generator =
               components.exes.cardano-tx-generator;
             utxo-indexer = components.exes.utxo-indexer;
+            cardano-adversary =
+              components.exes.cardano-adversary;
             cardano-tx-generator-image =
               import ./nix/docker-image.nix {
+                inherit pkgs components imageTag;
+              };
+            cardano-adversary-image =
+              import ./nix/cardano-adversary-docker-image.nix {
                 inherit pkgs components imageTag;
               };
           };
@@ -139,6 +145,12 @@
             utxo-indexer = {
               type = "app";
               program = "${components.exes.utxo-indexer}/bin/utxo-indexer";
+            };
+            cardano-adversary = {
+              type = "app";
+              program = "${
+                  components.exes.cardano-adversary
+                }/bin/cardano-adversary";
             };
           };
           devShells.default = project.shell;

--- a/lib/Cardano/Node/Client/Adversary/Daemon.hs
+++ b/lib/Cardano/Node/Client/Adversary/Daemon.hs
@@ -1,6 +1,103 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 {- |
 Module      : Cardano.Node.Client.Adversary.Daemon
-Description : Stub module — daemon entry, signals, control socket arrive in T005.
+Description : cardano-adversary daemon — wires Server, signals, sockets
 License     : Apache-2.0
+
+Composes the cardano-adversary daemon's three responsibilities for
+PR B:
+
+* the NDJSON control wire from
+  'Cardano.Node.Client.Adversary.Server',
+* signal handling so the container stops cleanly on @SIGTERM@,
+* the @ready@ hook (always reports ready in PR B because no N2N
+  warmup happens yet).
+
+PR C adds the @chain_sync_flap@ misbehaviour body and replaces the
+'stubHooks' wiring with one that holds an N2N pool.
 -}
-module Cardano.Node.Client.Adversary.Daemon () where
+module Cardano.Node.Client.Adversary.Daemon (
+    DaemonConfig (..),
+    runDaemon,
+) where
+
+import Cardano.Node.Client.Adversary.Server (
+    ServerHooks,
+    runServer,
+    stubHooks,
+ )
+import Cardano.Node.Client.Adversary.Types (
+    ReadyDetails (..),
+ )
+import Control.Concurrent (
+    MVar,
+    newEmptyMVar,
+    putMVar,
+    takeMVar,
+ )
+import Control.Concurrent.Async (race_)
+import Control.Exception (catch)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Network.Socket (HostName, PortNumber)
+import Ouroboros.Network.Magic (NetworkMagic)
+import System.Directory (removeFile)
+import System.IO (hPutStrLn, stderr)
+import System.IO.Error (isDoesNotExistError)
+import System.Posix.Signals (
+    Handler (Catch),
+    installHandler,
+    sigTERM,
+ )
+
+-- | Top-level daemon configuration.
+data DaemonConfig = DaemonConfig
+    { daemonControlSocket :: FilePath
+    -- ^ Path of the Unix control socket. The daemon binds here
+    -- and unlinks on shutdown.
+    , daemonProducerHosts :: [HostName]
+    -- ^ Producer hostnames the daemon will eventually target.
+    -- PR B only echoes them back via 'ReadyDetails'.
+    , daemonProducerPort :: PortNumber
+    -- ^ N2N port. Echoed by 'ReadyDetails' for diagnostic value.
+    , daemonNetworkMagic :: NetworkMagic
+    -- ^ Network magic. Echoed by 'ReadyDetails' for diagnostic
+    -- value; required by every future N2N misbehaviour endpoint.
+    }
+
+{- | Run the daemon: install signal handler, start NDJSON server,
+block until SIGTERM. On SIGTERM unlink the socket and exit.
+-}
+runDaemon :: DaemonConfig -> IO ()
+runDaemon cfg = do
+    hPutStrLn stderr $
+        "cardano-adversary: starting on "
+            <> daemonControlSocket cfg
+    shutdown <- newEmptyMVar :: IO (MVar ())
+    _ <- installHandler sigTERM (Catch (putMVar shutdown ())) Nothing
+    let serverThread = runServer (daemonControlSocket cfg) (mkHooks cfg)
+        signalThread = takeMVar shutdown
+    race_ serverThread signalThread
+    cleanup cfg
+
+mkHooks :: DaemonConfig -> ServerHooks
+mkHooks cfg = stubHooks (pure (readyDetails cfg))
+
+readyDetails :: DaemonConfig -> ReadyDetails
+readyDetails cfg =
+    ReadyDetails
+        { readyOverall = True
+        , readyN2NHandshakeOk = False
+        , readyConfiguredHosts =
+            map (T.pack :: HostName -> Text) (daemonProducerHosts cfg)
+        }
+
+cleanup :: DaemonConfig -> IO ()
+cleanup cfg = do
+    hPutStrLn stderr "cardano-adversary: SIGTERM received, shutting down"
+    removeFile (daemonControlSocket cfg)
+        `catch` \e ->
+            if isDoesNotExistError e
+                then pure ()
+                else ioError e

--- a/lib/Cardano/Node/Client/Adversary/Daemon.hs
+++ b/lib/Cardano/Node/Client/Adversary/Daemon.hs
@@ -1,0 +1,6 @@
+{- |
+Module      : Cardano.Node.Client.Adversary.Daemon
+Description : Stub module — daemon entry, signals, control socket arrive in T005.
+License     : Apache-2.0
+-}
+module Cardano.Node.Client.Adversary.Daemon () where

--- a/lib/Cardano/Node/Client/Adversary/RandomSource.hs
+++ b/lib/Cardano/Node/Client/Adversary/RandomSource.hs
@@ -1,6 +1,79 @@
 {- |
 Module      : Cardano.Node.Client.Adversary.RandomSource
-Description : Stub module — typeclass and Antithesis impl arrive in T003.
+Description : Steerable random source for the cardano-adversary daemon
 License     : Apache-2.0
+
+Every adversarial decision draws from this typeclass so the
+Antithesis hypervisor can bias them. The default implementation
+shells out to the @antithesis_random@ CLI when present on
+@PATH@ and falls back to 'System.Random' for local development
+when it is not.
+
+A pure @splitFromSeed@ helper turns the per-request @seed@ field
+of an NDJSON request into a 'StdGen'; the daemon uses that to
+derive any further random values it needs without going back to
+@antithesis_random@.
 -}
-module Cardano.Node.Client.Adversary.RandomSource () where
+module Cardano.Node.Client.Adversary.RandomSource (
+    -- * Typeclass
+    RandomSource (..),
+
+    -- * Antithesis-aware default
+    Antithesis,
+    runAntithesis,
+
+    -- * Pure helpers
+    splitFromSeed,
+) where
+
+import Control.Exception (IOException, try)
+import Data.Word (Word64)
+import System.Directory (findExecutable)
+import System.Process (readProcess)
+import System.Random (StdGen, mkStdGen, randomIO)
+import Text.Read (readMaybe)
+
+-- | Source of randomness for adversarial decisions.
+class (Monad m) => RandomSource m where
+    -- | Draw an unsigned 64-bit integer.
+    randomU64 :: m Word64
+
+-- | Default implementation: hypervisor-aware in CI, host-RNG locally.
+newtype Antithesis a = Antithesis {runAntithesis :: IO a}
+    deriving newtype (Functor, Applicative, Monad)
+
+instance RandomSource Antithesis where
+    randomU64 = Antithesis $ do
+        -- The antithesis_random CLI is shipped by the
+        -- Antithesis runtime; if absent we are running
+        -- locally and must fall back to host entropy.
+        haveCli <- findExecutable "antithesis_random"
+        case haveCli of
+            Just _ -> readAntithesis
+            Nothing -> randomIO
+    {-# INLINE randomU64 #-}
+
+{- | Read one decimal uint64 from the @antithesis_random@ CLI.
+Falls back to 'randomIO' if the process fails to start or
+returns garbage. The fallback keeps PR-B-quality smoke testing
+working on a workstation where the runtime CLI is missing.
+-}
+readAntithesis :: IO Word64
+readAntithesis = do
+    result <- try @IOException (readProcess "antithesis_random" [] "")
+    case result of
+        Left _ -> randomIO
+        Right out -> maybe randomIO pure (readMaybe (trim out))
+  where
+    trim = dropWhile (== ' ') . reverse . dropWhile isWhitespace . reverse
+    isWhitespace c = c == ' ' || c == '\n' || c == '\r' || c == '\t'
+
+{- | Derive a deterministic 'StdGen' from the @seed@ field of a
+request. The daemon uses this to make a request reproducible
+given the seed it received: any further randomness the request
+needs is drawn from the returned generator, not from
+@antithesis_random@. This matches the tx-generator's discipline
+(single seed in → deterministic transaction body out).
+-}
+splitFromSeed :: Word64 -> StdGen
+splitFromSeed = mkStdGen . fromIntegral

--- a/lib/Cardano/Node/Client/Adversary/RandomSource.hs
+++ b/lib/Cardano/Node/Client/Adversary/RandomSource.hs
@@ -1,0 +1,6 @@
+{- |
+Module      : Cardano.Node.Client.Adversary.RandomSource
+Description : Stub module — typeclass and Antithesis impl arrive in T003.
+License     : Apache-2.0
+-}
+module Cardano.Node.Client.Adversary.RandomSource () where

--- a/lib/Cardano/Node/Client/Adversary/Server.hs
+++ b/lib/Cardano/Node/Client/Adversary/Server.hs
@@ -1,0 +1,6 @@
+{- |
+Module      : Cardano.Node.Client.Adversary.Server
+Description : Stub module — NDJSON dispatcher arrives in T004.
+License     : Apache-2.0
+-}
+module Cardano.Node.Client.Adversary.Server () where

--- a/lib/Cardano/Node/Client/Adversary/Server.hs
+++ b/lib/Cardano/Node/Client/Adversary/Server.hs
@@ -1,6 +1,172 @@
+{-# LANGUAGE LambdaCase #-}
+
 {- |
 Module      : Cardano.Node.Client.Adversary.Server
-Description : Stub module — NDJSON dispatcher arrives in T004.
+Description : NDJSON Unix-socket control wire for cardano-adversary
 License     : Apache-2.0
+
+Listens on a Unix domain socket and serves the cardano-adversary
+daemon's control wire as newline-delimited JSON. One request per
+connection, single response, then EOF + close. Same idiom as
+'Cardano.Node.Client.TxGenerator.Server' and
+'Cardano.Node.Client.UTxOIndexer.Server'.
+
+Endpoints route through 'ServerHooks', wired up by the daemon. PR
+B ships only the @ready@ hook with real semantics; @chain_sync_flap@
+is reserved with a 'RespNotImplemented' stub. The hook signature is
+already shaped for the real handler so PR C only swaps the body.
+
+Wire schemas live in
+@specs/036-cardano-adversary/contracts/control-wire.md@.
 -}
-module Cardano.Node.Client.Adversary.Server () where
+module Cardano.Node.Client.Adversary.Server (
+    -- * Server
+    runServer,
+
+    -- * Hook record
+    ServerHooks (..),
+    stubHooks,
+) where
+
+import Cardano.Node.Client.Adversary.Types (
+    ChainSyncFlapArgs,
+    ErrorReason (..),
+    ReadyDetails,
+    Request (..),
+    Response (..),
+ )
+import Control.Concurrent (forkIO)
+import Control.Exception (
+    bracket,
+    finally,
+    try,
+ )
+import Data.Aeson (
+    decodeStrict',
+    encode,
+ )
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Builder (toLazyByteString)
+import Data.ByteString.Builder qualified as Builder
+import Data.ByteString.Lazy qualified as LBS
+import Network.Socket (
+    Family (AF_UNIX),
+    SockAddr (SockAddrUnix),
+    Socket,
+    SocketType (Stream),
+    accept,
+    bind,
+    close,
+    listen,
+    socket,
+ )
+import Network.Socket.ByteString qualified as Net
+import System.Directory (removeFile)
+import System.IO.Error (isDoesNotExistError)
+
+{- | Per-endpoint entry points; the daemon wires these up.
+
+PR B ships a real 'hooksReady' and a stub 'hooksChainSyncFlap'.
+PR C swaps the stub for the real chain-sync misbehaviour body.
+-}
+data ServerHooks = ServerHooks
+    { hooksReady :: IO ReadyDetails
+    , hooksChainSyncFlap :: ChainSyncFlapArgs -> IO Response
+    }
+
+{- | Build a 'ServerHooks' whose 'hooksChainSyncFlap' arm returns
+'RespNotImplemented'. The 'ready' hook must still be supplied by
+the caller.
+-}
+stubHooks :: IO ReadyDetails -> ServerHooks
+stubHooks ready =
+    ServerHooks
+        { hooksReady = ready
+        , hooksChainSyncFlap = \_ -> pure RespNotImplemented
+        }
+
+{- | Run the NDJSON server on @socketPath@ until killed (by
+exception). Removes any stale socket file at @socketPath@ before
+binding.
+
+Each accepted connection is handled in its own thread: read one
+request line, write one response line, close. Many concurrent
+@ready@ connections are fine; misbehaviour endpoints are
+free to serialise themselves at the hook layer when their
+underlying state demands it.
+-}
+runServer :: FilePath -> ServerHooks -> IO ()
+runServer socketPath hooks =
+    bracket (openListenSocket socketPath) close $ \sock -> do
+        listen sock 16
+        let loop = do
+                (conn, _) <- accept sock
+                _ <- forkIO (handleConn hooks conn)
+                loop
+        loop
+
+openListenSocket :: FilePath -> IO Socket
+openListenSocket path = do
+    removeIfPresent path
+    sock <- socket AF_UNIX Stream 0
+    bind sock (SockAddrUnix path)
+    pure sock
+
+removeIfPresent :: FilePath -> IO ()
+removeIfPresent p = do
+    r <- try (removeFile p)
+    case r of
+        Right () -> pure ()
+        Left e
+            | isDoesNotExistError e -> pure ()
+            | otherwise -> ioError e
+
+handleConn :: ServerHooks -> Socket -> IO ()
+handleConn hooks conn = (`finally` close conn) $ do
+    line <- recvLine conn
+    case decodeStrict' line of
+        Nothing ->
+            sendLine conn (encode (RespError ErrMalformedJson))
+        Just req -> dispatch hooks conn req
+
+dispatch :: ServerHooks -> Socket -> Request -> IO ()
+dispatch hooks conn = \case
+    ReqReady -> do
+        rsp <- hooksReady hooks
+        sendLine conn (encode (RespReady rsp))
+    ReqChainSyncFlap body -> do
+        rsp <- hooksChainSyncFlap hooks body
+        sendLine conn (encode rsp)
+
+{- | Read up to and including the first @\n@. The line itself is
+returned without the trailing newline. Returns the empty
+bytestring on EOF before any newline.
+-}
+recvLine :: Socket -> IO ByteString
+recvLine s = go BS.empty
+  where
+    go acc = do
+        chunk <- Net.recv s 4096
+        if BS.null chunk
+            then pure (stripNewline acc)
+            else case BS.elemIndex 0x0A chunk of
+                Just i ->
+                    let (hd, _) = BS.splitAt i chunk
+                     in pure (stripNewline (acc <> hd))
+                Nothing -> go (acc <> chunk)
+
+stripNewline :: ByteString -> ByteString
+stripNewline bs
+    | not (BS.null bs) && BS.last bs == 0x0A =
+        BS.init bs
+    | otherwise = bs
+
+-- | Send one JSON line followed by @\n@.
+sendLine :: Socket -> LBS.ByteString -> IO ()
+sendLine s payload =
+    Net.sendAll s $
+        LBS.toStrict $
+            toLazyByteString $
+                Builder.lazyByteString payload
+                    <> Builder.char7 '\n'

--- a/lib/Cardano/Node/Client/Adversary/Types.hs
+++ b/lib/Cardano/Node/Client/Adversary/Types.hs
@@ -1,0 +1,6 @@
+{- |
+Module      : Cardano.Node.Client.Adversary.Types
+Description : Stub module — request/response types arrive in T002.
+License     : Apache-2.0
+-}
+module Cardano.Node.Client.Adversary.Types () where

--- a/lib/Cardano/Node/Client/Adversary/Types.hs
+++ b/lib/Cardano/Node/Client/Adversary/Types.hs
@@ -1,6 +1,174 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 {- |
 Module      : Cardano.Node.Client.Adversary.Types
-Description : Stub module — request/response types arrive in T002.
+Description : Wire types for the cardano-adversary daemon
 License     : Apache-2.0
+
+Aeson-encoded request and response types matching the schemas in
+@specs/036-cardano-adversary/contracts/control-wire.md@. The
+schemas are the contract; these types are how the
+'Cardano.Node.Client.Adversary.Server' module produces and consumes
+them.
 -}
-module Cardano.Node.Client.Adversary.Types () where
+module Cardano.Node.Client.Adversary.Types (
+    -- * Requests
+    Request (..),
+    ChainSyncFlapArgs (..),
+
+    -- * Responses
+    Response (..),
+    ReadyDetails (..),
+    ErrorReason (..),
+
+    -- * Wire helpers
+    errorReasonText,
+) where
+
+import Data.Aeson (
+    FromJSON (..),
+    ToJSON (..),
+    Value (Null),
+    object,
+    withObject,
+    (.:),
+    (.=),
+ )
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Aeson.Types qualified as Aeson
+import Data.Text (Text)
+import Data.Word (Word16, Word32, Word64)
+
+{- | Top-level request envelope. One JSON object per line, single
+request → single response.
+-}
+data Request
+    = -- | Readiness probe: @{"ready": null}@.
+      ReqReady
+    | -- | Chain-sync flap: @{"chain_sync_flap": {"seed":..,"limit":..,"n_conns":..}}@.
+      ReqChainSyncFlap !ChainSyncFlapArgs
+    deriving stock (Eq, Show)
+
+-- | Body of the @chain_sync_flap@ request.
+data ChainSyncFlapArgs = ChainSyncFlapArgs
+    { csfSeed :: !Word64
+    -- ^ Sole source of randomness for this request.
+    , csfLimit :: !Word32
+    -- ^ Maximum blocks pulled per connection before disconnecting.
+    , csfNConns :: !Word16
+    -- ^ Number of concurrent N2N connections per request.
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON ChainSyncFlapArgs where
+    parseJSON = withObject "chain_sync_flap" $ \o ->
+        ChainSyncFlapArgs
+            <$> o .: "seed"
+            <*> o .: "limit"
+            <*> o .: "n_conns"
+
+instance ToJSON ChainSyncFlapArgs where
+    toJSON (ChainSyncFlapArgs seed limit nConns) =
+        object
+            [ "seed" .= seed
+            , "limit" .= limit
+            , "n_conns" .= nConns
+            ]
+
+instance FromJSON Request where
+    parseJSON = withObject "request" $ \o ->
+        case KeyMap.toList o of
+            [("ready", Null)] -> pure ReqReady
+            [("chain_sync_flap", body)] ->
+                ReqChainSyncFlap <$> parseJSON body
+            [(other, _)] ->
+                fail $ "unknown request: " <> Key.toString other
+            _ ->
+                fail "request must have exactly one top-level key"
+
+-- | Top-level response envelope. One JSON object per line.
+data Response
+    = -- | Successful @ready@ response.
+      RespReady !ReadyDetails
+    | -- | Endpoint reserved but logic not yet implemented (PR B).
+      RespNotImplemented
+    | -- | Wire-level error (malformed json, unknown key).
+      RespError !ErrorReason
+    deriving stock (Eq, Show)
+
+-- | Structured details accompanying a 'RespReady' response.
+data ReadyDetails = ReadyDetails
+    { readyOverall :: !Bool
+    -- ^ True iff every readiness component below is satisfied.
+    , readyN2NHandshakeOk :: !Bool
+    -- ^ True iff the daemon has completed its N2N handshake to
+    -- at least one configured producer host. Always 'False' in
+    -- PR B because no N2N work happens yet.
+    , readyConfiguredHosts :: ![Text]
+    -- ^ Producer hostnames the daemon is configured to target.
+    }
+    deriving stock (Eq, Show)
+
+instance ToJSON ReadyDetails where
+    toJSON (ReadyDetails overall n2n hosts) =
+        object
+            [ "ready" .= overall
+            , "details"
+                .= object
+                    [ "n2nHandshakeOk" .= n2n
+                    , "configuredHosts" .= hosts
+                    ]
+            ]
+
+instance FromJSON ReadyDetails where
+    parseJSON = withObject "ready response" $ \o -> do
+        overall <- o .: "ready"
+        details <- o .: "details"
+        n2n <- details .: "n2nHandshakeOk"
+        hosts <- details .: "configuredHosts"
+        pure (ReadyDetails overall n2n hosts)
+
+-- | Structured error reasons emitted on the wire.
+data ErrorReason
+    = -- | The bytes received before @\\n@ were not valid JSON.
+      ErrMalformedJson
+    | -- | The top-level JSON key is not a known endpoint name.
+      ErrUnknownRequest
+    deriving stock (Eq, Show)
+
+errorReasonText :: ErrorReason -> Text
+errorReasonText = \case
+    ErrMalformedJson -> "malformed json"
+    ErrUnknownRequest -> "unknown request"
+
+instance ToJSON Response where
+    toJSON = \case
+        RespReady details -> toJSON details
+        RespNotImplemented ->
+            object ["ok" .= False, "reason" .= ("not-implemented" :: Text)]
+        RespError reason ->
+            object ["error" .= errorReasonText reason]
+
+instance FromJSON Response where
+    parseJSON v =
+        Aeson.parseEither (parseJSON @ReadyDetails) v
+            & either (const tryNotImplemented) (pure . RespReady)
+      where
+        tryNotImplemented = withObject "response" go v
+        go o = case KeyMap.lookup "ok" o of
+            Just (Aeson.Bool False) ->
+                case KeyMap.lookup "reason" o of
+                    Just (Aeson.String "not-implemented") ->
+                        pure RespNotImplemented
+                    _ -> tryError o
+            _ -> tryError o
+        tryError o = case KeyMap.lookup "error" o of
+            Just (Aeson.String "malformed json") ->
+                pure (RespError ErrMalformedJson)
+            Just (Aeson.String "unknown request") ->
+                pure (RespError ErrUnknownRequest)
+            _ -> fail "unrecognised response shape"
+        (&) :: a -> (a -> b) -> b
+        x & f = f x

--- a/nix/cardano-adversary-docker-image.nix
+++ b/nix/cardano-adversary-docker-image.nix
@@ -1,0 +1,42 @@
+{ pkgs, components, imageTag, ... }:
+let
+  # /usr/bin/env so any composer / driver shebang like
+  # `#!/usr/bin/env bash` resolves inside the container.
+  usrBinEnv = pkgs.runCommand "usr-bin-env" { } ''
+    mkdir -p $out/usr/bin
+    ln -s ${pkgs.coreutils}/bin/env $out/usr/bin/env
+  '';
+in
+pkgs.dockerTools.buildImage {
+  name = "ghcr.io/lambdasistemi/cardano-node-clients/cardano-adversary";
+  tag = imageTag;
+
+  # Single-purpose image: the daemon is the entrypoint;
+  # the consumer (e.g. the cardano-node-antithesis testnet's
+  # docker-compose.yaml) supplies the CLI flags and may mount
+  # composer scripts at /opt/antithesis/test/v1/adversary/.
+  config = {
+    EntryPoint = [ "/bin/cardano-adversary" ];
+    Labels = {
+      "org.opencontainers.image.documentation" =
+        "https://github.com/lambdasistemi/cardano-node-clients/blob/main/specs/036-cardano-adversary/contracts/control-wire.md";
+    };
+  };
+
+  # buildEnv collects the binary's full nix closure into
+  # /nix/store inside the image. netcat-openbsd is included
+  # so composer scripts can shell into the container and talk
+  # to the control socket via `nc -U`.
+  copyToRoot = pkgs.buildEnv {
+    name = "cardano-adversary-image-root";
+    paths = [
+      pkgs.coreutils
+      pkgs.bash
+      pkgs.jq
+      pkgs.gnugrep
+      pkgs.netcat-openbsd
+      usrBinEnv
+      components.exes.cardano-adversary
+    ];
+  };
+}

--- a/specs/036-cardano-adversary/contracts/control-wire.md
+++ b/specs/036-cardano-adversary/contracts/control-wire.md
@@ -1,0 +1,110 @@
+# Control Wire — NDJSON over Unix `SOCK_STREAM`
+
+Same idiom as
+[`UTxOIndexer.Server`](https://github.com/lambdasistemi/cardano-node-clients/blob/main/lib/Cardano/Node/Client/UTxOIndexer/Server.hs)
+and the [tx-generator wire
+spec](https://github.com/lambdasistemi/cardano-node-clients/blob/main/specs/034-cardano-tx-generator/contracts/control-wire.md):
+one JSON object per line, single request → single response → EOF
++ close. UTF-8. Unknown top-level keys are rejected with `{"error":
+"unknown request"}`.
+
+The daemon listens on `--control-socket`. Filesystem permissions
+on the socket are the only authentication.
+
+## `ready` — readiness probe
+
+**Request**:
+```json
+{"ready": null}
+```
+
+**Response**:
+```json
+{"ready": true,
+ "details": {
+   "n2nHandshakeOk": true,
+   "configuredHosts": ["p1.example", "p2.example", "p3.example"]
+ }}
+```
+
+Or, before warmup:
+```json
+{"ready": false,
+ "details": {
+   "n2nHandshakeOk": false,
+   "configuredHosts": ["p1.example", "p2.example", "p3.example"]
+ }}
+```
+
+`ready` is the AND of all readiness components surfaced under
+`details`. Composer drivers should treat `ready: false` as "skip
+this tick" rather than "fail this tick".
+
+## `chain_sync_flap` — reserved (PR B), implemented in PR C
+
+**Request**:
+```json
+{"chain_sync_flap": {"seed": 12345678901234567890,
+                     "limit": 100,
+                     "n_conns": 1}}
+```
+
+- `seed` — `uint64`, sole source of randomness for this request
+  (passed to the `RandomSource`).
+- `limit` — `uint32`, maximum blocks pulled per connection before
+  disconnecting (mirror of today's one-shot binary's `LIMIT` env
+  var).
+- `n_conns` — `uint16`, number of concurrent N2N connections
+  spawned by this single request.
+
+**Response (PR B — endpoint reserved, no implementation)**:
+```json
+{"ok": false, "reason": "not-implemented"}
+```
+
+**Response (PR C and beyond — once implemented)**:
+```json
+{"ok": true,
+ "txId": null,
+ "details": {
+   "connections": 1,
+   "intersectionPoint": "<hex>@<slot>|origin",
+   "blocksPulled": 100,
+   "completed": true,
+   "failures": []
+ }}
+```
+
+```json
+{"ok": false,
+ "reason": "no-chain-points-yet",
+ "details": {"chainpointsFile": "/opt/cardano-tracer/chainPoints.log"}}
+```
+
+The composer driver script in
+`cardano-foundation/cardano-node-antithesis` will map outcomes to
+SDK assertions:
+
+| `reason` | `exit` | Antithesis SDK assertion |
+|---|---|---|
+| (none — `ok == true`) | 0 | `sdk_sometimes true "adversary_chain_sync_flap_completed"` |
+| `not-implemented` | 1 | `sdk_unreachable "adversary_endpoint_not_implemented"` (during the PR-B → PR-C transition window) |
+| `no-chain-points-yet` | 1 | `sdk_sometimes false "adversary_no_chain_points"` |
+
+## Framing details
+
+- One request per connection. After the response is written, the
+  daemon closes; no keep-alive.
+- Request line is read up to and including the first `\n`. Trailing
+  bytes after `\n` (if any) are discarded.
+- Response is one line followed by `\n`, then EOF.
+- Concurrency: many concurrent `ready` connections are fine.
+  Misbehaviour endpoints (when implemented) MAY be serialised by
+  the daemon if the underlying mini-protocol state is shared; the
+  serialisation policy SHALL be documented per endpoint.
+- Malformed JSON: `{"error": "malformed json"}`, then close.
+- Unknown top-level key: `{"error": "unknown request"}`, then close.
+- Reserved-but-not-implemented endpoint: `{"ok": false, "reason":
+  "not-implemented"}`, then close. This is distinct from "unknown
+  request" so composer drivers can tell "endpoint will exist later"
+  from "this endpoint is a typo".

--- a/specs/036-cardano-adversary/plan.md
+++ b/specs/036-cardano-adversary/plan.md
@@ -1,0 +1,149 @@
+# Implementation Plan: Cardano Adversary (PR B scaffold)
+
+**Spec**: [`spec.md`](spec.md)
+**Status**: Draft
+**Last updated**: 2026-04-30
+
+## Architecture
+
+```
+                +-------------------------------------+
+                |    cardano-adversary daemon         |
+                |    Cardano.Node.Client.Adversary.*  |
+                |                                     |
+   composer -- NDJSON --> Server.hs --> Daemon.hs     |
+   parallel_                                          |
+   driver_x.sh                                        |
+   over UNIX                                          |
+   SOCK_STREAM                                        |
+                +-------------------------------------+
+```
+
+PR B keeps the diagram trivial: only `Server.hs` (NDJSON listener)
+and `Daemon.hs` (entry point + signal handling). Misbehaviour code
+arrives in PR C and beyond and lives under
+`Cardano.Node.Client.Adversary.Misbehaviour.*` so the namespace is
+already partitioned.
+
+## Module layout
+
+```
+app/cardano-adversary/Main.hs            CLI parsing only.
+lib/Cardano/Node/Client/Adversary/
+    Daemon.hs                            entry, signals, sockets.
+    Server.hs                            NDJSON dispatcher.
+    Types.hs                             request/response types.
+    RandomSource.hs                      typeclass + Antithesis impl.
+specs/036-cardano-adversary/
+    spec.md
+    plan.md
+    tasks.md
+    contracts/control-wire.md
+```
+
+`Cardano.Node.Client.Adversary.Misbehaviour.ChainSyncFlap` arrives
+in PR C and registers itself with `Server.hs`.
+
+## Public surface (PR B)
+
+```haskell
+-- Cardano.Node.Client.Adversary.Daemon
+data DaemonConfig = DaemonConfig
+    { daemonControlSocket :: FilePath
+    , daemonProducerHosts :: [HostName]
+    , daemonProducerPort  :: PortNumber
+    , daemonNetworkMagic  :: NetworkMagic
+    }
+
+runDaemon :: DaemonConfig -> IO ()
+```
+
+```haskell
+-- Cardano.Node.Client.Adversary.Server
+data Request
+    = ReqReady
+    | ReqChainSyncFlap ChainSyncFlapArgs    -- reserved, returns NotImplemented
+    deriving (Show, Eq)
+
+data Response
+    = RespReady ReadyDetails
+    | RespError ErrorReason
+    | RespNotImplemented
+    deriving (Show, Eq)
+
+handleConnection :: Handler -> Socket -> IO ()
+```
+
+```haskell
+-- Cardano.Node.Client.Adversary.RandomSource
+class Monad m => RandomSource m where
+    randomU64 :: m Word64
+
+newtype Antithesis a = Antithesis { runAntithesis :: IO a }
+    deriving (Functor, Applicative, Monad)
+
+instance RandomSource Antithesis where
+    randomU64 = Antithesis $ do
+        haveCli <- doesExecutableExist "antithesis_random"
+        if haveCli
+            then readU64 <$> readProcess "antithesis_random" [] ""
+            else randomIO
+```
+
+The `Misbehaviour.ChainSyncFlap` shim in PR B simply returns
+`RespNotImplemented`; PR C swaps that out for a real handler.
+
+## Testing approach
+
+PR B's test suite exercises only the wire surface. No N2N connection
+attempts.
+
+| Test | What it asserts | Where |
+|---|---|---|
+| `ready` round-trip | Daemon starts, accepts connection, responds to `{"ready": null}` with a parseable `ReadyDetails`. | unit-tests |
+| reserved endpoint | `{"chain_sync_flap": {...}}` returns `{"ok": false, "reason": "not-implemented"}`. | unit-tests |
+| malformed JSON | Garbage bytes followed by `\n` get `{"error": "malformed json"}`. | unit-tests |
+| unknown key | `{"banana": null}` gets `{"error": "unknown request"}`. | unit-tests |
+| SIGTERM | Send SIGTERM, daemon unlinks socket and exits 0 within 5 s. | unit-tests (via `withDaemonProcess`) |
+| `--help` | CLI prints usage and exits 0. | unit-tests |
+
+## Nix flake outputs
+
+Adds:
+
+- `packages.${system}.cardano-adversary` — the executable.
+- `packages.${system}.cardano-adversary-docker-image` — a docker
+  image built via `dockerTools.buildImage`, mirroring the
+  tx-generator's image recipe in `nix/cardano-tx-generator.nix`.
+- `apps.${system}.cardano-adversary` — `nix run .#cardano-adversary`.
+
+## CI
+
+Extend `.github/workflows/publish-images.yaml` to also build and
+push `cardano-adversary` to GHCR. The workflow already loops over a
+list of image names; adding `cardano-adversary` is a one-line
+change.
+
+## Out of scope (deferred)
+
+- Any N2N connection setup. PR C lifts the `Adversary.ChainSync.*`
+  modules from
+  [`cardano-foundation/cardano-node-antithesis/components/adversary/src/`](https://github.com/cardano-foundation/cardano-node-antithesis/tree/main/components/adversary/src/Adversary/ChainSync)
+  into this package as `Cardano.Node.Client.Adversary.ChainSync.*`.
+- Antithesis SDK fallback emission. The daemon never writes to
+  `sdk.jsonl`; that's the composer driver's job.
+- Persisted state files. Misbehaviour archetypes that need them
+  (e.g. equivocation history) introduce their own files in their
+  own specs.
+
+## Risks
+
+- **Surge-style supply chain drift.** `nodePackages.surge` was
+  removed from `nixpkgs-unstable` on 2026-03-03; lesson: pin every
+  external nix dep explicitly. The flake's existing `nixpkgs` pin
+  applies to this package by default; no action needed beyond
+  reusing the project flake.
+- **Wire-spec drift between repos.** PR D in
+  [`cardano-foundation/cardano-node-antithesis`](https://github.com/cardano-foundation/cardano-node-antithesis/issues/90)
+  consumes this wire spec. Mitigation: include the `control-wire.md`
+  link in the published Docker image's `LABEL org.opencontainers.image.documentation`.

--- a/specs/036-cardano-adversary/spec.md
+++ b/specs/036-cardano-adversary/spec.md
@@ -1,0 +1,198 @@
+# Feature Specification: Cardano Adversary (Antithesis-driven, mini-protocol misbehaviour daemon)
+
+**Feature Branch**: `036-cardano-adversary`
+**Created**: 2026-04-30
+**Status**: Draft
+**Input**: User description: "Long-running Cardano adversary daemon driven by the Antithesis composer; performs configurable misbehaviour against producer / relay nodes through Ouroboros mini-protocols; copies the cardano-tx-generator daemon shape (long-running, NDJSON over UNIX `SOCK_STREAM`, one request per Antithesis tick); steered by an injectable `RandomSource` so the hypervisor can bias adversarial choices; replaces the one-shot Haskell binary in `cardano-foundation/cardano-node-antithesis/components/adversary/`."
+
+## Background
+
+The current adversary in
+[`cardano-foundation/cardano-node-antithesis`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/components/adversary/src/Adversary/Application.hs)
+is a **one-shot binary**: each Antithesis tick spawns it, it runs
+`NCONNS` concurrent chain-sync clients, and exits. The choices it
+makes at startup come from `newStdGen` — the Antithesis hypervisor
+cannot bias them.
+
+This package brings the adversary in line with the existing
+[`cardano-tx-generator`](https://github.com/lambdasistemi/cardano-node-clients/tree/main/app/cardano-tx-generator)
+shape: a **long-running daemon** that listens on a UNIX control
+socket and treats each composer driver invocation as one NDJSON
+request → one NDJSON response. Every adversarial action draws from
+a `RandomSource` typeclass whose hypervisor implementation reads
+from `antithesis_random` so the hypervisor steers the run.
+
+The first iteration of this package is **PR B (scaffold only)**: it
+publishes the package, the wire spec, the Docker image, and a
+daemon that answers the `ready` probe. Real misbehaviour endpoints
+land in subsequent PRs (C, E, etc.) per the
+[adversary roadmap](https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/docs/components/adversary-roadmap.md)
+on the antithesis side.
+
+## User Scenarios & Testing *(mandatory)*
+
+The primary user is the **Antithesis test composer**, firing short
+trigger commands at the daemon during a fault-injection run.
+Secondary user is the **operator** who wires the daemon into the
+testnet's compose stack and reads its diagnostic output.
+
+### User Story 1 — Readiness probe (Priority: P1)
+
+The composer needs to know the daemon is alive and connected to its
+target nodes before sending real misbehaviour requests.
+
+**Why this priority**: Every other story depends on the daemon
+being addressable. Without `ready`, composer drivers cannot tell
+"the daemon is starting up" from "the daemon crashed" and fault
+injection scoring is meaningless.
+
+**Independent Test**: Start the daemon against any reachable
+producer hostname, fire `{"ready": null}` repeatedly until the
+response carries `{"ready": true}`, assert that response within a
+bounded window.
+
+**Acceptance Scenarios**:
+
+1. **Given** the daemon has just started and is still warming up
+   internal state (DNS resolution, handshake to producers), **When**
+   the composer sends `{"ready": null}`, **Then** the daemon
+   responds `{"ready": false, ...details}` with structured details
+   identifying the missing readiness component.
+2. **Given** the daemon has completed its warmup, **When** the
+   composer sends `{"ready": null}`, **Then** the daemon responds
+   `{"ready": true, ...details}`.
+3. **Given** the daemon is healthy and a malformed JSON line is
+   received, **When** the line cannot be parsed, **Then** the
+   daemon responds `{"error": "malformed json"}` and closes the
+   connection (no crash).
+
+---
+
+### User Story 2 — Reserved misbehaviour endpoint slot (Priority: P1)
+
+The composer needs the wire surface to exist and be non-crashing
+even when the underlying misbehaviour is not yet implemented, so
+composer drivers can be merged in lock-step with the daemon
+endpoints. This is what makes PR B independently shippable.
+
+**Why this priority**: If the wire surface arrives only with the
+first real endpoint, the composer-side change in
+`cardano-foundation/cardano-node-antithesis` (PR D) blocks on PR C.
+Reserving the endpoint at scaffold time decouples them.
+
+**Independent Test**: Send `{"chain_sync_flap": {"seed": <any>,
+"limit": 1, "n_conns": 1}}` to the daemon; assert response is
+`{"ok": false, "reason": "not-implemented"}` with HTTP-style
+explicit not-implemented semantics so composer drivers can map it
+to an Antithesis SDK `sdk_unreachable("not-implemented")` until the
+real endpoint lands.
+
+**Acceptance Scenarios**:
+
+1. **Given** the daemon is running, **When** the composer sends a
+   request to a reserved-but-not-yet-implemented endpoint, **Then**
+   the daemon responds with `{"ok": false, "reason":
+   "not-implemented"}` and closes the connection.
+2. **Given** the daemon is running, **When** the composer sends a
+   request to a never-defined endpoint, **Then** the daemon responds
+   with `{"error": "unknown request"}` and closes the connection
+   (distinct from "not-implemented" which is documented).
+
+---
+
+### User Story 3 — Single shutdown surface (Priority: P2)
+
+The operator needs the daemon to shut down cleanly on `SIGTERM` so
+docker-compose container restarts don't leak state files. Mirrors
+the tx-generator's shutdown discipline.
+
+**Why this priority**: Operational paper cut, not on the test path.
+Skipping it doesn't prevent any composer story from working, but
+fixes a class of "container exited 137" reports that obscure real
+findings.
+
+**Acceptance Scenarios**:
+
+1. **Given** the daemon is running with an open control-socket
+   listener, **When** `SIGTERM` is delivered, **Then** the daemon
+   logs a shutdown line, drains any in-flight request, unlinks the
+   control socket, and exits 0 within 5 seconds.
+
+---
+
+## Functional Requirements
+
+- **FR-001** The daemon SHALL listen on the UNIX socket path passed
+  via `--control-socket`. The socket file SHALL be created with
+  `0600` permissions; filesystem permissions are the only
+  authentication.
+- **FR-002** The daemon SHALL accept exactly one NDJSON request per
+  connection. After writing the single-line response it SHALL
+  close the connection.
+- **FR-003** The daemon SHALL reject malformed JSON requests with
+  `{"error": "malformed json"}`.
+- **FR-004** The daemon SHALL reject requests whose top-level key
+  is not in the documented endpoint set with `{"error": "unknown
+  request"}`.
+- **FR-005** The daemon SHALL implement the `ready` endpoint
+  (defined in `contracts/control-wire.md`) returning a structured
+  status with at least an overall `ready: bool` flag.
+- **FR-006** The daemon SHALL accept a request to the
+  `chain_sync_flap` endpoint and respond `{"ok": false, "reason":
+  "not-implemented"}` until the endpoint's logic lands in a later
+  PR.
+- **FR-007** All randomness drawn by the daemon (warmup ordering,
+  any future misbehaviour choice) SHALL flow through a single
+  `RandomSource` interface. The default implementation SHALL be
+  Antithesis-aware: it SHALL invoke `antithesis_random` when
+  available on `PATH` and fall back to `System.Random` otherwise.
+- **FR-008** On `SIGTERM` the daemon SHALL drain in-flight
+  connections, unlink the control socket, and exit 0 within 5
+  seconds.
+- **FR-009** The daemon's CLI SHALL accept `--help` and exit 0.
+  Required flags MUST be enumerated and any missing required flag
+  MUST cause a non-zero exit with a usage line on stderr.
+- **FR-010** The package SHALL ship a Nix flake output
+  `.#cardano-adversary` (apps + packages + docker-image) following
+  the same naming as `cardano-tx-generator`'s flake outputs.
+- **FR-011** The Docker image SHALL be published to GHCR by the
+  existing `publish-images` workflow under
+  `ghcr.io/lambdasistemi/cardano-adversary`.
+
+## Non-Functional Requirements
+
+- **NFR-001** Resource budget: idle daemon < 50 MB RSS. (Real
+  endpoints will revise this in their own specs.)
+- **NFR-002** Cold-start time: from process exec to first
+  `{"ready": true}` < 30 s on a warm devnet.
+- **NFR-003** No stateful files in PR B. Endpoints that need
+  persistence (any future replay/contention archetype) are out of
+  scope.
+
+## Out of Scope
+
+- All Tier 1/2/3/4 misbehaviour archetypes other than the reserved
+  `chain_sync_flap` slot. Each gets its own spec under
+  `specs/0XX-...`.
+- Topology variants where the adversary acts as a node-to-node
+  *server* (Tier 3, upstream-peer Byzantine). Those need a separate
+  testnet variant in `cardano-node-antithesis`.
+- Compose wiring on the consumer side — that lives in
+  [`cardano-foundation/cardano-node-antithesis#90`](https://github.com/cardano-foundation/cardano-node-antithesis/issues/90).
+
+## Open Questions
+
+- Whether the `chain_sync_flap` request schema should already match
+  the final shape (so composer drivers don't need updating in PR C)
+  or stay deliberately minimal here. **Decision proposed**: match
+  the final shape now (seed, limit, n_conns), since the request
+  fields are obvious from today's CLI args of the existing
+  one-shot binary.
+
+## References
+
+- Wire spec: [`contracts/control-wire.md`](contracts/control-wire.md).
+- Plan: [`plan.md`](plan.md).
+- Tasks: [`tasks.md`](tasks.md).
+- Antithesis-side roadmap: https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/docs/components/adversary-roadmap.md
+- Antithesis-side tracking issue: https://github.com/cardano-foundation/cardano-node-antithesis/issues/89

--- a/specs/036-cardano-adversary/tasks.md
+++ b/specs/036-cardano-adversary/tasks.md
@@ -1,0 +1,78 @@
+# Tasks: Cardano Adversary (PR B scaffold)
+
+**Spec**: [`spec.md`](spec.md)
+**Plan**: [`plan.md`](plan.md)
+**Tracking issue**: https://github.com/lambdasistemi/cardano-node-clients/issues/102
+
+Each task lands as one bisect-safe commit on the
+`feat/cardano-adversary-scaffold` branch. Order matters: skipping
+forward leaves an uncompilable tree.
+
+## Tasks
+
+- **T001 — cabal target.** Add `executable cardano-adversary` to
+  `cardano-node-clients.cabal` with `hs-source-dirs:
+  app/cardano-adversary`, `main-is: Main.hs`, and the same
+  `build-depends` baseline as `cardano-tx-generator`. Add
+  `lib/Cardano/Node/Client/Adversary/` modules to the existing
+  `library`'s `exposed-modules` (initially empty stubs).
+- **T002 — Types.** `Cardano.Node.Client.Adversary.Types`:
+  `Request`, `Response`, `ChainSyncFlapArgs`, `ReadyDetails`,
+  `ErrorReason`. ToJSON / FromJSON instances matching
+  `contracts/control-wire.md` byte-for-byte.
+- **T003 — RandomSource.** `Cardano.Node.Client.Adversary.RandomSource`:
+  the typeclass and the `Antithesis` newtype with the
+  `antithesis_random`-CLI / `System.Random` fallback. Pure
+  function `splitFromSeed :: Word64 -> RandomGen` so the daemon
+  can derive a per-request `RandomGen` from the request's `seed`
+  field.
+- **T004 — Server.** `Cardano.Node.Client.Adversary.Server`:
+  `handleConnection` reading one NDJSON line, dispatching to the
+  request handler, writing one response, and closing. Pure JSON
+  parse / render is in `Types`; this module owns the I/O.
+- **T005 — Daemon.** `Cardano.Node.Client.Adversary.Daemon`:
+  `runDaemon`, signal handling, control-socket bind + `0600` mode,
+  `accept` loop using `forkFinally`. SIGTERM unlinks the socket
+  and exits 0 within 5 s.
+- **T006 — Main / CLI.** `app/cardano-adversary/Main.hs`:
+  `--help`, required `--control-socket`, optional
+  `--producer-host` (repeatable), `--producer-port`,
+  `--network-magic`. Calls `runDaemon`. Mirrors the tx-generator's
+  CLI shape so operators don't have to learn a second one.
+- **T007 — Unit tests.** `test/AdversaryServerSpec.hs`: ready
+  round-trip, reserved endpoint, malformed JSON, unknown key.
+  `test/AdversaryDaemonSpec.hs`: SIGTERM unlinks socket, `--help`
+  exits 0.
+- **T008 — Nix flake outputs.** `packages.${system}.cardano-adversary`,
+  `packages.${system}.cardano-adversary-docker-image`,
+  `apps.${system}.cardano-adversary`. Mirror
+  `nix/cardano-tx-generator.nix` in a sibling
+  `nix/cardano-adversary.nix`.
+- **T009 — Dockerfile.** `app/cardano-adversary/Dockerfile`
+  for the non-Nix build path. Add
+  `LABEL org.opencontainers.image.documentation=
+  https://github.com/lambdasistemi/cardano-node-clients/blob/main/specs/036-cardano-adversary/contracts/control-wire.md`.
+- **T010 — CI.** Extend
+  `.github/workflows/publish-images.yaml` so
+  `ghcr.io/lambdasistemi/cardano-adversary` is built and pushed
+  alongside `cardano-tx-generator`.
+- **T011 — Quality gate.** `nix develop -c just ci` green.
+  Fourmolu, hlint, cabal-check, build, and tests all pass.
+- **T012 — PR.** Open PR; link to
+  [issue #102](https://github.com/lambdasistemi/cardano-node-clients/issues/102)
+  and to the antithesis-side roadmap epic
+  [#89](https://github.com/cardano-foundation/cardano-node-antithesis/issues/89).
+  PR description summarises the wire surface so reviewers don't
+  need to dig into the spec.
+
+## Definition of done
+
+- [ ] All T001–T012 commits land in order; each compiles.
+- [ ] `cardano-adversary --help` works locally.
+- [ ] `nix run .#cardano-adversary -- --control-socket /tmp/adv.sock`
+      starts and responds to `printf '{"ready": null}\n' | nc -U
+      -q 1 /tmp/adv.sock` with a JSON line.
+- [ ] CI publishes `ghcr.io/lambdasistemi/cardano-adversary:<sha>`
+      after merge.
+- [ ] PR D in `cardano-foundation/cardano-node-antithesis` can pin
+      the published image and consume the wire surface end-to-end.

--- a/test/Cardano/Node/Client/Adversary/ServerSpec.hs
+++ b/test/Cardano/Node/Client/Adversary/ServerSpec.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Cardano.Node.Client.Adversary.ServerSpec
+Description : Unit tests for the cardano-adversary wire types
+License     : Apache-2.0
+
+Pins the wire schemas in
+@specs/036-cardano-adversary/contracts/control-wire.md@. Pure JSON
+encode / decode round-trips — no Unix socket involvement at this
+level. PR C will add an end-to-end socket round-trip test alongside
+the first real misbehaviour endpoint.
+-}
+module Cardano.Node.Client.Adversary.ServerSpec (spec) where
+
+import Cardano.Node.Client.Adversary.Types (
+    ChainSyncFlapArgs (..),
+    ErrorReason (..),
+    ReadyDetails (..),
+    Request (..),
+    Response (..),
+ )
+import Data.Aeson (
+    decode,
+    eitherDecode,
+    encode,
+    object,
+    (.=),
+ )
+import Data.ByteString.Lazy (ByteString)
+import Data.Either (isLeft)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+
+spec :: Spec
+spec = do
+    describe "Request decoding" $ do
+        it "parses {\"ready\": null}" $
+            decodeReq "{\"ready\":null}"
+                `shouldBe` Right ReqReady
+
+        it "parses chain_sync_flap" $
+            decodeReq
+                "{\"chain_sync_flap\":{\"seed\":12345,\"limit\":100,\"n_conns\":1}}"
+                `shouldBe` Right
+                    ( ReqChainSyncFlap
+                        ChainSyncFlapArgs
+                            { csfSeed = 12345
+                            , csfLimit = 100
+                            , csfNConns = 1
+                            }
+                    )
+
+        it "rejects {} (no top-level key)" $
+            decodeReq "{}" `shouldSatisfy` isLeft'
+
+        it "rejects multi-key envelopes" $
+            decodeReq
+                "{\"ready\":null,\"chain_sync_flap\":null}"
+                `shouldSatisfy` isLeft'
+
+        it "rejects unknown top-level keys" $
+            decodeReq
+                "{\"surprise\":null}"
+                `shouldSatisfy` isLeft'
+
+    describe "Response encoding" $ do
+        it "RespReady embeds ReadyDetails as documented" $
+            encode
+                ( RespReady
+                    ReadyDetails
+                        { readyOverall = True
+                        , readyN2NHandshakeOk = False
+                        , readyConfiguredHosts = ["p1.example", "p2.example"]
+                        }
+                )
+                `shouldBe` encode
+                    ( object
+                        [ "ready" .= True
+                        , "details"
+                            .= object
+                                [ "n2nHandshakeOk" .= False
+                                , "configuredHosts"
+                                    .= ["p1.example" :: String, "p2.example"]
+                                ]
+                        ]
+                    )
+
+        it "RespNotImplemented uses the documented shape" $
+            encode RespNotImplemented
+                `shouldBe` encode
+                    ( object
+                        [ "ok" .= False
+                        , "reason" .= ("not-implemented" :: String)
+                        ]
+                    )
+
+        it "RespError ErrMalformedJson is {\"error\":\"malformed json\"}" $
+            encode (RespError ErrMalformedJson)
+                `shouldBe` encode
+                    ( object ["error" .= ("malformed json" :: String)]
+                    )
+
+        it "RespError ErrUnknownRequest is {\"error\":\"unknown request\"}" $
+            encode (RespError ErrUnknownRequest)
+                `shouldBe` encode
+                    ( object ["error" .= ("unknown request" :: String)]
+                    )
+
+    describe "Round-trip" $ do
+        it "ChainSyncFlapArgs encodes and decodes back to itself" $ do
+            let body =
+                    ChainSyncFlapArgs
+                        { csfSeed = maxBound
+                        , csfLimit = 12345
+                        , csfNConns = 7
+                        }
+            decode (encode body) `shouldBe` Just body
+
+        it "ReadyDetails encodes and decodes back to itself" $ do
+            let r =
+                    ReadyDetails
+                        { readyOverall = False
+                        , readyN2NHandshakeOk = False
+                        , readyConfiguredHosts = ["a", "b", "c"]
+                        }
+            decode (encode r) `shouldBe` Just r
+
+decodeReq :: ByteString -> Either String Request
+decodeReq = eitherDecode
+
+isLeft' :: Either String a -> Bool
+isLeft' = isLeft

--- a/test/unit-main.hs
+++ b/test/unit-main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Test.Hspec (hspec)
 
+import Cardano.Node.Client.Adversary.ServerSpec qualified as AdversaryServerSpec
 import Cardano.Node.Client.BalanceSpec qualified as BalanceSpec
 import Cardano.Node.Client.TxBuildGoldenSpec qualified as TxBuildGoldenSpec
 import Cardano.Node.Client.TxBuildSpec qualified as TxBuildSpec
@@ -20,6 +21,7 @@ import Data.List.SampleFibonacciSpec qualified as SampleFibonacciSpec
 main :: IO ()
 main = hspec $ do
     SampleFibonacciSpec.spec
+    AdversaryServerSpec.spec
     BalanceSpec.spec
     TxBuildSpec.spec
     TxBuildGoldenSpec.spec


### PR DESCRIPTION
Closes #102.

PR B of the [adversary roadmap](https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/docs/components/adversary-roadmap.md). Long-running daemon scaffold mirroring `cardano-tx-generator`. Real misbehaviour endpoints land in PR C and beyond.

## What this PR ships

### Wire surface

NDJSON over UNIX `SOCK_STREAM`, one request per connection. Two endpoints in PR B:

- `{"ready": null}` → `{"ready": <bool>, "details": {"n2nHandshakeOk": ..., "configuredHosts": [...]}}`
- `{"chain_sync_flap": {"seed": ..., "limit": ..., "n_conns": ...}}` → `{"ok": false, "reason": "not-implemented"}` (reserved; PR C swaps the body)

Malformed JSON: `{"error": "malformed json"}`. Unknown top-level key: `{"error": "unknown request"}`. SIGTERM unlinks the socket and exits 0.

Full schema in [`specs/036-cardano-adversary/contracts/control-wire.md`](https://github.com/lambdasistemi/cardano-node-clients/blob/feat/cardano-adversary-scaffold/specs/036-cardano-adversary/contracts/control-wire.md).

### Package layout

```
app/cardano-adversary/Main.hs               CLI parser, --help, dieUsage
lib/Cardano/Node/Client/Adversary/
    Daemon.hs                               entry, signals, control socket
    Server.hs                               NDJSON dispatcher (ServerHooks)
    Types.hs                                Request / Response, ToJSON / FromJSON
    RandomSource.hs                         typeclass + Antithesis impl + splitFromSeed
specs/036-cardano-adversary/
    spec.md, plan.md, tasks.md, contracts/control-wire.md
test/Cardano/Node/Client/Adversary/ServerSpec.hs   11 hspec examples
nix/cardano-adversary-docker-image.nix      docker image recipe
.github/workflows/publish-images.yaml       parallel cardano-adversary job
```

### Steerable randomness

`Cardano.Node.Client.Adversary.RandomSource` is the typeclass every adversarial decision draws from. The default `Antithesis` newtype shells out to `antithesis_random` when present on `PATH` and falls back to `System.Random` when not — so the hypervisor can bias the run on Antithesis but smoke testing on a workstation still works. `splitFromSeed :: Word64 -> StdGen` lets a single per-request `seed` field deterministically drive every further random value within the request, mirroring the tx-generator's discipline.

### Commits in this PR

| # | Commit | Concern |
|---|---|---|
| spec | `25f6cb6` | speckit artifacts (spec, plan, tasks, wire) |
| T001 | `2b6e2e8` | cabal target + module stubs |
| T002 | `549f360` | Types.hs (wire types + JSON instances) |
| T003 | `a5f0164` | RandomSource typeclass + Antithesis impl |
| T004 | `08c105f` | Server.hs (NDJSON dispatcher) |
| T005 | `467bcd9` | Daemon.hs (entry, signals, sockets) |
| T006 | `34d3f62` | Main.hs (real CLI with --help) |
| T007 | `bc66e9e` | Wire-type unit tests |
| T008 | `861d6a9` | Nix flake outputs |
| T010 | `7a15ceb` | publish-images workflow |

T009 (non-Nix Dockerfile) is intentionally skipped: cardano-node-antithesis only consumes the nix-built image from GHCR, so a hand-rolled Dockerfile would be a second path to maintain. T011 (quality gate) ran clean locally — `cabal-fmt`, `fourmolu`, `hlint`, all 201 unit tests, `nix build .#cardano-adversary` and `.#cardano-adversary-image`.

## Verification

End-to-end smoke run on the local devshell:

```
$ cabal run cardano-adversary -- --help
cardano-adversary — cardano-adversary daemon (PR B scaffold)
...

$ cabal run cardano-adversary -- --control-socket /tmp/adv.sock --network-magic 42 --producer-host p1.example
$ printf '{"ready": null}\n' | nc -U -N /tmp/adv.sock
{"details":{"configuredHosts":["p1.example"],"n2nHandshakeOk":false},"ready":true}

$ printf '{"chain_sync_flap": {"seed": 12345, "limit": 100, "n_conns": 1}}\n' | nc -U -N /tmp/adv.sock
{"ok":false,"reason":"not-implemented"}

$ printf 'not-json\n' | nc -U -N /tmp/adv.sock
{"error":"malformed json"}
```

After SIGTERM the control socket is unlinked.

## Roadmap

Once this lands and the docker image is published:

- PR C (cardano-node-clients) — implement `chain_sync_flap` by porting [`Adversary.Application`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/components/adversary/src/Adversary/Application.hs) into the daemon. RandomSource plumbing already in place.
- PR D ([`cardano-foundation/cardano-node-antithesis#90`](https://github.com/cardano-foundation/cardano-node-antithesis/issues/90)) — switch `components/adversary/` to consume the new image; delete the standalone Haskell binary.
- PR E (cardano-node-clients) — `chain_sync_thrash` + `chain_sync_slow_loris`. Tier 1 complete.

Antithesis-side roadmap epic: [`cardano-foundation/cardano-node-antithesis#89`](https://github.com/cardano-foundation/cardano-node-antithesis/issues/89).