### PR TITLE
spec(037-cardano-adversary-thrash): Tier 1.2 spec

### DIFF
--- a/specs/037-cardano-adversary-thrash/contracts/control-wire.md
+++ b/specs/037-cardano-adversary-thrash/contracts/control-wire.md
@@ -1,0 +1,71 @@
+# Control Wire — `chain_sync_thrash` endpoint
+
+Extends the cardano-adversary daemon's NDJSON control wire (defined
+in [`../../036-cardano-adversary/contracts/control-wire.md`][036])
+with one additional endpoint. Same framing rules apply: one JSON
+object per line, single request → single response → EOF + close.
+
+## `chain_sync_thrash` — single connection, repeated `MsgFindIntersect`
+
+**Request**:
+```json
+{"chain_sync_thrash": {"seed": 12345678901234567890,
+                       "intersect_count": 50,
+                       "settle_ms": 50}}
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `seed` | `uint64` | Sole source of randomness. Drives the per-request `StdGen` via `splitFromSeed`, which then chooses the producer and samples each successive intersect point. |
+| `intersect_count` | `uint16` (clamped to `[1, 1000]`) | How many `MsgFindIntersect` messages to issue on the single chain-sync connection. |
+| `settle_ms` | `uint16` (clamped to `[0, 60000]`) | Additional sleep between issues (on top of the protocol's natural RTT). |
+
+**Response (success)**:
+```json
+{"ok": true,
+ "details": {
+   "peerName": "p2.example",
+   "intersectsIssued": 50,
+   "intersectCountClamped": false,
+   "settleMsClamped": false
+ }}
+```
+
+`intersectCountClamped` / `settleMsClamped` are `true` iff the
+incoming value was outside the documented range and the daemon
+clamped it. The actual value used is `intersectsIssued` (mirrors
+the request's `intersect_count` after clamping).
+
+**Response (structured failure)**:
+```json
+{"ok": false, "reason": "no-chain-points-file"}
+{"ok": false, "reason": "no-chain-points-yet"}
+{"ok": false, "reason": "no-producers"}
+{"ok": false, "reason": "connection-refused"}
+```
+
+| `reason` | When |
+|---|---|
+| `no-chain-points-file` | Daemon was started without `--chain-points-file`, or the configured path does not exist on disk. |
+| `no-chain-points-yet` | File exists but contains no parseable lines (typical at start-of-test). |
+| `no-producers` | Daemon was started without any `--producer-host` flag. |
+| `connection-refused` | DNS resolution failed or the TCP connect was refused / RST. The daemon does not retry — the composer driver retries by firing the next tick. |
+
+## Composer driver SDK assertion mapping
+
+| `reason` | exit | Antithesis SDK assertion |
+|---|---|---|
+| (none — `ok == true`) | 0 | `sdk_sometimes true "adversary_chain_sync_thrash_completed"` |
+| `no-chain-points-file` | 1 | `sdk_unreachable "adversary_misconfigured_no_points_file"` |
+| `no-chain-points-yet` | 1 | `sdk_sometimes false "adversary_no_chain_points"` |
+| `no-producers` | 1 | `sdk_unreachable "adversary_misconfigured_no_producers"` |
+| `connection-refused` | 1 | `sdk_sometimes false "adversary_thrash_connection_refused"` (expected occasionally under fault injection) |
+
+## Framing rules
+
+Inherited from [`036-cardano-adversary/contracts/control-wire.md`][036]:
+one request per connection, response is one line + `\n`, malformed
+JSON → `{"error": "malformed json"}`, unknown top-level key →
+`{"error": "unknown request"}`. No streaming.
+
+[036]: ../../036-cardano-adversary/contracts/control-wire.md

--- a/specs/037-cardano-adversary-thrash/plan.md
+++ b/specs/037-cardano-adversary-thrash/plan.md
@@ -1,0 +1,147 @@
+# Implementation Plan: chain_sync_thrash endpoint
+
+**Spec**: [`spec.md`](spec.md)
+**Tracking issue**: https://github.com/lambdasistemi/cardano-node-clients/issues/107
+
+## Architecture (delta against 036)
+
+```
+   composer ----> NDJSON ----> Server.hs (036)
+                              dispatcher
+                                  |
+                                  +--> hooksReady           (existing)
+                                  +--> hooksChainSyncFlap   (existing, 036)
+                                  +--> hooksChainSyncThrash (new — this PR)
+                                                |
+                                                v
+                  Cardano.Node.Client.Adversary.ChainSyncThrash
+                                                |
+                                                +--> ChainSync.Connection (existing, 036)
+                                                +--> ChainSync.Codec      (existing, 036)
+                                                +--> ChainPoints          (existing, 036)
+                                                +--> RandomSource         (existing, 036)
+```
+
+Everything that existed in 036 stays exactly as it is. The new
+endpoint adds one module and one hook.
+
+## Module layout
+
+```
+lib/Cardano/Node/Client/Adversary/
+    Application.hs            — existing; gains a small helper
+                                'thrashApplication' that wraps the
+                                ChainSync.Codec idiom for the new
+                                ClientStIdle that only sends
+                                MsgFindIntersect.
+    ChainSyncThrash.hs        — NEW. Top-level driver, picks the
+                                producer host via splitFromSeed,
+                                reads chain points, runs the
+                                bounded intersect loop, returns
+                                Response.
+specs/037-cardano-adversary-thrash/
+    spec.md
+    plan.md
+    tasks.md
+    contracts/control-wire.md
+```
+
+## Public surface (additions only)
+
+```haskell
+-- Cardano.Node.Client.Adversary.Types  (extend Request + Response)
+data Request
+    = ReqReady                                -- existing
+    | ReqChainSyncFlap !ChainSyncFlapArgs     -- existing
+    | ReqChainSyncThrash !ChainSyncThrashArgs -- new
+
+data ChainSyncThrashArgs = ChainSyncThrashArgs
+    { ctaSeed           :: !Word64
+    , ctaIntersectCount :: !Word16   -- clamped [1, 1000]
+    , ctaSettleMs       :: !Word16   -- clamped [0, 60000]
+    }
+
+data Response
+    = RespReady !ReadyDetails                  -- existing
+    | RespNotImplemented                       -- existing
+    | RespChainSyncFlapOk !ChainSyncFlapDetails -- existing
+    | RespChainSyncFlapFail !ChainSyncFlapFailure -- existing
+    | RespChainSyncThrashOk !ChainSyncThrashDetails -- new
+    | RespChainSyncThrashFail !ChainSyncThrashFailure -- new
+    | RespError !ErrorReason                   -- existing
+
+data ChainSyncThrashDetails = ChainSyncThrashDetails
+    { cstdPeerName              :: !Text
+    , cstdIntersectsIssued      :: !Word16
+    , cstdIntersectCountClamped :: !Bool
+    , cstdSettleMsClamped       :: !Bool
+    }
+
+data ChainSyncThrashFailure
+    = CstfNoChainPointsFile          -- shared semantics with chain_sync_flap
+    | CstfNoChainPointsYet
+    | CstfNoProducers
+    | CstfConnectionRefused          -- new for this endpoint
+```
+
+```haskell
+-- Cardano.Node.Client.Adversary.Server  (extend ServerHooks)
+data ServerHooks = ServerHooks
+    { hooksReady           :: IO ReadyDetails                    -- existing
+    , hooksChainSyncFlap   :: ChainSyncFlapArgs   -> IO Response -- existing
+    , hooksChainSyncThrash :: ChainSyncThrashArgs -> IO Response -- new
+    }
+```
+
+```haskell
+-- Cardano.Node.Client.Adversary.ChainSyncThrash  (NEW)
+runThrash :: DaemonConfig -> ChainSyncThrashArgs -> IO Response
+```
+
+## Reuse contract
+
+| Concern | Source |
+|---|---|
+| N2N initiator handshake + chain-sync codec | `Cardano.Node.Client.Adversary.ChainSync.{Codec,Connection}` |
+| Chain-points file parser + sampler | `Cardano.Node.Client.Adversary.ChainPoints` |
+| Per-request determinism | `Cardano.Node.Client.Adversary.RandomSource.splitFromSeed` |
+| Producer-host fan-out | none — this endpoint picks **one** producer, not all |
+| Chain-sync state machine | New helper `thrashClient` in `Application.hs`, or a sibling module that owns the new ClientStIdle |
+
+`runThrash` can be implemented in pure-IO without an STM TVar (no
+chain accumulation needed — we never call `MsgRequestNext`). State
+is just a counter for `intersectsIssued`.
+
+## Testing approach
+
+| Test | Where |
+|---|---|
+| `chain_sync_thrash` request decodes from documented JSON | `test/.../Adversary/ServerSpec.hs` (extend) |
+| `RespChainSyncThrashOk` / each `Fail` variant encodes byte-for-byte | same |
+| `intersect_count` clamping at the type/clamp helper | `test/.../Adversary/ChainSyncThrashSpec.hs` (new) |
+| Same seed → same producer choice (determinism) | same |
+| End-to-end: daemon answers thrash against an unreachable host with `connection-refused` | smoke step inside the existing devnet harness if cheap; otherwise leave for the antithesis-side compose smoke |
+
+## Out of scope (deferred)
+
+- Slow-loris (1.3) — same connection, slow `MsgRequestNext`. Lives
+  in `038-cardano-adversary-slow-loris`.
+- All Tier 2 / 3 / 4 endpoints.
+- Antithesis-side compose tag bump — separate one-line PR after
+  this merges (mirror of the PR D pattern).
+
+## Risks
+
+- **State-machine correctness in `ouroboros-network`.** The
+  chain-sync client state machine permits sending another
+  `MsgFindIntersect` after the previous one's
+  `MsgIntersectFound` / `MsgIntersectNotFound` reply has been
+  received. Verify against the spec; if intersect-after-intersect
+  is *not* allowed in `StIdle`, the loop must instead disconnect
+  and reconnect, which would defeat the point of the endpoint.
+  Mitigation: prototype against a local devnet before claiming the
+  request shape final.
+- **Composer driver order with chain_sync_flap.** Both endpoints
+  read the same chain-points file. If thrash holds a connection
+  open while flap is firing, it shouldn't matter — they're
+  separate connections — but worth a smoke run to confirm.

--- a/specs/037-cardano-adversary-thrash/spec.md
+++ b/specs/037-cardano-adversary-thrash/spec.md
@@ -1,0 +1,173 @@
+# Feature Specification: chain_sync_thrash endpoint
+
+**Feature Branch**: `037-cardano-adversary-thrash`
+**Created**: 2026-04-30
+**Status**: Draft
+**Input**: User description: "Second misbehaviour endpoint of the cardano-adversary daemon. On a single open N2N chain-sync connection, repeatedly issue MsgFindIntersect to a different randomly-chosen point and never finish the sync. Stresses the producer's intersection-finding cache. Same control-socket NDJSON shape as chain_sync_flap (036)."
+
+## Background
+
+[`036-cardano-adversary`][036] established the daemon and the
+`chain_sync_flap` endpoint, where each request opens N concurrent
+connections, each one issues one `MsgFindIntersect` and pulls
+`limit` blocks before disconnecting. That exercises connection
+churn but only ever sends **one** intersect per connection.
+
+A complementary archetype: stay on **one** connection, repeatedly
+issue `MsgFindIntersect` to different points without ever pulling
+blocks. The producer side has to maintain a per-peer search context
+and keep up with rapid pivots through the volatile chain. This is
+the canonical "intersection-finding cache thrash" test.
+
+## User Scenarios & Testing *(mandatory)*
+
+The primary user is the **Antithesis test composer** firing one
+NDJSON request per tick. Secondary user is the **operator** wiring
+the daemon into the testnet.
+
+### User Story 1 — Thrash a single peer's intersection cache (Priority: P1)
+
+The composer fires a single tick; the daemon opens one N2N
+chain-sync connection to a randomly-chosen producer, completes the
+handshake, and within a bounded time window issues
+`intersect_count` `MsgFindIntersect` messages to randomly-chosen
+points drawn from the chain-points file, with `settle_ms`
+milliseconds between each. After the last one it disconnects.
+
+**Why this priority**: This is the entire endpoint. There is no
+useful sub-feature.
+
+**Independent Test**: Stand up the daemon against a devnet whose
+`tracer-sidecar` has populated the chain-points file. Send one
+request with `intersect_count=10, settle_ms=50`. Verify (a) the
+daemon responds `{"ok": true, ...}`, (b) the producer's tracer
+log shows ~10 `FindIntersect` events from the adversary peer
+within the same connection ID, (c) no `MsgRequestNext` events
+from the same peer.
+
+**Acceptance Scenarios**:
+
+1. **Given** the daemon is running and the chain-points file has
+   at least one parseable point, **When** the composer sends
+   `{"chain_sync_thrash":{"seed":S,"intersect_count":N,"settle_ms":W}}`,
+   **Then** the daemon opens exactly one N2N chain-sync
+   connection, issues N `MsgFindIntersect` messages with W ms
+   between them, then disconnects, and responds with
+   `{"ok": true, "details": {"intersectsIssued": N, ...}}`.
+2. **Given** the chain-points file is missing or empty, **When**
+   the composer fires a request, **Then** the daemon responds
+   `{"ok": false, "reason": "no-chain-points-yet"}` (or
+   `"no-chain-points-file"`) without dialing any producer.
+3. **Given** no `--producer-host` was configured, **When** the
+   composer fires a request, **Then** the daemon responds
+   `{"ok": false, "reason": "no-producers"}`.
+4. **Given** the daemon's TCP connection to the chosen producer
+   is refused (host unreachable, port closed), **When** the
+   thrash request fires, **Then** the daemon responds
+   `{"ok": false, "reason": "connection-refused"}` and never
+   crashes.
+
+---
+
+### User Story 2 — Determinism for replay (Priority: P2)
+
+Given a fixed seed and a fixed chain-points file, two thrash
+requests must visit the same sequence of producers and the same
+sequence of intersect points (modulo network non-determinism on the
+producer side).
+
+**Why this priority**: Useful for debugging / triage. If a thrash
+caused a finding, replaying the same seed should reproduce it.
+
+**Acceptance Scenarios**:
+
+1. **Given** the same `seed` and the same chain-points file,
+   **When** two thrash requests are fired, **Then** the chosen
+   producer host and the sequence of intersect points selected for
+   `MsgFindIntersect` are byte-identical.
+
+---
+
+## Functional Requirements
+
+- **FR-001** A new top-level NDJSON request shape
+  `{"chain_sync_thrash": {"seed": uint64, "intersect_count":
+  uint16, "settle_ms": uint16}}` SHALL be accepted on the
+  daemon's control socket. Field names match
+  `contracts/control-wire.md`.
+- **FR-002** The daemon SHALL select exactly one producer host from
+  `--producer-host` using the request's `seed` (via
+  `splitFromSeed`).
+- **FR-003** The daemon SHALL open exactly one chain-sync N2N
+  connection per request. After the connection completes its
+  intersect loop the daemon SHALL close it and return.
+- **FR-004** The daemon SHALL issue `intersect_count`
+  `MsgFindIntersect` messages with `settle_ms` milliseconds
+  between them. Each intersect's point is drawn from the parsed
+  chain-points file via the same `generatePoints` stream used by
+  `chain_sync_flap` (036).
+- **FR-005** The daemon SHALL NOT send `MsgRequestNext`. The thrash
+  loop is **purely** intersect spam.
+- **FR-006** Failure modes mirror `chain_sync_flap`:
+  `no-chain-points-file`, `no-chain-points-yet`, `no-producers`.
+  Add one new mode: `connection-refused` for unreachable
+  producers (DNS-not-found or TCP RST).
+- **FR-007** The daemon SHALL clamp `intersect_count` to `[1,
+  1000]` and `settle_ms` to `[0, 60000]` to keep one tick bounded.
+  Clamping is silent — the response carries the actual value
+  used.
+- **FR-008** Adding the endpoint SHALL NOT regress existing
+  endpoints (`ready`, `chain_sync_flap`). The `Server` dispatcher
+  must accept the new shape and route to the new hook; existing
+  hooks unchanged.
+- **FR-009** Wire-spec contract (`control-wire.md`) SHALL be
+  updated to document the new endpoint, with the SDK-assertion
+  table for the composer driver to map outcomes.
+
+## Non-Functional Requirements
+
+- **NFR-001** Per-tick wall-clock budget: a request with
+  `intersect_count=100, settle_ms=50` should complete within
+  `100*50ms + connection-setup ≈ 6 s`. Anything longer is a bug.
+- **NFR-002** Memory budget: one open connection's chain-sync state
+  is sub-MB; idle daemon RSS budget from 036 stands.
+- **NFR-003** No persisted state files. The endpoint is stateless
+  modulo the chain-points file it shares with `chain_sync_flap`.
+
+## Out of Scope
+
+- Tier 1.3 `chain_sync_slow_loris` (different misbehaviour
+  pattern; kept on the same connection but with **slow**
+  `MsgRequestNext` instead of intersect thrashing).
+- Tier 2 (other mini-protocols).
+- The compose-side image bump in `cardano-foundation/cardano-node-antithesis`
+  — that's a separate one-line PR after this PR merges.
+
+## Open Questions
+
+- Should the daemon assert that the producer answers each
+  `MsgFindIntersect` before sending the next, or is the
+  intersect loop purely "send and forget"? **Decision proposed**:
+  send-and-forget at the application layer, but the chain-sync
+  state machine in `ouroboros-network` already enforces a
+  send/receive cadence per protocol. So in practice the daemon
+  blocks waiting for the producer's `MsgIntersectFound` /
+  `MsgIntersectNotFound` reply between issues. `settle_ms` then
+  governs an *additional* sleep on top of the protocol's natural
+  RTT.
+- Should the same seed produce the same producer choice across
+  daemon restarts? **Decision proposed**: yes — the seed alone
+  determines both, since the producer list is configured at
+  startup and won't change mid-test.
+
+## References
+
+- Wire spec: [`contracts/control-wire.md`](contracts/control-wire.md).
+- Plan: [`plan.md`](plan.md).
+- Tasks: [`tasks.md`](tasks.md).
+- Sibling spec [`036-cardano-adversary`][036] — same daemon, the
+  `chain_sync_flap` endpoint.
+- Antithesis-side roadmap: https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/docs/components/adversary-roadmap.md
+- Tracking issue: https://github.com/lambdasistemi/cardano-node-clients/issues/107
+
+[036]: ../036-cardano-adversary/spec.md

--- a/specs/037-cardano-adversary-thrash/tasks.md
+++ b/specs/037-cardano-adversary-thrash/tasks.md
@@ -1,0 +1,70 @@
+# Tasks: chain_sync_thrash endpoint
+
+**Spec**: [`spec.md`](spec.md)
+**Plan**: [`plan.md`](plan.md)
+**Tracking issue**: https://github.com/lambdasistemi/cardano-node-clients/issues/107
+
+Each task lands as one bisect-safe commit on `feat/chain-sync-thrash-impl`.
+
+## Tasks
+
+- **T201 — Wire types.** Extend
+  `Cardano.Node.Client.Adversary.Types` with
+  `ChainSyncThrashArgs`, `ChainSyncThrashDetails`,
+  `ChainSyncThrashFailure`, the new `Request` and `Response`
+  constructors, and ToJSON / FromJSON instances byte-for-byte
+  matching `contracts/control-wire.md`. **Daemon hook still
+  unchanged — `Server` returns `RespNotImplemented` for the new
+  request.**
+- **T202 — Server hook slot.** Extend `ServerHooks` with
+  `hooksChainSyncThrash :: ChainSyncThrashArgs -> IO Response`.
+  Default implementation in the daemon's `mkHooks` returns
+  `RespNotImplemented`. Bisect-safe: the wire decode works, the
+  endpoint responds, but with `RespNotImplemented`.
+- **T203 — Chain-sync state machine for thrash.** Add a small
+  helper alongside the existing `Application.hs` (or in a new
+  `Cardano.Node.Client.Adversary.ChainSyncThrash` module): a
+  `ClientStIdle` whose `recvMsgIntersectFound` /
+  `recvMsgIntersectNotFound` callbacks both schedule another
+  `MsgFindIntersect` until the bounded counter is exhausted, then
+  `SendMsgDone`. Pure unit test that the chain-sync state
+  machine's response matches the bound under a stub responder.
+- **T204 — Top-level runner.** New module
+  `Cardano.Node.Client.Adversary.ChainSyncThrash` exporting
+  `runThrash :: DaemonConfig -> ChainSyncThrashArgs -> IO Response`:
+  - clamp inputs;
+  - read chain-points file (mirror of the flap path);
+  - draw `producerHost` and the intersect-point stream from the
+    request's `seed`;
+  - call into T203's state-machine helper;
+  - map per-connection outcomes onto the documented `Response`.
+- **T205 — Daemon wiring.** Replace `mkHooks`'s
+  `hooksChainSyncThrash` stub with `runThrash cfg`.
+  End-to-end: `printf '{"chain_sync_thrash":...}\n' | nc -U
+  /state/adversary-control.sock` against a local devnet returns a
+  documented body.
+- **T206 — Unit tests.** Extend `Adversary.ServerSpec` for the new
+  wire shapes; new `Adversary.ChainSyncThrashSpec` covering the
+  clamp, the determinism property (same seed → same producer
+  choice), and the chain-sync state machine helper from T203.
+- **T207 — Quality gate.** `nix develop -c just ci` green.
+- **T208 — PR.** Open the PR; link to
+  [issue #107](https://github.com/lambdasistemi/cardano-node-clients/issues/107)
+  and to the antithesis-side roadmap epic
+  [#89](https://github.com/cardano-foundation/cardano-node-antithesis/issues/89).
+
+## Definition of done
+
+- [ ] All T201–T208 commits land in order.
+- [ ] `cabal run cardano-adversary -- --help` still works (no CLI
+      regression — endpoint is configured per-request, not at
+      startup).
+- [ ] `printf '{"chain_sync_thrash":{"seed":1,"intersect_count":5,"settle_ms":50}}\n' | nc -U /tmp/adv.sock`
+      against a daemon connected to a devnet returns
+      `{"ok":true,"details":{"peerName":"...","intersectsIssued":5,...}}`.
+- [ ] Producer's tracer shows ~5 `FindIntersect` events from the
+      adversary peer in the same connection.
+- [ ] CI publishes a fresh `ghcr.io/lambdasistemi/cardano-node-clients/cardano-adversary:<sha>`
+      image after merge.
+- [ ] Follow-up one-line PR in `cardano-foundation/cardano-node-antithesis` bumps
+      the wrapper image's `cardano-node-clients` flake input + compose tag.


### PR DESCRIPTION
Tracks #107 (Tier 1.2 chain_sync_thrash). Spec-only; no code changes.

The implementation lands as T201–T208 bisect-safe commits per [tasks.md](https://github.com/lambdasistemi/cardano-node-clients/blob/feat/chain-sync-thrash-spec/specs/037-cardano-adversary-thrash/tasks.md). Filed as a separate spec-first PR so review can pin the wire surface (request fields, success body, failure reasons, SDK-assertion table) before any Haskell goes in.

## Highlights

- New endpoint slot `{"chain_sync_thrash":{"seed":..,"intersect_count":..,"settle_ms":..}}` on the existing daemon control socket.
- Single open chain-sync N2N connection; repeatedly issue `MsgFindIntersect` to randomly-sampled chain points; never `MsgRequestNext`.
- Reuses everything from 036: `RandomSource`, `splitFromSeed`, `ChainPoints`, `ChainSync.{Codec,Connection}`. Only one new module: `Cardano.Node.Client.Adversary.ChainSyncThrash`.
- New failure reason `connection-refused` (vs. flap which fans across multiple hosts and survives one DNS-not-found gracefully).
- Full SDK-assertion table for the composer driver in `contracts/control-wire.md`.

## Risks called out

- Chain-sync state machine in `ouroboros-network` may not allow `MsgFindIntersect` → `MsgFindIntersect` without an intervening `MsgRequestNext`. The plan flags this and proposes prototyping against a local devnet in T203 before claiming the request shape final.

## Roadmap context

- Antithesis-side: https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/docs/components/adversary-roadmap.md
- Epic: https://github.com/cardano-foundation/cardano-node-antithesis/issues/89