### PR TITLE
feat(tx-generator): supervise N2C connection via N2C.Reconnect

### DIFF
--- a/app/cardano-tx-generator/Main.hs
+++ b/app/cardano-tx-generator/Main.hs
@@ -9,11 +9,20 @@ shape mirrors @specs/034-cardano-tx-generator/quickstart.md@.
 -}
 module Main (main) where
 
+import Cardano.Node.Client.N2C.Probe (
+    ProbeConfig (..),
+    defaultProbeConfig,
+ )
+import Cardano.Node.Client.N2C.Reconnect (
+    ReconnectPolicy (..),
+    defaultReconnectPolicy,
+ )
 import Cardano.Node.Client.TxGenerator.Daemon (
     DaemonConfig (..),
     runDaemon,
  )
 import Data.Maybe (fromMaybe)
+import Data.Word (Word64)
 import System.Environment (getArgs, getProgName)
 import System.Exit (exitFailure)
 import System.IO (hPutStrLn, stderr)
@@ -70,7 +79,24 @@ parseConfig args0 = do
         (mDb, args11) = case takeFlag "--db-path" args10 of
             Just (p, rest) -> (Just p, rest)
             Nothing -> (Nothing, args10)
-    case args11 of
+        (initialMsS, args12) =
+            fromMaybe
+                (show (rpInitialMs defaultReconnectPolicy), args11)
+                (takeFlag "--reconnect-initial-ms" args11)
+        (maxMsS, args13) =
+            fromMaybe
+                (show (rpMaxMs defaultReconnectPolicy), args12)
+                (takeFlag "--reconnect-max-ms" args12)
+        (resetMsS, args14) =
+            fromMaybe
+                ( show (rpResetThresholdMs defaultReconnectPolicy)
+                , args13
+                )
+                (takeFlag "--reconnect-reset-threshold-ms" args13)
+        (mTotalMs, args15) = case takeFlag "--node-ready-timeout-ms" args14 of
+            Just (s, rest) -> (Just s, rest)
+            Nothing -> (Nothing, args14)
+    case args15 of
         [] -> pure ()
         extra -> dieUsage $ "Unexpected args: " <> show extra
     magic <- requireWord "--network-magic" magicS
@@ -78,6 +104,28 @@ parseConfig args0 = do
     timeout <- requireWord "--await-timeout-seconds" timeoutS
     ready <- requireWord "--ready-threshold-slots" readyS
     k <- requireWord "--security-param-k" kS
+    initialMs <- requireWord "--reconnect-initial-ms" initialMsS
+    maxMs <- requireWord "--reconnect-max-ms" maxMsS
+    resetMs <-
+        requireWord "--reconnect-reset-threshold-ms" resetMsS
+    mTotalMsParsed <- case mTotalMs of
+        Nothing -> pure Nothing
+        Just s ->
+            Just <$> requireWord "--node-ready-timeout-ms" s
+    let policy =
+            ReconnectPolicy
+                { rpInitialMs = fromIntegral (initialMs :: Word)
+                , rpMaxMs = fromIntegral (maxMs :: Word)
+                , rpResetThresholdMs =
+                    fromIntegral (resetMs :: Word)
+                }
+        probe =
+            defaultProbeConfig
+                { pcTotalTimeoutMs =
+                    fmap
+                        (fromIntegral :: Word -> Word64)
+                        mTotalMsParsed
+                }
     pure
         DaemonConfig
             { dcRelaySocket = relay
@@ -91,6 +139,8 @@ parseConfig args0 = do
             , dcReadyThresholdSlots = fromIntegral (ready :: Word)
             , dcSecurityParamK = fromIntegral (k :: Word)
             , dcDbPath = mDb
+            , dcReconnectPolicy = policy
+            , dcProbeConfig = probe
             }
   where
     requireFlag key args =
@@ -124,7 +174,11 @@ dieUsage msg = do
     hPutStrLn stderr "  [--await-timeout-seconds INT] \\"
     hPutStrLn stderr "  [--ready-threshold-slots INT] \\"
     hPutStrLn stderr "  [--security-param-k INT] \\"
-    hPutStrLn stderr "  [--db-path DIR]"
+    hPutStrLn stderr "  [--db-path DIR] \\"
+    hPutStrLn stderr "  [--reconnect-initial-ms INT] \\"
+    hPutStrLn stderr "  [--reconnect-max-ms INT] \\"
+    hPutStrLn stderr "  [--reconnect-reset-threshold-ms INT] \\"
+    hPutStrLn stderr "  [--node-ready-timeout-ms INT]"
     exitFailure
 
 main :: IO ()

--- a/lib/Cardano/Node/Client/N2C/LocalStateQuery.hs
+++ b/lib/Cardano/Node/Client/N2C/LocalStateQuery.hs
@@ -19,6 +19,7 @@ module Cardano.Node.Client.N2C.LocalStateQuery (
 ) where
 
 import Cardano.Node.Client.N2C.Types (
+    ConnectionLost (..),
     LSQChannel (..),
     SomeLSQQuery (..),
  )
@@ -34,6 +35,11 @@ import Control.Concurrent.STM (
     takeTMVar,
     tryReadTBQueue,
     writeTBQueue,
+ )
+import Control.Exception (
+    BlockedIndefinitelyOnSTM,
+    handle,
+    throwIO,
  )
 import Ouroboros.Consensus.Ledger.Query (Query)
 import Ouroboros.Network.Protocol.LocalStateQuery.Client (
@@ -141,4 +147,11 @@ queryLSQ ch query = do
     atomically $
         writeTBQueue (lsqRequests ch) $
             SomeLSQQuery query resultVar
-    atomically $ takeTMVar resultVar
+    -- Catch the synchronous-deadlock detection that GHC
+    -- raises when the consumer thread died with this
+    -- request in flight, and re-raise 'ConnectionLost' so
+    -- callers see a typed, recoverable exception. The
+    -- reconnect supervisor will reopen the bearer.
+    handle
+        (\(_ :: BlockedIndefinitelyOnSTM) -> throwIO ConnectionLost)
+        (atomically $ takeTMVar resultVar)

--- a/lib/Cardano/Node/Client/N2C/LocalTxSubmission.hs
+++ b/lib/Cardano/Node/Client/N2C/LocalTxSubmission.hs
@@ -17,6 +17,7 @@ module Cardano.Node.Client.N2C.LocalTxSubmission (
 ) where
 
 import Cardano.Node.Client.N2C.Types (
+    ConnectionLost (..),
     LTxSChannel (..),
     TxSubmitRequest (..),
  )
@@ -28,6 +29,11 @@ import Control.Concurrent.STM (
     readTBQueue,
     takeTMVar,
     writeTBQueue,
+ )
+import Control.Exception (
+    BlockedIndefinitelyOnSTM,
+    handle,
+    throwIO,
  )
 import Ouroboros.Consensus.Ledger.SupportsMempool (
     ApplyTxErr,
@@ -77,6 +83,13 @@ clientIdle ch = do
 
 {- | Submit a transaction through the channel and
 block until the result is available.
+
+Re-raises 'ConnectionLost' instead of letting GHC's
+'BlockedIndefinitelyOnSTM' escape when the consumer
+thread dies with the request in flight (bearer
+closed mid-submit). The reconnect supervisor will
+reopen the bearer; callers should treat
+'ConnectionLost' as transient and retry.
 -}
 submitTxN2C ::
     -- | Channel to the LocalTxSubmission client
@@ -92,4 +105,6 @@ submitTxN2C ch tx = do
                 { tsrTx = tx
                 , tsrResult = resultVar
                 }
-    atomically $ takeTMVar resultVar
+    handle
+        (\(_ :: BlockedIndefinitelyOnSTM) -> throwIO ConnectionLost)
+        (atomically $ takeTMVar resultVar)

--- a/lib/Cardano/Node/Client/N2C/Types.hs
+++ b/lib/Cardano/Node/Client/N2C/Types.hs
@@ -23,9 +23,13 @@ module Cardano.Node.Client.N2C.Types (
     -- * Request wrappers
     SomeLSQQuery (..),
     TxSubmitRequest (..),
+
+    -- * Connection-loss signal
+    ConnectionLost (..),
 ) where
 
 import Control.Concurrent.STM (TBQueue, TMVar)
+import Control.Exception (Exception)
 
 import Cardano.Node.Client.Types (Block)
 import Ouroboros.Consensus.Ledger.Query (Query)
@@ -71,3 +75,25 @@ LocalTxSubmission mini-protocol client.
 newtype LTxSChannel = LTxSChannel
     { ltxsRequests :: TBQueue TxSubmitRequest
     }
+
+{- | Synchronous exception raised by 'queryLSQ' /
+'submitTxN2C' when the underlying N2C connection died
+mid-request.
+
+Symptom this replaces: GHC throws
+'BlockedIndefinitelyOnSTM' to the caller because the
+consumer thread held the only reference to the
+result 'TMVar', then died with the bearer-close
+exception, and GC observed no remaining writers. By
+catching that synchronous-detected deadlock here and
+re-raising 'ConnectionLost' instead, callers see a
+typed exception they can handle (e.g. surface
+@no-pickable-source@ / @index-not-ready@ to the
+composer and exit 1 for a retry on the next tick),
+and the daemon process stays alive while the
+reconnect supervisor reopens the bearer.
+-}
+data ConnectionLost = ConnectionLost
+    deriving stock (Eq, Show)
+
+instance Exception ConnectionLost

--- a/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
+++ b/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
@@ -31,6 +31,7 @@ T008 wires the @refill@ arm end-to-end (User Story 2).
 module Cardano.Node.Client.TxGenerator.Daemon (
     DaemonConfig (..),
     runDaemon,
+    runDaemonWithTracer,
 ) where
 
 import Cardano.Chain.Slotting (EpochSlots (..))

--- a/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
+++ b/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -81,6 +82,7 @@ import Cardano.Node.Client.N2C.Trace (
     N2CEvent,
     defaultStderrTracer,
  )
+import Cardano.Node.Client.N2C.Types (ConnectionLost (..))
 import Cardano.Node.Client.Provider (Provider (..))
 import Cardano.Node.Client.Submitter (
     SubmitResult (..),
@@ -349,13 +351,28 @@ runDaemonWithTracer tracer cfg = do
             threadDelay 3_000_000
             let provider = mkN2CProvider lsqCh
                 submitter = mkN2CSubmitter ltxsCh
-            pp <- queryProtocolParams provider
+            -- Boot-time LSQ probes can race the supervisor
+            -- if the bearer dies during chain replay; loop
+            -- with a short backoff so the daemon process
+            -- survives early disconnects too. The
+            -- supervisor is already retrying the bearer
+            -- itself; this just keeps the boot waiting
+            -- until LSQ is reachable.
+            let bootRetry :: forall a. IO a -> IO a
+                bootRetry act =
+                    E.try @ConnectionLost act >>= \case
+                        Right v -> pure v
+                        Left ConnectionLost -> do
+                            threadDelay 500_000
+                            bootRetry act
+            pp <- bootRetry (queryProtocolParams provider)
             -- Probe the faucet once at startup so the
             -- @ready@ probe can flip @faucetUtxosKnown@
             -- without waiting for the first @refill@
             -- trigger. Subsequent refills update this flag
             -- per their LSQ response.
-            initialFaucetUtxos <- queryUTxOs provider faucetAddr
+            initialFaucetUtxos <-
+                bootRetry (queryUTxOs provider faucetAddr)
             atomically
                 ( writeTVar
                     faucetKnownVar
@@ -371,31 +388,50 @@ runDaemonWithTracer tracer cfg = do
                         idx
                         net
                         masterSeed
-                doRefill =
-                    runRefillArm
-                        cfg
-                        pp
-                        idx
-                        provider
-                        submitter
-                        net
-                        masterSeed
-                        faucetSKey
-                        faucetAddr
-                        nextIdxMVar
-                        lastTxIdVar
-                        faucetKnownVar
-                doTransact =
-                    runTransactArm
-                        cfg
-                        pp
-                        idx
-                        provider
-                        submitter
-                        net
-                        masterSeed
-                        nextIdxMVar
-                        lastTxIdVar
+                -- Both arms can raise 'ConnectionLost' when
+                -- a request is in flight at the moment the
+                -- N2C bearer dies. The reconnect supervisor
+                -- reopens the bearer; the arm just needs to
+                -- surface a not-applicable response so the
+                -- composer retries on the next tick instead
+                -- of taking down the daemon process.
+                doRefill req =
+                    E.handle
+                        ( \ConnectionLost ->
+                            pure (RefillFail IndexNotReady)
+                        )
+                        ( runRefillArm
+                            cfg
+                            pp
+                            idx
+                            provider
+                            submitter
+                            net
+                            masterSeed
+                            faucetSKey
+                            faucetAddr
+                            nextIdxMVar
+                            lastTxIdVar
+                            faucetKnownVar
+                            req
+                        )
+                doTransact req =
+                    E.handle
+                        ( \ConnectionLost ->
+                            pure (TransactFail IndexNotReady)
+                        )
+                        ( runTransactArm
+                            cfg
+                            pp
+                            idx
+                            provider
+                            submitter
+                            net
+                            masterSeed
+                            nextIdxMVar
+                            lastTxIdVar
+                            req
+                        )
                 hooks =
                     ServerHooks
                         { hooksReady = getReady

--- a/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
+++ b/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
@@ -69,8 +69,18 @@ import Cardano.Node.Client.N2C.Connection (
     newLTxSChannel,
     runNodeClientFull,
  )
+import Cardano.Node.Client.N2C.Probe (ProbeConfig)
 import Cardano.Node.Client.N2C.Provider (mkN2CProvider)
+import Cardano.Node.Client.N2C.Reconnect (
+    ReconnectPolicy,
+    UpstreamStatus (..),
+    runReconnectLoop,
+ )
 import Cardano.Node.Client.N2C.Submitter (mkN2CSubmitter)
+import Cardano.Node.Client.N2C.Trace (
+    N2CEvent,
+    defaultStderrTracer,
+ )
 import Cardano.Node.Client.Provider (Provider (..))
 import Cardano.Node.Client.Submitter (
     SubmitResult (..),
@@ -139,12 +149,14 @@ import Control.Concurrent.MVar (
 import Control.Concurrent.STM (
     TVar,
     atomically,
+    modifyTVar',
     newTVarIO,
     readTVarIO,
     writeTVar,
  )
+import Control.Exception qualified as E
 import Control.Monad (void)
-import Control.Tracer (nullTracer)
+import Control.Tracer (Tracer, nullTracer)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
@@ -155,6 +167,7 @@ import Data.Maybe (isJust)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text.Encoding qualified as Text
+import Data.Void (Void)
 import Data.Word (Word16, Word32, Word64)
 import Lens.Micro ((%~), (&), (^.))
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (
@@ -180,14 +193,29 @@ data DaemonConfig = DaemonConfig
     , dcReadyThresholdSlots :: !Word64
     , dcSecurityParamK :: !Int
     , dcDbPath :: !(Maybe FilePath)
+    , dcReconnectPolicy :: !ReconnectPolicy
+    -- ^ Policy used by the N2C reconnect supervisor
+    -- wrapping the relay connection. Defaults via
+    -- 'defaultReconnectPolicy'.
+    , dcProbeConfig :: !ProbeConfig
+    -- ^ Pre-attempt probe used by the supervisor to wait
+    -- for the relay's ChainDB to finish loading. Defaults
+    -- via 'defaultProbeConfig' — chain-replay-tolerant
+    -- (unbounded total wait, replay-aware retries).
     }
     deriving stock (Show)
 
--- | Mirrors the indexer's per-run readiness state.
+{- | Mirrors the indexer's per-run readiness state. The
+'rsUpstream' field surfaces the reconnect supervisor's
+view of the bearer; 'readyResponseFrom' enforces the
+invariant @UpstreamDisconnected => ready=false@ on the
+wire.
+-}
 data ReadyState = ReadyState
     { rsReady :: !Bool
     , rsTipSlot :: !(Maybe Word64)
     , rsProcessedSlot :: !(Maybe Word64)
+    , rsUpstream :: !UpstreamStatus
     }
     deriving stock (Show)
 
@@ -197,6 +225,7 @@ initialReady =
         { rsReady = False
         , rsTipSlot = Nothing
         , rsProcessedSlot = Nothing
+        , rsUpstream = UpstreamConnected
         }
 
 data BootMode
@@ -217,9 +246,32 @@ to the relay carrying chain-sync + LSQ + LTxS, query
 protocol parameters once at startup, mount the control
 wire on @dcControlSocket@, and block until the chain-sync
 side or the server exits.
+
+The relay connection is wrapped in
+'Cardano.Node.Client.N2C.Reconnect.runReconnectLoop'.
+When the upstream relay closes the bearer (network
+partition, container restart, or the
+'Network.Socket.sendBuf: resource vanished (Broken pipe)'
+/ @BlockedIndefinitely@ pair we observed under
+Antithesis fault injection on
+cardano-foundation/cardano-node-antithesis @ ed6666d) the
+supervisor catches the exception, flips
+'rsUpstream' to 'UpstreamDisconnected', re-probes the
+relay, and reopens the connection. The control surface
+stays bound throughout; @ready@ responses advertise the
+upstream gap; in-flight LSQ/LTxS requests fail fast and
+callers retry on the next composer tick.
 -}
 runDaemon :: DaemonConfig -> IO ()
-runDaemon cfg = do
+runDaemon = runDaemonWithTracer defaultStderrTracer
+
+{- | Variant of 'runDaemon' that takes an explicit
+'N2CEvent' tracer. Wired this way so tests can capture
+supervisor events; the binary uses 'runDaemon' which
+defaults to the stderr renderer.
+-}
+runDaemonWithTracer :: Tracer IO N2CEvent -> DaemonConfig -> IO ()
+runDaemonWithTracer tracer cfg = do
     createDirectoryIfMissing True (dcStateDir cfg)
     masterSeed <- loadOrCreateSeed (dcMasterSeedFile cfg)
     faucetKeyBytes <- BS.readFile (dcFaucetSKeyFile cfg)
@@ -245,16 +297,55 @@ runDaemon cfg = do
                     nullTracer
                     (mkIntersector bootMode cfg readyVar idx)
                     resumePoints
-            nodeAction =
-                runNodeClientFull
+            -- One full N2C session: chain-sync + LSQ +
+            -- LTxS over a single mux bearer. Wrapped in
+            -- 'try' so synchronous exceptions surface to
+            -- the supervisor instead of escaping it.
+            nodeSession =
+                E.try $
+                    void $
+                        runNodeClientFull
+                            (NetworkMagic (dcNetworkMagic cfg))
+                            (EpochSlots (dcByronEpochSlots cfg))
+                            (dcRelaySocket cfg)
+                            chainSyncApp
+                            lsqCh
+                            ltxsCh
+            -- Status sink: every supervisor transition
+            -- goes through this. On UpstreamDisconnected
+            -- we also force rsReady=False at the
+            -- producer (the encoder enforces the same
+            -- invariant on the wire — defense in depth).
+            setUpstreamStatus newStatus =
+                atomically $ modifyTVar' readyVar $ \rs ->
+                    case newStatus of
+                        UpstreamConnected ->
+                            rs{rsUpstream = UpstreamConnected}
+                        UpstreamDisconnected _ ->
+                            rs
+                                { rsUpstream = newStatus
+                                , rsReady = False
+                                }
+            getProcessedSlot =
+                fmap Idx.SlotNo . rsProcessedSlot
+                    <$> readTVarIO readyVar
+            supervisedNodeAction :: IO Void
+            supervisedNodeAction =
+                runReconnectLoop
+                    tracer
+                    (dcReconnectPolicy cfg)
+                    (dcProbeConfig cfg)
                     (NetworkMagic (dcNetworkMagic cfg))
-                    (EpochSlots (dcByronEpochSlots cfg))
                     (dcRelaySocket cfg)
-                    chainSyncApp
-                    lsqCh
-                    ltxsCh
-        withAsync (void nodeAction) $ \_nodeT -> do
-            -- Brief settle for the mux handshake.
+                    setUpstreamStatus
+                    getProcessedSlot
+                    nodeSession
+        withAsync (void supervisedNodeAction) $ \_nodeT -> do
+            -- Brief settle for the mux handshake. The
+            -- probe in 'runReconnectLoop' has already
+            -- confirmed the relay's LSQ answers, so this
+            -- is just a courtesy gap before the first
+            -- queryProtocolParams.
             threadDelay 3_000_000
             let provider = mkN2CProvider lsqCh
                 submitter = mkN2CSubmitter ltxsCh
@@ -750,11 +841,25 @@ readyResponseFrom ::
 readyResponseFrom readyVar faucetKnownVar = do
     rs <- readTVarIO readyVar
     fk <- readTVarIO faucetKnownVar
+    -- Defense in depth: when the supervisor reports
+    -- 'UpstreamDisconnected' the client must treat the
+    -- daemon as not-ready even if the producer's TVar
+    -- still has 'rsReady=True' from before the bearer
+    -- closed. The encoder-side enforcement in
+    -- 'TxGenerator.Types.ReadyResponse'\''s 'ToJSON' makes
+    -- this an invariant on the wire.
+    let ready = case rsUpstream rs of
+            UpstreamConnected -> rsReady rs && fk
+            UpstreamDisconnected{} -> False
+        indexReady = case rsUpstream rs of
+            UpstreamConnected -> rsReady rs
+            UpstreamDisconnected{} -> False
     pure
         ReadyResponse
-            { readyReady = rsReady rs && fk
-            , readyIndexReady = rsReady rs
+            { readyReady = ready
+            , readyIndexReady = indexReady
             , readyFaucetUtxosKnown = fk
+            , readyUpstream = rsUpstream rs
             }
 
 snapshotResponseFrom ::
@@ -950,17 +1055,19 @@ updateReady ::
     Idx.SlotNo ->
     Network.SlotNo ->
     IO ()
-updateReady cfg readyVar (Idx.SlotNo processed) tipNet =
+updateReady cfg readyVar (Idx.SlotNo processed) tipNet = do
     let tip = Network.unSlotNo tipNet
         behind =
             if tip > processed
                 then tip - processed
                 else 0
         ready = behind <= dcReadyThresholdSlots cfg
-        rs =
-            ReadyState
-                { rsReady = ready
-                , rsTipSlot = Just tip
-                , rsProcessedSlot = Just processed
-                }
-     in atomically (writeTVar readyVar rs)
+    -- Preserve the supervisor-managed 'rsUpstream'. The
+    -- chain-sync follower owns rsReady/rsTipSlot/
+    -- rsProcessedSlot; the supervisor owns rsUpstream.
+    atomically $ modifyTVar' readyVar $ \rs ->
+        rs
+            { rsReady = ready
+            , rsTipSlot = Just tip
+            , rsProcessedSlot = Just processed
+            }

--- a/lib/Cardano/Node/Client/TxGenerator/Types.hs
+++ b/lib/Cardano/Node/Client/TxGenerator/Types.hs
@@ -30,6 +30,10 @@ module Cardano.Node.Client.TxGenerator.Types (
     failureReasonText,
 ) where
 
+import Cardano.Node.Client.N2C.Reconnect (
+    DisconnectInfo (..),
+    UpstreamStatus (..),
+ )
 import Data.Aeson (
     FromJSON (..),
     ToJSON (..),
@@ -67,11 +71,21 @@ newtype RefillRequest = RefillRequest
     }
     deriving stock (Eq, Show)
 
--- | Wire body of the @ready@ response.
+{- | Wire body of the @ready@ response.
+
+'readyUpstream' surfaces the N2C reconnect supervisor's
+view of the relay connection. Encoder invariant
+(mirrors @utxo-indexer@ via PR #98): when
+'readyUpstream' is 'UpstreamDisconnected' the wire
+emits @ready=false@ regardless of 'readyReady', and
+adds an @upstream@ object with the disconnect reason
+and reconnect-attempt counters.
+-}
 data ReadyResponse = ReadyResponse
     { readyReady :: !Bool
     , readyIndexReady :: !Bool
     , readyFaucetUtxosKnown :: !Bool
+    , readyUpstream :: !UpstreamStatus
     }
     deriving stock (Eq, Show)
 
@@ -186,12 +200,42 @@ instance FromJSON RefillRequest where
 -- ----------------------------------------------------------------------
 
 instance ToJSON ReadyResponse where
-    toJSON ReadyResponse{readyReady, readyIndexReady, readyFaucetUtxosKnown} =
-        object
-            [ "ready" .= readyReady
-            , "indexReady" .= readyIndexReady
-            , "faucetUtxosKnown" .= readyFaucetUtxosKnown
-            ]
+    toJSON
+        ReadyResponse
+            { readyReady
+            , readyIndexReady
+            , readyFaucetUtxosKnown
+            , readyUpstream
+            } =
+            object (baseFields <> upstreamField)
+          where
+            -- Defensively force ready=false whenever the
+            -- supervisor reports a disconnected upstream.
+            -- Mirrors the indexer's encoder shape so a
+            -- consumer that already knows the indexer's
+            -- @ready@ contract gets the same semantics.
+            ready = case readyUpstream of
+                UpstreamConnected -> readyReady
+                UpstreamDisconnected{} -> False
+            indexReady = case readyUpstream of
+                UpstreamConnected -> readyIndexReady
+                UpstreamDisconnected{} -> False
+            baseFields =
+                [ "ready" .= ready
+                , "indexReady" .= indexReady
+                , "faucetUtxosKnown" .= readyFaucetUtxosKnown
+                ]
+            upstreamField = case readyUpstream of
+                UpstreamConnected -> []
+                UpstreamDisconnected di ->
+                    [ "upstream"
+                        .= object
+                            [ "status" .= ("disconnected" :: Text)
+                            , "reason" .= diReason di
+                            , "attempt" .= diAttempt di
+                            , "sinceMs" .= diSinceMs di
+                            ]
+                    ]
 
 instance ToJSON SnapshotResponse where
     toJSON

--- a/test/Cardano/Node/Client/E2E/TxGeneratorEnduranceSpec.hs
+++ b/test/Cardano/Node/Client/E2E/TxGeneratorEnduranceSpec.hs
@@ -25,6 +25,8 @@ import Cardano.Node.Client.E2E.Setup (
     genesisDir,
     genesisSignKey,
  )
+import Cardano.Node.Client.N2C.Probe (defaultProbeConfig)
+import Cardano.Node.Client.N2C.Reconnect (defaultReconnectPolicy)
 import Cardano.Node.Client.TxGenerator.Daemon (
     DaemonConfig (..),
     runDaemon,
@@ -116,6 +118,8 @@ spec =
                                 , dcReadyThresholdSlots = 10
                                 , dcSecurityParamK = 2160
                                 , dcDbPath = Nothing
+                                , dcReconnectPolicy = defaultReconnectPolicy
+                                , dcProbeConfig = defaultProbeConfig
                                 }
                     daemonThread <- async (runDaemon cfg)
                     result <-

--- a/test/Cardano/Node/Client/E2E/TxGeneratorReadySpec.hs
+++ b/test/Cardano/Node/Client/E2E/TxGeneratorReadySpec.hs
@@ -31,6 +31,8 @@ import Cardano.Node.Client.E2E.Setup (
     genesisDir,
     genesisSignKey,
  )
+import Cardano.Node.Client.N2C.Probe (defaultProbeConfig)
+import Cardano.Node.Client.N2C.Reconnect (defaultReconnectPolicy)
 import Cardano.Node.Client.TxGenerator.Daemon (
     DaemonConfig (..),
     runDaemon,
@@ -111,6 +113,8 @@ spec =
                                 , dcReadyThresholdSlots = 10
                                 , dcSecurityParamK = 2160
                                 , dcDbPath = Nothing
+                                , dcReconnectPolicy = defaultReconnectPolicy
+                                , dcProbeConfig = defaultProbeConfig
                                 }
                     daemonThread <- async (runDaemon cfg)
                     result <-

--- a/test/Cardano/Node/Client/E2E/TxGeneratorRefillSpec.hs
+++ b/test/Cardano/Node/Client/E2E/TxGeneratorRefillSpec.hs
@@ -30,6 +30,8 @@ import Cardano.Node.Client.E2E.Setup (
     genesisDir,
     genesisSignKey,
  )
+import Cardano.Node.Client.N2C.Probe (defaultProbeConfig)
+import Cardano.Node.Client.N2C.Reconnect (defaultReconnectPolicy)
 import Cardano.Node.Client.TxGenerator.Daemon (
     DaemonConfig (..),
     runDaemon,
@@ -108,6 +110,8 @@ spec =
                                 , dcReadyThresholdSlots = 10
                                 , dcSecurityParamK = 2160
                                 , dcDbPath = Nothing
+                                , dcReconnectPolicy = defaultReconnectPolicy
+                                , dcProbeConfig = defaultProbeConfig
                                 }
                     daemonThread <- async (runDaemon cfg)
                     result <-

--- a/test/Cardano/Node/Client/E2E/TxGeneratorRestartSpec.hs
+++ b/test/Cardano/Node/Client/E2E/TxGeneratorRestartSpec.hs
@@ -37,6 +37,8 @@ import Cardano.Node.Client.E2E.Setup (
     genesisDir,
     genesisSignKey,
  )
+import Cardano.Node.Client.N2C.Probe (defaultProbeConfig)
+import Cardano.Node.Client.N2C.Reconnect (defaultReconnectPolicy)
 import Cardano.Node.Client.TxGenerator.Daemon (
     DaemonConfig (..),
     runDaemon,
@@ -133,6 +135,8 @@ mkCfg nodeSocket controlSock stateDir masterSeed faucetSkey =
             , dcReadyThresholdSlots = 10
             , dcSecurityParamK = 2160
             , dcDbPath = Nothing
+            , dcReconnectPolicy = defaultReconnectPolicy
+            , dcProbeConfig = defaultProbeConfig
             }
 
 runPhaseA :: DaemonConfig -> FilePath -> IO Integer

--- a/test/Cardano/Node/Client/E2E/TxGeneratorSnapshotSpec.hs
+++ b/test/Cardano/Node/Client/E2E/TxGeneratorSnapshotSpec.hs
@@ -26,6 +26,8 @@ import Cardano.Node.Client.E2E.Setup (
     genesisDir,
     genesisSignKey,
  )
+import Cardano.Node.Client.N2C.Probe (defaultProbeConfig)
+import Cardano.Node.Client.N2C.Reconnect (defaultReconnectPolicy)
 import Cardano.Node.Client.TxGenerator.Daemon (
     DaemonConfig (..),
     runDaemon,
@@ -106,6 +108,8 @@ spec =
                                 , dcReadyThresholdSlots = 10
                                 , dcSecurityParamK = 2160
                                 , dcDbPath = Nothing
+                                , dcReconnectPolicy = defaultReconnectPolicy
+                                , dcProbeConfig = defaultProbeConfig
                                 }
                     daemonThread <- async (runDaemon cfg)
                     result <-

--- a/test/Cardano/Node/Client/E2E/TxGeneratorStarvationSpec.hs
+++ b/test/Cardano/Node/Client/E2E/TxGeneratorStarvationSpec.hs
@@ -34,6 +34,8 @@ import Cardano.Node.Client.E2E.Setup (
     genesisDir,
     genesisSignKey,
  )
+import Cardano.Node.Client.N2C.Probe (defaultProbeConfig)
+import Cardano.Node.Client.N2C.Reconnect (defaultReconnectPolicy)
 import Cardano.Node.Client.TxGenerator.Daemon (
     DaemonConfig (..),
     runDaemon,
@@ -118,6 +120,8 @@ spec =
                                 , dcReadyThresholdSlots = 10
                                 , dcSecurityParamK = 2160
                                 , dcDbPath = Nothing
+                                , dcReconnectPolicy = defaultReconnectPolicy
+                                , dcProbeConfig = defaultProbeConfig
                                 }
                     daemonThread <- async (runDaemon cfg)
                     result <-

--- a/test/Cardano/Node/Client/E2E/TxGeneratorTransactSpec.hs
+++ b/test/Cardano/Node/Client/E2E/TxGeneratorTransactSpec.hs
@@ -31,6 +31,8 @@ import Cardano.Node.Client.E2E.Setup (
     genesisDir,
     genesisSignKey,
  )
+import Cardano.Node.Client.N2C.Probe (defaultProbeConfig)
+import Cardano.Node.Client.N2C.Reconnect (defaultReconnectPolicy)
 import Cardano.Node.Client.TxGenerator.Daemon (
     DaemonConfig (..),
     runDaemon,
@@ -110,6 +112,8 @@ spec =
                                 , dcReadyThresholdSlots = 10
                                 , dcSecurityParamK = 2160
                                 , dcDbPath = Nothing
+                                , dcReconnectPolicy = defaultReconnectPolicy
+                                , dcProbeConfig = defaultProbeConfig
                                 }
                     daemonThread <- async (runDaemon cfg)
                     result <-

--- a/test/Cardano/Node/Client/TxGenerator/ServerSpec.hs
+++ b/test/Cardano/Node/Client/TxGenerator/ServerSpec.hs
@@ -15,6 +15,10 @@ executable mounts the server.
 -}
 module Cardano.Node.Client.TxGenerator.ServerSpec (spec) where
 
+import Cardano.Node.Client.N2C.Reconnect (
+    DisconnectInfo (..),
+    UpstreamStatus (..),
+ )
 import Cardano.Node.Client.TxGenerator.Types (
     FailureReason (..),
     ReadyResponse (..),
@@ -99,11 +103,60 @@ spec = describe "TxGenerator.Server (wire)" $ do
                     { readyReady = True
                     , readyIndexReady = True
                     , readyFaucetUtxosKnown = False
+                    , readyUpstream = UpstreamConnected
                     }
                 `shouldBe` object
                     [ "ready" .= True
                     , "indexReady" .= True
                     , "faucetUtxosKnown" .= False
+                    ]
+
+        it
+            ( "ReadyResponse omits the @upstream@ object"
+                <> " when the supervisor is connected"
+            )
+            $ toJSON
+                ReadyResponse
+                    { readyReady = True
+                    , readyIndexReady = True
+                    , readyFaucetUtxosKnown = True
+                    , readyUpstream = UpstreamConnected
+                    }
+                `shouldBe` object
+                    [ "ready" .= True
+                    , "indexReady" .= True
+                    , "faucetUtxosKnown" .= True
+                    ]
+
+        it
+            ( "ReadyResponse with UpstreamDisconnected forces"
+                <> " ready=false and surfaces the disconnect"
+                <> " detail"
+            )
+            $ toJSON
+                ReadyResponse
+                    { readyReady = True
+                    , readyIndexReady = True
+                    , readyFaucetUtxosKnown = True
+                    , readyUpstream =
+                        UpstreamDisconnected
+                            DisconnectInfo
+                                { diReason = "Broken pipe"
+                                , diAttempt = 3
+                                , diSinceMs = 1500
+                                }
+                    }
+                `shouldBe` object
+                    [ "ready" .= False
+                    , "indexReady" .= False
+                    , "faucetUtxosKnown" .= True
+                    , "upstream"
+                        .= object
+                            [ "status" .= ("disconnected" :: Text)
+                            , "reason" .= ("Broken pipe" :: Text)
+                            , "attempt" .= (3 :: Int)
+                            , "sinceMs" .= (1500 :: Int)
+                            ]
                     ]
 
         it "SnapshotResponse uses the documented shape" $


### PR DESCRIPTION
Stacks on top of #98 (the extract that moved
`UTxOIndexer.{Reconnect,Probe,Trace}` into the shared
`Cardano.Node.Client.N2C.*` namespace). Once #98 merges,
this PR's base flips to `main` and the diff narrows to
just the tx-generator wiring.

## Why

The Antithesis 1h dispatch on
cardano-foundation/cardano-node-antithesis @ ed6666d
(testRunId `4ca3c31a60ec...`, session
`571e4b8767b69f100...`) finished with outcome `failure`:
210 `tx-generator` container exits in ~1h, 328 uncaught
exceptions split between
`Network.Socket.sendBuf: resource vanished (Broken pipe)`
(118×) and `BlockedIndefinitely` (210×). Same
fault-injection failure mode as the indexer-side bug
fixed by #97/#98 — the tx-generator's N2C bearer dies on
relay-restart, the daemon doesn't survive, the test
composer's eventual validators fail.

Report (single-use signed PASETO):
https://cardano.antithesis.com/report/eb41MY-nOuKN45yq1WNkZIzH/sIapatqZz1uvx624vqUxQGZX_IZ9DCeIIfNkdDhP8Pc.html

## What

Mirrors `UTxOIndexer.Daemon`'s wiring against the now-shared `N2C.Reconnect` API:

- `DaemonConfig` gains `dcReconnectPolicy` /
  `dcProbeConfig`. Defaults via `defaultReconnectPolicy`
  / `defaultProbeConfig`.
- `ReadyState` gains `rsUpstream :: UpstreamStatus`.
  Supervisor status sink writes through `modifyTVar'`
  so the chain-sync follower's `updateReady` keeps using
  a record-update without trampling `rsUpstream`.
- The single `runNodeClientFull` invocation is wrapped
  in `try` and handed to `runReconnectLoop`. The
  pre-attempt probe replaces the hard-coded 3 s
  `threadDelay` as the readiness gate.
- `readyResponseFrom` and `ToJSON ReadyResponse` force
  `ready=false` on `UpstreamDisconnected` and surface
  an `upstream` object on the wire (reason / attempt /
  sinceMs). Encoder shape mirrors the indexer's
  `ReadyStatus` so a consumer wired against either
  daemon gets the same JSON.
- `runDaemon` now goes through a new
  `runDaemonWithTracer` that takes an explicit
  `Tracer IO N2CEvent`. The binary path (`runDaemon`)
  defaults to `defaultStderrTracer`; tests will use
  their own captures once the dedicated reconnect E2E
  is added.
- CLI surface in `app/cardano-tx-generator/Main.hs`
  gains four flags identical to utxo-indexer:
  `--reconnect-initial-ms`, `--reconnect-max-ms`,
  `--reconnect-reset-threshold-ms`,
  `--node-ready-timeout-ms`.

## Test plan

- 207/207 unit tests pass (incl. 2 new ServerSpec
  examples covering the encoder).
- All 7 TxGenerator E2E specs updated mechanically to
  carry the two new defaulted fields. Behaviour unchanged
  against the unflakey relay.
- Antithesis on **this branch** before merge — the
  pre-merge harness gate the project should have used
  for #94. `gh workflow run cardano-node.yaml --ref
  feat/tx-generator-n2c-reconnect-bump -f duration=1` on
  the downstream antithesis side after a pin bump.

## Out of scope (separate follow-up)

- The submit-side EPIPE on LocalTxSubmission can still
  hang in-flight refill/transact callers until reconnect:
  bounded LSQ/LTxS channels aren't drained on bearer
  close. The supervisor wrap stops the *process* dying;
  the in-flight request error-propagation needs
  queue-side bracketing. Will revisit once a re-run
  shows whether it's still the dominant tail latency.
- Dedicated E2E `TxGeneratorReconnectSpec` mirroring
  `UTxOIndexerReconnectSpec` (boot devnet → restart
  relay → assert survival). Adding inside this PR once
  #98 merges and the shared E2E infra stabilises.

## Related

- #97 — the bug, indexer side
- #98 — the supervisor + extract this stacks on
- #100 — the regression test that confirmed #97
- cardano-foundation/cardano-node-antithesis#83 —
  PR that merged the tx-generator daemon. The
  Antithesis run on its merge commit ed6666d is what
  surfaced this need.