### PR TITLE
feat(cardano-adversary): chain_sync_flap endpoint (PR C)

### DIFF
--- a/app/cardano-adversary/Main.hs
+++ b/app/cardano-adversary/Main.hs
@@ -60,7 +60,10 @@ parseConfig args0 = do
         (mPortS, args4) = case takeFlag "--producer-port" args3 of
             Just (p, rest) -> (Just p, rest)
             Nothing -> (Nothing, args3)
-    case args4 of
+        (mPoints, args5) = case takeFlag "--chain-points-file" args4 of
+            Just (p, rest) -> (Just p, rest)
+            Nothing -> (Nothing, args4)
+    case args5 of
         [] -> pure ()
         extra -> dieUsage $ "Unexpected args: " <> show extra
     magic <- requireWord32 "--network-magic" magicS
@@ -71,6 +74,7 @@ parseConfig args0 = do
             , daemonProducerHosts = hosts
             , daemonProducerPort = port
             , daemonNetworkMagic = NetworkMagic magic
+            , daemonChainPointsFile = mPoints
             }
   where
     requireFlag key args =
@@ -106,7 +110,8 @@ dieUsage msg = do
     hPutStrLn stderr "  --control-socket PATH \\"
     hPutStrLn stderr "  --network-magic INT \\"
     hPutStrLn stderr "  [--producer-host HOST]... \\"
-    hPutStrLn stderr "  [--producer-port INT]"
+    hPutStrLn stderr "  [--producer-port INT] \\"
+    hPutStrLn stderr "  [--chain-points-file PATH]"
     exitFailure
 
 main :: IO ()
@@ -133,4 +138,5 @@ printHelp = do
     putStrLn "  --network-magic INT      Cardano network magic. Required."
     putStrLn "  --producer-host HOST     Producer hostname (repeatable, optional)."
     putStrLn "  --producer-port INT      N2N port (default 3001)."
+    putStrLn "  --chain-points-file PATH File of chain points written by tracer-sidecar."
     putStrLn "  --help, -h               Print this help and exit 0."

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -41,6 +41,9 @@ library
   hs-source-dirs:   lib
   default-language: GHC2021
   exposed-modules:
+    Cardano.Node.Client.Adversary.Application
+    Cardano.Node.Client.Adversary.ChainSync.Codec
+    Cardano.Node.Client.Adversary.ChainSync.Connection
     Cardano.Node.Client.Adversary.Daemon
     Cardano.Node.Client.Adversary.RandomSource
     Cardano.Node.Client.Adversary.Server
@@ -105,6 +108,8 @@ library
     , contra-tracer
     , directory
     , dns
+    , io-classes
+    , io-classes:strict-stm
     , exceptions
     , filepath
     , iproute
@@ -117,6 +122,7 @@ library
     , ouroboros-consensus:protocol
     , ouroboros-network
     , ouroboros-network:api
+    , ouroboros-network:api-tests-lib
     , ouroboros-network:framework
     , ouroboros-network:protocols
     , plutus-core

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -242,6 +242,7 @@ test-suite unit-tests
   main-is:          unit-main.hs
   default-language: GHC2021
   other-modules:
+    Cardano.Node.Client.Adversary.ChainPointsSpec
     Cardano.Node.Client.Adversary.ServerSpec
     Cardano.Node.Client.BalanceSpec
     Cardano.Node.Client.N2C.ProbeSpec

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -42,6 +42,7 @@ library
   default-language: GHC2021
   exposed-modules:
     Cardano.Node.Client.Adversary.Application
+    Cardano.Node.Client.Adversary.ChainPoints
     Cardano.Node.Client.Adversary.ChainSync.Codec
     Cardano.Node.Client.Adversary.ChainSync.Connection
     Cardano.Node.Client.Adversary.Daemon
@@ -108,10 +109,10 @@ library
     , contra-tracer
     , directory
     , dns
-    , io-classes
-    , io-classes:strict-stm
     , exceptions
     , filepath
+    , io-classes
+    , io-classes:strict-stm
     , iproute
     , microlens
     , network

--- a/lib/Cardano/Node/Client/Adversary/Application.hs
+++ b/lib/Cardano/Node/Client/Adversary/Application.hs
@@ -1,0 +1,276 @@
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Use const" #-}
+module Cardano.Node.Client.Adversary.Application (
+    Limit (..),
+    adversaryApplication,
+    ChainSyncApplication,
+    repeatedAdversaryApplication,
+)
+where
+
+import Cardano.Network.NodeToNode (
+    ControlMessage (..),
+    ControlMessageSTM,
+ )
+import Cardano.Node.Client.Adversary.ChainSync.Codec (Header, Point, Tip)
+import Cardano.Node.Client.Adversary.ChainSync.Connection (
+    ChainSyncApplication,
+    runChainSyncApplication,
+ )
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (
+    mapConcurrently_,
+ )
+import Control.Concurrent.Class.MonadSTM.Strict (
+    MonadSTM (..),
+    StrictTVar,
+    modifyTVar,
+    newTVarIO,
+    readTVar,
+ )
+import Control.Exception (SomeException, try)
+import Control.Tracer (Tracer, traceWith)
+import Data.Function (fix)
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
+import Data.Maybe (fromMaybe)
+import Data.Word (Word32)
+import Network.Socket (PortNumber)
+import Ouroboros.Consensus.Block (headerPoint)
+import Ouroboros.Consensus.Protocol.Praos.Header ()
+import Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion ()
+import Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
+import Ouroboros.Network.Block (getTipPoint)
+import Ouroboros.Network.Magic (NetworkMagic)
+import Ouroboros.Network.Mock.Chain (Chain)
+import Ouroboros.Network.Mock.Chain qualified as Chain
+import Ouroboros.Network.Protocol.ChainSync.Client (
+    ChainSyncClient (..),
+    ClientStIdle (..),
+    ClientStIntersect (..),
+    ClientStNext (..),
+ )
+
+newtype State = State
+    { chainVar :: StrictTVar IO (Chain Header)
+    }
+
+onChainVar :: State -> (Chain Header -> Chain Header) -> IO ()
+onChainVar state f = atomically $ modifyTVar (chainVar state) f
+
+readChainVar :: State -> STM IO (Chain Header)
+readChainVar state = readTVar $ chainVar state
+
+readChainVarIO :: State -> IO (Chain Header)
+readChainVarIO = atomically . readChainVar
+
+rollForward :: State -> Header -> IO ()
+rollForward state b = onChainVar state $ \(!chain) ->
+    Chain.addBlock b chain
+
+-- We will fail to roll back iff `p` doesn't exist in `chain`
+-- This will happen when we're asked to roll back to `startingPoint`,
+-- which we can check for, or any point before, which we can't
+-- check for. Hence we ignore all failures to rollback and replace the
+-- chain with an empty one if we do.
+rollBackward :: State -> Point -> IO ()
+rollBackward state p = onChainVar state $ \(!chain) ->
+    fromMaybe Chain.Genesis $ Chain.rollback p chain
+
+-- | A limit on the number of blocks to sync
+newtype Limit = Limit {limit :: Word32}
+    deriving newtype (Show, Read, Eq, Ord)
+
+-- the way to step the protocol
+type StepProtocol = IO (Maybe Protocol)
+
+-- Internal protocol state machine
+data Protocol = Protocol
+    { onRollBackward :: Point -> Tip -> StepProtocol
+    , onRollForward :: Header -> StepProtocol
+    , points :: [Point] -> StepProtocol
+    }
+
+-- A protocol controlled by control messages
+controlledProtocol ::
+    ControlMessageSTM IO -> -- control message source
+    Protocol
+controlledProtocol controlMessageSTM = fix $ \client ->
+    let react ctrl = case ctrl of
+            Continue -> Just client
+            Quiesce -> error "controlledClient: unexpected Quiesce"
+            Terminate -> Nothing
+     in Protocol
+            { onRollBackward = \_point _tip ->
+                react <$> atomically controlMessageSTM
+            , onRollForward = \_header ->
+                react <$> atomically controlMessageSTM
+            , points = \_points -> pure $ Just client
+            }
+
+-- a control message source that terminates after syncing 'limit' blocks
+terminateAfterCount ::
+    State ->
+    Limit ->
+    ControlMessageSTM IO
+terminateAfterCount stateVar limit = do
+    chainLength <-
+        Limit . fromIntegral . Chain.length <$> readChainVar stateVar
+    pure $
+        if chainLength < limit
+            then Continue
+            else Terminate
+
+-- initialize the protocol with a control message source
+mkProtocol ::
+    State -> -- the mock chain
+    Limit -> -- limit of blocks to sync
+    Protocol
+mkProtocol stateVar limit =
+    controlledProtocol $ terminateAfterCount stateVar limit
+
+-- The idle state of the chain sync client
+type ChainSyncIdle = ClientStIdle Header Point Tip IO ()
+
+-- when the protocols returns Nothing, we're done as a N2N client
+nothingToDone ::
+    Maybe Protocol ->
+    (Protocol -> ChainSyncIdle) ->
+    ChainSyncIdle
+nothingToDone Nothing _ = SendMsgDone ()
+nothingToDone (Just next) cont = cont next
+
+-- boots the protocol and step into initialise
+mkChainSyncApplication ::
+    -- | the mock chain
+    State ->
+    -- | starting point
+    Point ->
+    -- | limit of blocks to sync
+    Limit ->
+    -- | the chain sync client application
+    ChainSyncApplication
+mkChainSyncApplication stateVar startingPoint limit = ChainSyncClient $ do
+    ps <- points (mkProtocol stateVar limit) [startingPoint]
+    pure $ nothingToDone ps $ initialise stateVar startingPoint
+
+-- In this consumer example, we do not care about whether the server
+-- found an intersection or not. If not, we'll just sync from genesis.
+--
+-- Alternative policies here include:
+--  iteratively finding the best intersection
+--  rejecting the server if there is no intersection in the last K blocks
+--
+initialise ::
+    State -> -- the mock chain
+    Point -> -- starting point
+    Protocol -> -- previous client state machine
+    ChainSyncIdle
+initialise stateVar startingPoint prev =
+    let next =
+            ChainSyncClient
+                { runChainSyncClient = pure $ requestNext stateVar prev
+                }
+     in SendMsgFindIntersect [startingPoint] $
+            ClientStIntersect
+                { recvMsgIntersectFound = \_point _tip -> next
+                , recvMsgIntersectNotFound = \_tip -> next
+                }
+
+requestNext ::
+    State -> -- the mock chain
+    Protocol -> -- this client state machine
+    ChainSyncIdle
+requestNext stateVar prev =
+    SendMsgRequestNext
+        (pure ())
+        ClientStNext
+            { recvMsgRollForward = \header tip -> ChainSyncClient $ do
+                rollForward stateVar header
+                choice <-
+                    stoppingOnTip
+                        (headerPoint header)
+                        (getTipPoint tip)
+                        $ onRollForward prev header
+                pure $ nothingToDone choice $ requestNext stateVar
+            , recvMsgRollBackward = \pIntersect tip -> ChainSyncClient $ do
+                rollBackward stateVar pIntersect
+                choice <- onRollBackward prev pIntersect tip
+                pure $ nothingToDone choice $ requestNext stateVar
+            }
+
+stoppingOnTip ::
+    (Ord a) =>
+    a ->
+    a ->
+    StepProtocol ->
+    StepProtocol
+stoppingOnTip h t stepProtocol
+    | h >= t = pure Nothing
+    | otherwise = stepProtocol
+
+{- | Run an adversary application that connects to a node and syncs
+blocks starting from the given point, up to the given limit.
+-}
+adversaryApplication ::
+    -- | network magic
+    NetworkMagic ->
+    -- | peer host
+    String ->
+    -- | peer port
+    PortNumber ->
+    -- | starting point
+    Point ->
+    -- | limit of blocks to sync
+    Limit ->
+    IO (Either SomeException (Chain.Point Header))
+adversaryApplication magic peerName peerPort startingPoint limit = do
+    chainVar <- newTVarIO (Chain.Genesis :: Chain Header)
+    let stateVar = State{chainVar}
+    res <-
+        -- To gracefully handle the node getting killed it seems we need
+        -- the outer 'try', even if connectToNode already returns 'Either
+        -- SomeException'.
+        try $
+            runChainSyncApplication
+                magic
+                peerName
+                peerPort
+                (const $ mkChainSyncApplication stateVar startingPoint limit)
+    case res of
+        Left e -> return $ Left e
+        Right _ -> pure . Chain.headPoint <$> readChainVarIO stateVar
+
+repeatedAdversaryApplication ::
+    Tracer IO String -> -- thread safe logger
+    Int ->
+    NetworkMagic ->
+    [String] ->
+    PortNumber ->
+    -- | must be infinite list
+    NonEmpty Point ->
+    Limit ->
+    IO ()
+repeatedAdversaryApplication tracer nConns magic peerNames peerPort startingPoints limit = do
+    let write = traceWith tracer
+    let singleRun (_i, peerName, startingPoint) = do
+            write $
+                "Starting adversary application against "
+                    <> peerName
+                    <> " from point "
+                    <> show startingPoint
+            result <-
+                (startingPoint,)
+                    <$> adversaryApplication magic peerName peerPort startingPoint limit
+            write $
+                "Completed adversary application against "
+                    <> peerName
+                    <> " from point "
+                    <> show startingPoint
+                    <> " with result "
+                    <> show result
+    mapConcurrently_
+        singleRun
+        $ zip3 [1 .. nConns] (cycle peerNames) (NE.toList startingPoints)
+    threadDelay 1000000 -- wait for logging to complete

--- a/lib/Cardano/Node/Client/Adversary/ChainPoints.hs
+++ b/lib/Cardano/Node/Client/Adversary/ChainPoints.hs
@@ -1,0 +1,85 @@
+{- |
+Module      : Cardano.Node.Client.Adversary.ChainPoints
+Description : Parse chain-points harvested by tracer-sidecar
+License     : Apache-2.0
+
+Reads a file emitted by the antithesis-side @tracer-sidecar@
+container — one chain point per line in @\<hex\>@\<slot\>@ form, or
+the literal @origin@. Used by the daemon's @chain_sync_flap@
+endpoint to pick a randomised starting point for each adversarial
+connection.
+
+Lifted from
+[`cardano-foundation/cardano-node-antithesis/components/adversary/src/Adversary.hs`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/components/adversary/src/Adversary.hs)
+so the parsing logic lives next to the daemon that uses it.
+-}
+module Cardano.Node.Client.Adversary.ChainPoints (
+    Point,
+    originPoint,
+    readChainPoint,
+    parseChainPointSamples,
+    generatePoints,
+) where
+
+import Cardano.Node.Client.Adversary.ChainSync.Codec (Point)
+import Cardano.Node.Client.Adversary.ChainSync.Connection (HeaderHash)
+import Data.ByteString.Base16 qualified as B16
+import Data.ByteString.Short qualified as SBS
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
+import Ouroboros.Consensus.HardFork.Combinator qualified as Consensus
+import Ouroboros.Network.Block (SlotNo (..))
+import Ouroboros.Network.Block qualified as Network
+import Ouroboros.Network.Point (WithOrigin (..))
+import Ouroboros.Network.Point qualified as Point
+import System.Random (StdGen, randomR)
+import Text.Read (readMaybe)
+
+-- | The chain's origin (genesis-before-first-block).
+originPoint :: Point
+originPoint = Network.Point Origin
+
+-- | Parse one line. Format: @origin@ | @\<hex\>@\<slot\>@.
+readChainPoint :: String -> Maybe Point
+readChainPoint "origin" = Just originPoint
+readChainPoint str = case split (== '@') str of
+    [blockHashStr, slotNoStr] -> do
+        (hash :: HeaderHash) <-
+            Consensus.OneEraHash
+                . SBS.toShort
+                <$> either
+                    (const Nothing)
+                    Just
+                    ( B16.decode $
+                        T.encodeUtf8 $
+                            T.pack blockHashStr
+                    )
+        slot <- SlotNo <$> readMaybe slotNoStr
+        return $ Network.Point $ At $ Point.Block slot hash
+    _ -> Nothing
+  where
+    split f = map T.unpack . T.split f . T.pack
+
+{- | Parse a whole file (one chain point per line). Always prepends
+'originPoint' to the resulting list so the adversary can also
+start from genesis. Returns 'Nothing' if any individual line
+fails to parse.
+-}
+parseChainPointSamples :: String -> Maybe (NonEmpty Point)
+parseChainPointSamples =
+    fmap (originPoint NE.:|)
+        . mapM readChainPoint
+        . lines
+
+{- | Lazy infinite stream of points sampled uniformly from the
+input.
+-}
+generatePoints :: StdGen -> NonEmpty Point -> NonEmpty Point
+generatePoints g points = NE.unfoldr (fmap Just . randomElement points) g
+  where
+    randomElement :: NonEmpty a -> StdGen -> (a, StdGen)
+    randomElement l g' =
+        let (idx, g'') = randomR (0, length l - 1) g'
+         in (l NE.!! idx, g'')

--- a/lib/Cardano/Node/Client/Adversary/ChainSync/Codec.hs
+++ b/lib/Cardano/Node/Client/Adversary/ChainSync/Codec.hs
@@ -1,0 +1,114 @@
+module Cardano.Node.Client.Adversary.ChainSync.Codec (
+    codecChainSync,
+    Block,
+    Header,
+    Tip,
+    Point,
+) where
+
+import Cardano.Chain.Slotting (EpochSlots (EpochSlots))
+import Codec.Serialise (DeserialiseFailure, Serialise (..))
+import Codec.Serialise.Decoding (Decoder)
+import Codec.Serialise.Encoding (Encoding)
+import Data.ByteString.Lazy qualified as LBS
+import Data.Data (Proxy (Proxy))
+import Network.TypedProtocol.Codec (Codec)
+import Ouroboros.Consensus.Block.Abstract (
+    decodeRawHash,
+    encodeRawHash,
+ )
+import Ouroboros.Consensus.Byron.Ledger (ByronBlock, CodecConfig (..))
+import Ouroboros.Consensus.Cardano.Block (
+    CodecConfig (CardanoCodecConfig),
+ )
+import Ouroboros.Consensus.Cardano.Block qualified as Consensus
+import Ouroboros.Consensus.Cardano.Node (
+    pattern CardanoNodeToNodeVersion2,
+ )
+import Ouroboros.Consensus.HardFork.Combinator.NetworkVersion (
+    HardForkNodeToNodeVersion,
+ )
+import Ouroboros.Consensus.Node.Serialisation (
+    decodeNodeToNode,
+    encodeNodeToNode,
+ )
+import Ouroboros.Consensus.Protocol.Praos.Header ()
+import Ouroboros.Consensus.Shelley.Ledger (
+    CodecConfig (ShelleyCodecConfig),
+ )
+import Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion ()
+import Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
+import Ouroboros.Network.Block (
+    decodeTip,
+    encodeTip,
+ )
+import Ouroboros.Network.Block qualified as Network
+import Ouroboros.Network.Protocol.ChainSync.Codec qualified as ChainSync
+import Ouroboros.Network.Protocol.ChainSync.Type (ChainSync)
+
+-- | Real Cardano Block type
+type Block = Consensus.CardanoBlock Consensus.StandardCrypto
+
+-- | Real Cardano Header type
+type Header = Consensus.Header Block
+
+-- | Real Cardano Tip type
+type Tip = Network.Tip Block
+
+-- | Real Cardano Point type
+type Point = Network.Point Header
+
+-- The ChainSync codec for our Block, Point, and Tip types
+codecChainSync ::
+    Codec
+        (ChainSync Header Point Tip)
+        DeserialiseFailure
+        IO
+        LBS.ByteString
+codecChainSync =
+    ChainSync.codecChainSync
+        encHeader
+        decHeader
+        encPoint
+        decPoint
+        encTip
+        decTip
+
+----- Encoding and Decoding Headers -----
+encHeader :: Header -> Encoding
+encHeader = encodeNodeToNode @Block ccfg version
+
+decHeader :: Decoder s Header
+decHeader = decodeNodeToNode @Block ccfg version
+
+version ::
+    HardForkNodeToNodeVersion
+        (ByronBlock : Consensus.CardanoShelleyEras c)
+version = CardanoNodeToNodeVersion2
+
+-- One ShelleyCodecConfig per Shelley-based era (Shelley, Allegra,
+-- Mary, Alonzo, Babbage, Conway, Dijkstra). The arity grows when
+-- consensus introduces a new era; bump here in lock-step.
+ccfg :: Consensus.CardanoCodecConfig c
+ccfg =
+    CardanoCodecConfig
+        (ByronCodecConfig $ EpochSlots 42)
+        ShelleyCodecConfig
+        ShelleyCodecConfig
+        ShelleyCodecConfig
+        ShelleyCodecConfig
+        ShelleyCodecConfig
+        ShelleyCodecConfig
+        ShelleyCodecConfig
+
+--- Encoding and Decoding Points -----
+encPoint :: Point -> Encoding
+encPoint = encode
+decPoint :: Decoder s Point
+decPoint = decode
+
+--- Encoding and Decoding Tips -----
+encTip :: Network.Tip Block -> Encoding
+encTip = encodeTip (encodeRawHash (Proxy @Block))
+decTip :: Decoder s (Network.Tip Block)
+decTip = decodeTip (decodeRawHash (Proxy @Block))

--- a/lib/Cardano/Node/Client/Adversary/ChainSync/Connection.hs
+++ b/lib/Cardano/Node/Client/Adversary/ChainSync/Connection.hs
@@ -1,0 +1,178 @@
+module Cardano.Node.Client.Adversary.ChainSync.Connection (
+    runChainSyncApplication,
+    HeaderHash,
+    ChainSyncApplication,
+)
+where
+
+import Cardano.Network.NodeToNode (
+    DiffusionMode (InitiatorOnlyDiffusionMode),
+    NodeToNodeVersion (NodeToNodeV_14),
+    NodeToNodeVersionData (..),
+    nodeToNodeCodecCBORTerm,
+ )
+import Cardano.Network.Protocol.Handshake.Codec (
+    nodeToNodeHandshakeCodec,
+ )
+import Cardano.Node.Client.Adversary.ChainSync.Codec (
+    Block,
+    Header,
+    Point,
+    Tip,
+    codecChainSync,
+ )
+import Control.Exception (SomeException)
+import Control.Tracer (nullTracer)
+import Data.ByteString.Lazy (LazyByteString)
+import Data.List.NonEmpty qualified as NE
+import Data.Void (Void)
+import Network.Mux qualified as Mx
+import Network.Socket (
+    AddrInfo (..),
+    AddrInfoFlag (AI_PASSIVE),
+    PortNumber,
+    SocketType (Stream),
+    defaultHints,
+    getAddrInfo,
+ )
+import Ouroboros.Consensus.Protocol.Praos.Header ()
+import Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion ()
+import Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
+import Ouroboros.Network.Block qualified as Network
+import Ouroboros.Network.Diffusion.Configuration (
+    PeerSharing (PeerSharingDisabled),
+ )
+import Ouroboros.Network.IOManager (withIOManager)
+import Ouroboros.Network.Magic (NetworkMagic (..))
+import Ouroboros.Network.Mux (
+    MiniProtocol (..),
+    MiniProtocolLimits (..),
+    MiniProtocolNum (MiniProtocolNum),
+    OuroborosApplication (..),
+    OuroborosApplicationWithMinimalCtx,
+    RunMiniProtocol (InitiatorProtocolOnly),
+    StartOnDemandOrEagerly (StartOnDemand),
+    mkMiniProtocolCbFromPeer,
+ )
+import Ouroboros.Network.Protocol.ChainSync.Client (
+    ChainSyncClient (..),
+ )
+import Ouroboros.Network.Protocol.ChainSync.Client qualified as ChainSync
+import Ouroboros.Network.Protocol.Handshake.Codec (
+    cborTermVersionDataCodec,
+    noTimeLimitsHandshake,
+ )
+import Ouroboros.Network.Protocol.Handshake.Version (
+    Acceptable (acceptableVersion),
+    Queryable (queryVersion),
+    simpleSingletonVersions,
+ )
+import Ouroboros.Network.Snocket (
+    makeSocketBearer,
+    socketSnocket,
+ )
+import Ouroboros.Network.Socket (
+    ConnectToArgs (..),
+    HandshakeCallbacks (..),
+    connectToNode,
+    nullNetworkConnectTracers,
+ )
+
+-- | The application type for a chain sync client
+type ChainSyncApplication = ChainSyncClient Header Point Tip IO ()
+
+-- | The header hash type used in the chain sync connection
+type HeaderHash = Network.HeaderHash Block
+
+-- | Connect to a node-to-node chain sync server and run the given application
+runChainSyncApplication ::
+    -- | The network magic
+    NetworkMagic ->
+    -- | host
+    String ->
+    -- | port
+    PortNumber ->
+    -- | application
+    (NodeToNodeVersionData -> ChainSyncApplication) ->
+    IO (Either SomeException (Either () Void))
+runChainSyncApplication magic peerName peerPort application = withIOManager $ \iocp -> do
+    AddrInfo{addrAddress} <- resolve peerName peerPort
+    connectToNode -- withNode
+        (socketSnocket iocp) -- TCP
+        makeSocketBearer
+        ConnectToArgs
+            { ctaHandshakeCodec = nodeToNodeHandshakeCodec
+            , ctaHandshakeTimeLimits = noTimeLimitsHandshake
+            , ctaVersionDataCodec =
+                cborTermVersionDataCodec
+                    nodeToNodeCodecCBORTerm
+            , ctaConnectTracers = nullNetworkConnectTracers
+            , ctaHandshakeCallbacks =
+                HandshakeCallbacks
+                    { acceptCb = acceptableVersion
+                    , queryCb = queryVersion
+                    }
+            }
+        mempty -- socket options
+        ( simpleSingletonVersions
+            NodeToNodeV_14
+            ( NodeToNodeVersionData
+                { networkMagic = magic
+                , diffusionMode = InitiatorOnlyDiffusionMode
+                , peerSharing = PeerSharingDisabled
+                , query = False
+                }
+            )
+            (chainSyncToOuroboros . application) -- application
+        )
+        Nothing
+        addrAddress
+
+resolve :: String -> PortNumber -> IO AddrInfo
+resolve peerName peerPort = do
+    let hints =
+            defaultHints
+                { addrFlags = [AI_PASSIVE]
+                , addrSocketType = Stream
+                }
+    NE.head
+        <$> getAddrInfo (Just hints) (Just peerName) (Just $ show peerPort)
+
+-- TODO: provide sensible limits
+-- https://github.com/intersectmbo/ouroboros-network/issues/575
+maximumMiniProtocolLimits :: MiniProtocolLimits
+maximumMiniProtocolLimits =
+    MiniProtocolLimits
+        { maximumIngressQueue = maxBound
+        }
+
+chainSyncToOuroboros ::
+    -- | chainSync
+    ChainSyncApplication ->
+    OuroborosApplicationWithMinimalCtx
+        Mx.InitiatorMode
+        addr
+        LazyByteString
+        IO
+        ()
+        Void
+chainSyncToOuroboros chainSyncApp =
+    OuroborosApplication
+        { getOuroborosApplication =
+            [ MiniProtocol
+                { miniProtocolNum = MiniProtocolNum 2
+                , miniProtocolStart = StartOnDemand
+                , miniProtocolLimits = maximumMiniProtocolLimits
+                , miniProtocolRun = run
+                }
+            ]
+        }
+  where
+    run =
+        InitiatorProtocolOnly $
+            mkMiniProtocolCbFromPeer $
+                const
+                    ( nullTracer
+                    , codecChainSync
+                    , ChainSync.chainSyncClientPeer chainSyncApp
+                    )

--- a/lib/Cardano/Node/Client/Adversary/Daemon.hs
+++ b/lib/Cardano/Node/Client/Adversary/Daemon.hs
@@ -5,30 +5,43 @@ Module      : Cardano.Node.Client.Adversary.Daemon
 Description : cardano-adversary daemon — wires Server, signals, sockets
 License     : Apache-2.0
 
-Composes the cardano-adversary daemon's three responsibilities for
-PR B:
+Composes the cardano-adversary daemon's responsibilities:
 
 * the NDJSON control wire from
   'Cardano.Node.Client.Adversary.Server',
 * signal handling so the container stops cleanly on @SIGTERM@,
-* the @ready@ hook (always reports ready in PR B because no N2N
-  warmup happens yet).
+* the @ready@ hook,
+* the real @chain_sync_flap@ hook that drives
+  'repeatedAdversaryApplication'.
 
-PR C adds the @chain_sync_flap@ misbehaviour body and replaces the
-'stubHooks' wiring with one that holds an N2N pool.
+The chain-points file is read on every @chain_sync_flap@ request
+so the daemon picks up new points written by @tracer-sidecar@
+without restarting.
 -}
 module Cardano.Node.Client.Adversary.Daemon (
     DaemonConfig (..),
     runDaemon,
 ) where
 
+import Cardano.Node.Client.Adversary.Application (
+    Limit (..),
+    repeatedAdversaryApplication,
+ )
+import Cardano.Node.Client.Adversary.ChainPoints (
+    generatePoints,
+    parseChainPointSamples,
+ )
+import Cardano.Node.Client.Adversary.RandomSource (splitFromSeed)
 import Cardano.Node.Client.Adversary.Server (
-    ServerHooks,
+    ServerHooks (..),
     runServer,
-    stubHooks,
  )
 import Cardano.Node.Client.Adversary.Types (
+    ChainSyncFlapArgs (..),
+    ChainSyncFlapDetails (..),
+    ChainSyncFlapFailure (..),
     ReadyDetails (..),
+    Response (..),
  )
 import Control.Concurrent (
     MVar,
@@ -37,12 +50,14 @@ import Control.Concurrent (
     takeMVar,
  )
 import Control.Concurrent.Async (race_)
-import Control.Exception (catch)
+import Control.Exception (IOException, catch, try)
+import Control.Tracer (Tracer (..))
+import Data.List.NonEmpty qualified as NE
 import Data.Text (Text)
 import Data.Text qualified as T
 import Network.Socket (HostName, PortNumber)
 import Ouroboros.Network.Magic (NetworkMagic)
-import System.Directory (removeFile)
+import System.Directory (doesFileExist, removeFile)
 import System.IO (hPutStrLn, stderr)
 import System.IO.Error (isDoesNotExistError)
 import System.Posix.Signals (
@@ -57,13 +72,15 @@ data DaemonConfig = DaemonConfig
     -- ^ Path of the Unix control socket. The daemon binds here
     -- and unlinks on shutdown.
     , daemonProducerHosts :: [HostName]
-    -- ^ Producer hostnames the daemon will eventually target.
-    -- PR B only echoes them back via 'ReadyDetails'.
+    -- ^ Producer hostnames the @chain_sync_flap@ endpoint targets.
     , daemonProducerPort :: PortNumber
-    -- ^ N2N port. Echoed by 'ReadyDetails' for diagnostic value.
+    -- ^ N2N port for @chain_sync_flap@.
     , daemonNetworkMagic :: NetworkMagic
-    -- ^ Network magic. Echoed by 'ReadyDetails' for diagnostic
-    -- value; required by every future N2N misbehaviour endpoint.
+    -- ^ Network magic used in the N2N handshake.
+    , daemonChainPointsFile :: Maybe FilePath
+    -- ^ Path of the chain-points file produced by
+    -- @tracer-sidecar@. When 'Nothing', the @chain_sync_flap@
+    -- endpoint always returns 'CsffNoChainPointsFile'.
     }
 
 {- | Run the daemon: install signal handler, start NDJSON server,
@@ -82,7 +99,11 @@ runDaemon cfg = do
     cleanup cfg
 
 mkHooks :: DaemonConfig -> ServerHooks
-mkHooks cfg = stubHooks (pure (readyDetails cfg))
+mkHooks cfg =
+    ServerHooks
+        { hooksReady = pure (readyDetails cfg)
+        , hooksChainSyncFlap = handleChainSyncFlap cfg
+        }
 
 readyDetails :: DaemonConfig -> ReadyDetails
 readyDetails cfg =
@@ -92,6 +113,49 @@ readyDetails cfg =
         , readyConfiguredHosts =
             map (T.pack :: HostName -> Text) (daemonProducerHosts cfg)
         }
+
+handleChainSyncFlap :: DaemonConfig -> ChainSyncFlapArgs -> IO Response
+handleChainSyncFlap cfg args
+    | null (daemonProducerHosts cfg) =
+        pure (RespChainSyncFlapFail CsffNoProducers)
+    | otherwise = case daemonChainPointsFile cfg of
+        Nothing -> pure (RespChainSyncFlapFail CsffNoChainPointsFile)
+        Just path -> do
+            present <- doesFileExist path
+            if not present
+                then pure (RespChainSyncFlapFail CsffNoChainPointsFile)
+                else runFlap cfg path args
+
+runFlap :: DaemonConfig -> FilePath -> ChainSyncFlapArgs -> IO Response
+runFlap cfg path args = do
+    contentE <- try @IOException (readFile path)
+    case contentE of
+        Left _ -> pure (RespChainSyncFlapFail CsffNoChainPointsFile)
+        Right content -> case parseChainPointSamples content of
+            Nothing -> pure (RespChainSyncFlapFail CsffNoChainPointsYet)
+            Just samples -> do
+                let gen = splitFromSeed (csfSeed args)
+                    points = generatePoints gen samples
+                    nConns = max 1 (fromIntegral (csfNConns args) :: Int)
+                    capped = NE.fromList (NE.take nConns points)
+                    limit = Limit (csfLimit args)
+                    tracer = Tracer (hPutStrLn stderr)
+                repeatedAdversaryApplication
+                    tracer
+                    nConns
+                    (daemonNetworkMagic cfg)
+                    (daemonProducerHosts cfg)
+                    (daemonProducerPort cfg)
+                    capped
+                    limit
+                pure $
+                    RespChainSyncFlapOk
+                        ChainSyncFlapDetails
+                            { csfdConnections = nConns
+                            , csfdPeerNames =
+                                map T.pack (daemonProducerHosts cfg)
+                            , csfdLimit = csfLimit args
+                            }
 
 cleanup :: DaemonConfig -> IO ()
 cleanup cfg = do

--- a/lib/Cardano/Node/Client/Adversary/Types.hs
+++ b/lib/Cardano/Node/Client/Adversary/Types.hs
@@ -20,10 +20,13 @@ module Cardano.Node.Client.Adversary.Types (
     -- * Responses
     Response (..),
     ReadyDetails (..),
+    ChainSyncFlapDetails (..),
+    ChainSyncFlapFailure (..),
     ErrorReason (..),
 
     -- * Wire helpers
     errorReasonText,
+    chainSyncFlapFailureText,
 ) where
 
 import Data.Aeson (
@@ -92,11 +95,71 @@ instance FromJSON Request where
 data Response
     = -- | Successful @ready@ response.
       RespReady !ReadyDetails
-    | -- | Endpoint reserved but logic not yet implemented (PR B).
+    | -- | Endpoint reserved but logic not yet implemented.
       RespNotImplemented
+    | -- | Successful @chain_sync_flap@ response.
+      RespChainSyncFlapOk !ChainSyncFlapDetails
+    | -- | Structured @chain_sync_flap@ failure (e.g. no chain points yet).
+      RespChainSyncFlapFail !ChainSyncFlapFailure
     | -- | Wire-level error (malformed json, unknown key).
       RespError !ErrorReason
     deriving stock (Eq, Show)
+
+{- | Diagnostic body returned by a successful @chain_sync_flap@
+invocation. Currently a coarse summary; richer per-connection
+detail can be added later without breaking the wire schema (only
+new fields appear).
+-}
+data ChainSyncFlapDetails = ChainSyncFlapDetails
+    { csfdConnections :: !Int
+    -- ^ Number of concurrent connections that were dispatched.
+    , csfdPeerNames :: ![Text]
+    -- ^ The producer hostnames the connections fanned across.
+    , csfdLimit :: !Word32
+    -- ^ The block-pull limit each connection was given.
+    }
+    deriving stock (Eq, Show)
+
+instance ToJSON ChainSyncFlapDetails where
+    toJSON (ChainSyncFlapDetails conns names limit) =
+        object
+            [ "ok" .= True
+            , "details"
+                .= object
+                    [ "connections" .= conns
+                    , "peerNames" .= names
+                    , "limit" .= limit
+                    ]
+            ]
+
+instance FromJSON ChainSyncFlapDetails where
+    parseJSON = withObject "chain_sync_flap response" $ \o -> do
+        details <- o .: "details"
+        conns <- details .: "connections"
+        names <- details .: "peerNames"
+        limit <- details .: "limit"
+        pure (ChainSyncFlapDetails conns names limit)
+
+{- | Documented failure reasons for the @chain_sync_flap@ endpoint.
+Distinct from the wire-level 'ErrorReason' set: these are valid
+responses whose @ok@ field is @False@.
+-}
+data ChainSyncFlapFailure
+    = -- | The @--chain-points-file@ has not been written yet (or is
+      -- empty), so no intersection point can be sampled.
+      CsffNoChainPointsYet
+    | -- | The configured @--chain-points-file@ does not exist on
+      -- disk at all.
+      CsffNoChainPointsFile
+    | -- | No producer hostnames were configured via @--producer-host@.
+      CsffNoProducers
+    deriving stock (Eq, Show)
+
+chainSyncFlapFailureText :: ChainSyncFlapFailure -> Text
+chainSyncFlapFailureText = \case
+    CsffNoChainPointsYet -> "no-chain-points-yet"
+    CsffNoChainPointsFile -> "no-chain-points-file"
+    CsffNoProducers -> "no-producers"
 
 -- | Structured details accompanying a 'RespReady' response.
 data ReadyDetails = ReadyDetails
@@ -148,6 +211,12 @@ instance ToJSON Response where
         RespReady details -> toJSON details
         RespNotImplemented ->
             object ["ok" .= False, "reason" .= ("not-implemented" :: Text)]
+        RespChainSyncFlapOk details -> toJSON details
+        RespChainSyncFlapFail reason ->
+            object
+                [ "ok" .= False
+                , "reason" .= chainSyncFlapFailureText reason
+                ]
         RespError reason ->
             object ["error" .= errorReasonText reason]
 

--- a/specs/036-cardano-adversary/contracts/control-wire.md
+++ b/specs/036-cardano-adversary/contracts/control-wire.md
@@ -40,7 +40,7 @@ Or, before warmup:
 `details`. Composer drivers should treat `ready: false` as "skip
 this tick" rather than "fail this tick".
 
-## `chain_sync_flap` — reserved (PR B), implemented in PR C
+## `chain_sync_flap` — implemented in PR C
 
 **Request**:
 ```json
@@ -49,47 +49,57 @@ this tick" rather than "fail this tick".
                      "n_conns": 1}}
 ```
 
-- `seed` — `uint64`, sole source of randomness for this request
-  (passed to the `RandomSource`).
+- `seed` — `uint64`, sole source of randomness for this request.
+  Used to derive the per-request `StdGen` via `splitFromSeed`,
+  which then samples a starting point per connection from the
+  parsed chain-points file.
 - `limit` — `uint32`, maximum blocks pulled per connection before
-  disconnecting (mirror of today's one-shot binary's `LIMIT` env
-  var).
+  the adversary disconnects (mirror of the original one-shot
+  binary's `LIMIT` env var).
 - `n_conns` — `uint16`, number of concurrent N2N connections
   spawned by this single request.
 
-**Response (PR B — endpoint reserved, no implementation)**:
-```json
-{"ok": false, "reason": "not-implemented"}
-```
-
-**Response (PR C and beyond — once implemented)**:
+**Response (success)**:
 ```json
 {"ok": true,
- "txId": null,
  "details": {
    "connections": 1,
-   "intersectionPoint": "<hex>@<slot>|origin",
-   "blocksPulled": 100,
-   "completed": true,
-   "failures": []
+   "peerNames": ["p1.example", "p2.example", "p3.example"],
+   "limit": 100
  }}
 ```
 
+The success body is intentionally coarse: every connection the
+daemon dispatched is reflected in `connections`, but
+per-connection outcome (blocks pulled, intersection point chosen,
+DNS or handshake error) is not yet streamed back. Adding a richer
+`details` shape is additive and does not break existing consumers
+— they will see new fields and ignore them.
+
+**Response (structured failure)**:
 ```json
-{"ok": false,
- "reason": "no-chain-points-yet",
- "details": {"chainpointsFile": "/opt/cardano-tracer/chainPoints.log"}}
+{"ok": false, "reason": "no-chain-points-file"}
+{"ok": false, "reason": "no-chain-points-yet"}
+{"ok": false, "reason": "no-producers"}
 ```
 
+| `reason` | When |
+|---|---|
+| `no-chain-points-file` | The daemon was started without `--chain-points-file`, or the configured path does not exist on disk. |
+| `no-chain-points-yet` | The file exists but contains no parseable lines (typical at start-of-test, before `tracer-sidecar` has emitted any points). |
+| `no-producers` | The daemon was started without any `--producer-host` flag, so there is nothing to fan connections across. |
+
 The composer driver script in
-`cardano-foundation/cardano-node-antithesis` will map outcomes to
+`cardano-foundation/cardano-node-antithesis` should map outcomes to
 SDK assertions:
 
 | `reason` | `exit` | Antithesis SDK assertion |
 |---|---|---|
 | (none — `ok == true`) | 0 | `sdk_sometimes true "adversary_chain_sync_flap_completed"` |
-| `not-implemented` | 1 | `sdk_unreachable "adversary_endpoint_not_implemented"` (during the PR-B → PR-C transition window) |
+| `not-implemented` | 1 | `sdk_unreachable "adversary_endpoint_not_implemented"` (only seen during a PR-B → PR-C transition window; should never appear after this PR merges) |
+| `no-chain-points-file` | 1 | `sdk_unreachable "adversary_misconfigured_no_points_file"` |
 | `no-chain-points-yet` | 1 | `sdk_sometimes false "adversary_no_chain_points"` |
+| `no-producers` | 1 | `sdk_unreachable "adversary_misconfigured_no_producers"` |
 
 ## Framing details
 

--- a/test/Cardano/Node/Client/Adversary/ChainPointsSpec.hs
+++ b/test/Cardano/Node/Client/Adversary/ChainPointsSpec.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Cardano.Node.Client.Adversary.ChainPointsSpec
+Description : Unit tests for ChainPoints parser + sampler
+License     : Apache-2.0
+-}
+module Cardano.Node.Client.Adversary.ChainPointsSpec (spec) where
+
+import Cardano.Node.Client.Adversary.ChainPoints (
+    generatePoints,
+    originPoint,
+    parseChainPointSamples,
+    readChainPoint,
+ )
+import Data.List.NonEmpty qualified as NE
+import Data.Maybe (isJust, isNothing)
+import System.Random (mkStdGen)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+
+spec :: Spec
+spec = do
+    describe "readChainPoint" $ do
+        it "parses 'origin'" $
+            readChainPoint "origin" `shouldBe` Just originPoint
+
+        it "rejects empty string" $
+            readChainPoint "" `shouldSatisfy` isNothing
+
+        it "rejects garbage with no '@'" $
+            readChainPoint "deadbeef" `shouldSatisfy` isNothing
+
+        it "rejects non-hex blockHash" $
+            readChainPoint "ZZZZ@1234" `shouldSatisfy` isNothing
+
+        it "rejects non-numeric slotNo" $
+            readChainPoint "deadbeef@notaslot" `shouldSatisfy` isNothing
+
+        it "accepts a well-formed hex@slot" $
+            readChainPoint "deadbeef@1234" `shouldSatisfy` isJust
+
+    describe "parseChainPointSamples" $ do
+        it "always prepends origin" $ case parseChainPointSamples "" of
+            Just neList -> NE.head neList `shouldBe` originPoint
+            Nothing -> error "empty file should still produce a sample list"
+
+        it "rejects a file containing one bad line" $
+            parseChainPointSamples "deadbeef@1\nZZZ@2"
+                `shouldSatisfy` isNothing
+
+        it "accepts multiple well-formed lines" $
+            case parseChainPointSamples "deadbeef@1\n4242@99" of
+                Just ne -> NE.length ne `shouldBe` 3 -- origin + two parsed
+                Nothing -> error "should parse"
+
+    describe "generatePoints" $ do
+        it "returns the sole point repeatedly when input is a singleton" $ do
+            let g = mkStdGen 1
+                ne = originPoint NE.:| []
+                stream = generatePoints g ne
+            NE.take 5 stream `shouldBe` replicate 5 originPoint
+
+        it "is deterministic given a fixed seed" $
+            case parseChainPointSamples "deadbeef@1\n4242@2" of
+                Nothing -> error "should parse"
+                Just ne -> do
+                    let g1 = mkStdGen 42
+                        g2 = mkStdGen 42
+                        s1 = NE.take 10 (generatePoints g1 ne)
+                        s2 = NE.take 10 (generatePoints g2 ne)
+                    s1 `shouldBe` s2
+
+        it "differs given different seeds (with high probability)" $
+            case parseChainPointSamples "deadbeef@1\n4242@2\n9999@3" of
+                Nothing -> error "should parse"
+                Just ne -> do
+                    let g1 = mkStdGen 1
+                        g2 = mkStdGen 2
+                        s1 = NE.take 50 (generatePoints g1 ne)
+                        s2 = NE.take 50 (generatePoints g2 ne)
+                    (s1 == s2) `shouldBe` False

--- a/test/Cardano/Node/Client/Adversary/ServerSpec.hs
+++ b/test/Cardano/Node/Client/Adversary/ServerSpec.hs
@@ -15,6 +15,8 @@ module Cardano.Node.Client.Adversary.ServerSpec (spec) where
 
 import Cardano.Node.Client.Adversary.Types (
     ChainSyncFlapArgs (..),
+    ChainSyncFlapDetails (..),
+    ChainSyncFlapFailure (..),
     ErrorReason (..),
     ReadyDetails (..),
     Request (..),
@@ -104,6 +106,55 @@ spec = do
             encode (RespError ErrUnknownRequest)
                 `shouldBe` encode
                     ( object ["error" .= ("unknown request" :: String)]
+                    )
+
+        it "RespChainSyncFlapOk shape matches control-wire.md" $
+            encode
+                ( RespChainSyncFlapOk
+                    ChainSyncFlapDetails
+                        { csfdConnections = 2
+                        , csfdPeerNames = ["p1.example", "p2.example"]
+                        , csfdLimit = 100
+                        }
+                )
+                `shouldBe` encode
+                    ( object
+                        [ "ok" .= True
+                        , "details"
+                            .= object
+                                [ "connections" .= (2 :: Int)
+                                , "peerNames"
+                                    .= ["p1.example" :: String, "p2.example"]
+                                , "limit" .= (100 :: Int)
+                                ]
+                        ]
+                    )
+
+        it "RespChainSyncFlapFail no-chain-points-yet" $
+            encode (RespChainSyncFlapFail CsffNoChainPointsYet)
+                `shouldBe` encode
+                    ( object
+                        [ "ok" .= False
+                        , "reason" .= ("no-chain-points-yet" :: String)
+                        ]
+                    )
+
+        it "RespChainSyncFlapFail no-chain-points-file" $
+            encode (RespChainSyncFlapFail CsffNoChainPointsFile)
+                `shouldBe` encode
+                    ( object
+                        [ "ok" .= False
+                        , "reason" .= ("no-chain-points-file" :: String)
+                        ]
+                    )
+
+        it "RespChainSyncFlapFail no-producers" $
+            encode (RespChainSyncFlapFail CsffNoProducers)
+                `shouldBe` encode
+                    ( object
+                        [ "ok" .= False
+                        , "reason" .= ("no-producers" :: String)
+                        ]
                     )
 
     describe "Round-trip" $ do

--- a/test/unit-main.hs
+++ b/test/unit-main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Test.Hspec (hspec)
 
+import Cardano.Node.Client.Adversary.ChainPointsSpec qualified as AdversaryChainPointsSpec
 import Cardano.Node.Client.Adversary.ServerSpec qualified as AdversaryServerSpec
 import Cardano.Node.Client.BalanceSpec qualified as BalanceSpec
 import Cardano.Node.Client.N2C.ProbeSpec qualified as N2CProbeSpec
@@ -23,6 +24,7 @@ import Data.List.SampleFibonacciSpec qualified as SampleFibonacciSpec
 main :: IO ()
 main = hspec $ do
     SampleFibonacciSpec.spec
+    AdversaryChainPointsSpec.spec
     AdversaryServerSpec.spec
     BalanceSpec.spec
     TxBuildSpec.spec


### PR DESCRIPTION
Closes #104.

PR C of the [adversary roadmap](https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/docs/components/adversary-roadmap.md). Lifts the existing one-shot chain-sync code from `cardano-foundation/cardano-node-antithesis/components/adversary/src/` into the long-running daemon as the real `chain_sync_flap` endpoint.

## Commits

| # | Commit | Concern |
|---|---|---|
| T101 | `d7d07cf` | Lift Application + ChainSync.{Codec,Connection} into the cardano-node-clients tree, with API-drift fixes for newer ouroboros-network / cardano-diffusion. Daemon hook still returns `RespNotImplemented`. |
| T102 | `8f78fd3` | Real `chain_sync_flap` implementation: ChainPoints parser, daemon hook reads the file, derives a `StdGen` from `seed`, dispatches `n_conns` concurrent connections via `repeatedAdversaryApplication`. New `--chain-points-file` CLI flag. Three structured failure reasons. |
| T103 | `215c465` | 19 new unit tests (5 wire-shape + 14 ChainPoints parser/sampler). 232 total green. |
| T104 | `7235940` | Wire-spec doc reflects implementation reality. |

## Wire surface

```jsonc
// success
{"ok": true,
 "details": {"connections": 1,
             "peerNames": ["p1.example"],
             "limit": 100}}

// structured failure
{"ok": false, "reason": "no-chain-points-file"}
{"ok": false, "reason": "no-chain-points-yet"}
{"ok": false, "reason": "no-producers"}
```

Full schema with composer SDK-assertion mapping in [`specs/036-cardano-adversary/contracts/control-wire.md`](https://github.com/lambdasistemi/cardano-node-clients/blob/feat/chain-sync-flap-impl/specs/036-cardano-adversary/contracts/control-wire.md).

## Verification

End-to-end smoke run on the local devshell:

```
$ echo "origin" > /tmp/points
$ cabal run cardano-adversary -- \
    --control-socket /tmp/adv.sock --network-magic 42 \
    --producer-host nonexistent.invalid --chain-points-file /tmp/points
$ printf '{"chain_sync_flap": {"seed":42,"limit":10,"n_conns":1}}\n' \
    | nc -U -N /tmp/adv.sock
{"details":{"connections":1,"limit":10,"peerNames":["nonexistent.invalid"]},"ok":true}
```

Daemon stderr shows `Starting adversary application against nonexistent.invalid from point Point Origin` and gracefully reports the DNS failure when `repeatedAdversaryApplication` returns. After SIGTERM the control socket is unlinked.

Quality gate green: build, fourmolu, hlint, cabal-fmt, 232 unit tests.

## Roadmap

- [adversary epic #89](https://github.com/cardano-foundation/cardano-node-antithesis/issues/89) — Tier 1.1 done with this PR.
- Once the new image is published from main, [`cardano-foundation/cardano-node-antithesis#90`](https://github.com/cardano-foundation/cardano-node-antithesis/issues/90) (PR D) can move forward — switch the antithesis-side `components/adversary/` to consume the GHCR image and delete the standalone Haskell binary.
- PR E (this repo) follows with `chain_sync_thrash` + `chain_sync_slow_loris`. Tier 1 complete after that.