### PR TITLE
fix(tx-generator): gate refill/transact arms on indexer freshness post-reconnect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,12 @@
 # cardano-node-clients-tx-builder Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-28
+Auto-generated from all feature plans. Last updated: 2026-05-01
 
 ## Active Technologies
 - Haskell, GHC 9.6+ (matches repo). (034-cardano-tx-generator)
 - two files in `--state-dir` (`master.seed` 32 bytes, (034-cardano-tx-generator)
+- Haskell, GHC 9.6+ (matches repo) + `cardano-ledger-conway`, `ouroboros-network`, internal `chain-follower` `Follower` abstraction, internal `N2C.Reconnect.runReconnectLoop` (PR #105) (037-tx-gen-indexer-fresh)
+- in-memory `TVar ReadyState` (no persistence change) (037-tx-gen-indexer-fresh)
 
 - Haskell (GHC 9.6+, same as cardano-node-clients) + cardano-ledger-api, cardano-ledger-conway, plutus-ledger-api, plutus-tx (ToData/FromData) (003-tx-builder-dsl)
 
@@ -24,6 +26,7 @@ tests/
 Haskell (GHC 9.6+, same as cardano-node-clients): Follow standard conventions
 
 ## Recent Changes
+- 037-tx-gen-indexer-fresh: Added Haskell, GHC 9.6+ (matches repo) + `cardano-ledger-conway`, `ouroboros-network`, internal `chain-follower` `Follower` abstraction, internal `N2C.Reconnect.runReconnectLoop` (PR #105)
 - 034-cardano-tx-generator: Added Haskell, GHC 9.6+ (matches repo).
 
 - 003-tx-builder-dsl: Added Haskell (GHC 9.6+, same as cardano-node-clients) + cardano-ledger-api, cardano-ledger-conway, plutus-ledger-api, plutus-tx (ToData/FromData)

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -308,6 +308,7 @@ test-suite e2e-tests
     Cardano.Node.Client.E2E.ProviderSpec
     Cardano.Node.Client.E2E.TxBuildSpec
     Cardano.Node.Client.E2E.TxGeneratorEnduranceSpec
+    Cardano.Node.Client.E2E.TxGeneratorIndexFreshSpec
     Cardano.Node.Client.E2E.TxGeneratorReadySpec
     Cardano.Node.Client.E2E.TxGeneratorRefillSpec
     Cardano.Node.Client.E2E.TxGeneratorRestartSpec

--- a/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
+++ b/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
@@ -213,12 +213,20 @@ data DaemonConfig = DaemonConfig
 view of the bearer; 'readyResponseFrom' enforces the
 invariant @UpstreamDisconnected => ready=false@ on the
 wire.
+
+'rsIndexFresh' is orthogonal to 'rsReady' (which gates on
+tip-distance) and 'rsUpstream' (which gates on bearer
+state). It captures whether the indexer has applied at
+least one block since the most recent reconnect: false on
+cold start and on every transition into 'UpstreamConnected';
+true after the first 'rollForward' completes (issue #109).
 -}
 data ReadyState = ReadyState
     { rsReady :: !Bool
     , rsTipSlot :: !(Maybe Word64)
     , rsProcessedSlot :: !(Maybe Word64)
     , rsUpstream :: !UpstreamStatus
+    , rsIndexFresh :: !Bool
     }
     deriving stock (Show)
 
@@ -229,6 +237,7 @@ initialReady =
         , rsTipSlot = Nothing
         , rsProcessedSlot = Nothing
         , rsUpstream = UpstreamConnected
+        , rsIndexFresh = False
         }
 
 data BootMode
@@ -319,11 +328,20 @@ runDaemonWithTracer tracer cfg = do
             -- we also force rsReady=False at the
             -- producer (the encoder enforces the same
             -- invariant on the wire — defense in depth).
+            -- On UpstreamConnected we clear rsIndexFresh
+            -- so the arms refuse to read a stale UTxO
+            -- view until the chain-sync follower has
+            -- applied at least one post-reconnect block
+            -- (issue #109). rsIndexFresh flips back to
+            -- true inside 'updateReady'.
             setUpstreamStatus newStatus =
                 atomically $ modifyTVar' readyVar $ \rs ->
                     case newStatus of
                         UpstreamConnected ->
-                            rs{rsUpstream = UpstreamConnected}
+                            rs
+                                { rsUpstream = UpstreamConnected
+                                , rsIndexFresh = False
+                                }
                         UpstreamDisconnected _ ->
                             rs
                                 { rsUpstream = newStatus
@@ -396,43 +414,73 @@ runDaemonWithTracer tracer cfg = do
                 -- surface a not-applicable response so the
                 -- composer retries on the next tick instead
                 -- of taking down the daemon process.
+                --
+                -- The freshness gate ('rsIndexFresh') runs
+                -- before the arm body: between the
+                -- supervisor flipping rsUpstream to
+                -- 'UpstreamConnected' and the chain-sync
+                -- follower applying its first post-reconnect
+                -- block, the indexer's UTxO view is stale
+                -- (#109). Reading it would lead to a refill
+                -- submitting against already-spent inputs
+                -- ('ConwayMempoolFailure "All inputs are
+                -- spent"') or a transact returning
+                -- 'no-pickable-source'. We short-circuit
+                -- with 'IndexNotReady' instead so the
+                -- composer retries on the next tick.
+                indexFresh =
+                    rsIndexFresh <$> readTVarIO readyVar
                 doRefill req =
-                    E.handle
-                        ( \ConnectionLost ->
+                    indexFresh >>= \case
+                        False ->
                             pure (RefillFail IndexNotReady)
-                        )
-                        ( runRefillArm
-                            cfg
-                            pp
-                            idx
-                            provider
-                            submitter
-                            net
-                            masterSeed
-                            faucetSKey
-                            faucetAddr
-                            nextIdxMVar
-                            lastTxIdVar
-                            faucetKnownVar
-                            req
-                        )
+                        True ->
+                            E.handle
+                                ( \ConnectionLost ->
+                                    pure
+                                        ( RefillFail
+                                            IndexNotReady
+                                        )
+                                )
+                                ( runRefillArm
+                                    cfg
+                                    pp
+                                    idx
+                                    provider
+                                    submitter
+                                    net
+                                    masterSeed
+                                    faucetSKey
+                                    faucetAddr
+                                    nextIdxMVar
+                                    lastTxIdVar
+                                    faucetKnownVar
+                                    req
+                                )
                 doTransact req =
-                    E.handle
-                        ( \ConnectionLost ->
+                    indexFresh >>= \case
+                        False ->
                             pure (TransactFail IndexNotReady)
-                        )
-                        ( runTransactArm
-                            cfg
-                            pp
-                            idx
-                            provider
-                            submitter
-                            net
-                            masterSeed
-                            nextIdxMVar
-                            lastTxIdVar
-                            req
-                        )
+                        True ->
+                            E.handle
+                                ( \ConnectionLost ->
+                                    pure
+                                        ( TransactFail
+                                            IndexNotReady
+                                        )
+                                )
+                                ( runTransactArm
+                                    cfg
+                                    pp
+                                    idx
+                                    provider
+                                    submitter
+                                    net
+                                    masterSeed
+                                    nextIdxMVar
+                                    lastTxIdVar
+                                    req
+                                )
                 hooks =
                     ServerHooks
                         { hooksReady = getReady
@@ -1101,10 +1149,15 @@ updateReady cfg readyVar (Idx.SlotNo processed) tipNet = do
         ready = behind <= dcReadyThresholdSlots cfg
     -- Preserve the supervisor-managed 'rsUpstream'. The
     -- chain-sync follower owns rsReady/rsTipSlot/
-    -- rsProcessedSlot; the supervisor owns rsUpstream.
+    -- rsProcessedSlot/rsIndexFresh; the supervisor owns
+    -- rsUpstream. rsIndexFresh flips true here on every
+    -- applied 'rollForward' — which proves chain-sync has
+    -- resumed past the most recent reconnect anchor and
+    -- the indexer's UTxO view is no longer stale (#109).
     atomically $ modifyTVar' readyVar $ \rs ->
         rs
             { rsReady = ready
             , rsTipSlot = Just tip
             , rsProcessedSlot = Just processed
+            , rsIndexFresh = True
             }

--- a/specs/037-tx-gen-indexer-fresh/checklists/requirements.md
+++ b/specs/037-tx-gen-indexer-fresh/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Gate tx-generator arms on indexer freshness after N2C reconnect
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec deliberately mentions `rsUpstream`, `UpstreamConnected`, `rsReady`, `setUpstreamStatus`, `RollForward`, and `ConwayMempoolFailure` — these are accepted as cross-spec vocabulary (defined in spec 035) and as protocol-domain terms that any reader of the tx-generator subsystem will already know. They are NOT implementation choices being made by this spec; they are the contract this spec hooks into.
+- "Refill arm" / "transact arm" / "composer tick" are likewise pre-existing tx-generator vocabulary, not implementation choices introduced here.

--- a/specs/037-tx-gen-indexer-fresh/contracts/arm-gate.md
+++ b/specs/037-tx-gen-indexer-fresh/contracts/arm-gate.md
@@ -1,0 +1,60 @@
+# Contract: Arm-side freshness gate
+
+**Spec**: [../spec.md](../spec.md)
+**Plan**: [../plan.md](../plan.md)
+**Data model**: [../data-model.md](../data-model.md)
+
+## Scope
+
+This contract describes the arm-side gating behaviour added by issue #109. It is internal to the daemon process — no NDJSON message changes, no new wire field, no new failure reason.
+
+## Refill arm contract
+
+Before the existing `runRefillArm` is invoked, the daemon takes a snapshot of `ReadyState` and:
+
+| `rsIndexFresh` | Action                                                                  | Response                       |
+|----------------|-------------------------------------------------------------------------|--------------------------------|
+| `False`        | Short-circuit. Do **not** query LSQ. Do **not** call `submitTx`.        | `RefillFail IndexNotReady`     |
+| `True`         | Proceed exactly as today. The existing `E.handle ConnectionLost` wrap and `runRefillArm` body run unchanged. | (per existing arm behaviour)   |
+
+NDJSON shape on the wire (unchanged from existing): `{"ok": false, "reason": "index-not-ready"}`.
+
+## Transact arm contract
+
+Identical structure to refill:
+
+| `rsIndexFresh` | Action                                                                  | Response                         |
+|----------------|-------------------------------------------------------------------------|----------------------------------|
+| `False`        | Short-circuit. Do **not** query LSQ for source UTxOs.                   | `TransactFail IndexNotReady`     |
+| `True`         | Proceed with `runTransactArm` as today.                                 | (per existing arm behaviour)     |
+
+NDJSON shape on the wire (unchanged): `{"ok": false, "reason": "index-not-ready"}`.
+
+## Composability with existing gates
+
+The freshness gate is **orthogonal** to the existing `rsReady` (within-N-slots-of-tip) gate and to the supervisor-managed `rsUpstream` (bearer state). The decision matrix at the top of each arm:
+
+| `rsUpstream`           | `rsIndexFresh` | `rsReady`  | Arm behaviour                                                        |
+|------------------------|----------------|------------|----------------------------------------------------------------------|
+| `UpstreamDisconnected` | (any)          | (any)      | `IndexNotReady` (existing — encoder enforces this on the wire too)   |
+| `UpstreamConnected`    | `False`        | (any)      | `IndexNotReady` (NEW — this PR)                                      |
+| `UpstreamConnected`    | `True`         | `False`    | The existing arm logic runs; whether it emits `IndexNotReady` or proceeds depends on the arm's existing tip/ready handling. |
+| `UpstreamConnected`    | `True`         | `True`     | Arms run normally (steady state, unchanged behaviour).               |
+
+This PR adds only the second row.
+
+## Read-sequence guarantees
+
+- The freshness check uses `readTVarIO`, not `atomically`. It is non-blocking: the arm tick either short-circuits or proceeds immediately.
+- The check happens *before* the existing `E.handle ConnectionLost` wrapper. If the bearer dies between the freshness read and the LSQ call inside the arm, the existing `ConnectionLost` handler still translates to `IndexNotReady` — the two paths produce the same wire response.
+- No invariant is required between the freshness check and subsequent LSQ activity; staleness is a *read*-side concern only, and a stale read followed by a tx submission against the relay is what the existing relay-side rejection ultimately catches anyway. The gate is a coverage improvement, not a correctness guarantee.
+
+## Out-of-scope contracts
+
+- **Composer-side `tx_generator_*_landed` Sometimes thresholds**: out of scope for this repo. Filed as a companion change in `cardano-foundation/cardano-node-antithesis` (cross-link from issue #109 once the companion PR is opened).
+- **Composer-side Always-assertions B/C/D**: tracked at cardano-foundation/cardano-node-antithesis #105/#106/#107.
+- **Indexer chain-sync re-sync semantics**: unchanged. The follower keeps streaming forward; this PR only gates the arm reads.
+
+## Backwards compatibility
+
+The wire protocol is unchanged. Older composers that already retry on `index-not-ready` will see slightly more `index-not-ready` responses during reconnect storms but otherwise no behavioural difference. Older composers that did *not* retry on `index-not-ready` would already have been broken by the existing daemon (this is a pre-existing wire response, not a new one).

--- a/specs/037-tx-gen-indexer-fresh/data-model.md
+++ b/specs/037-tx-gen-indexer-fresh/data-model.md
@@ -1,0 +1,93 @@
+# Phase 1 — Data Model: Indexer-fresh gate
+
+**Spec**: [spec.md](spec.md)
+**Plan**: [plan.md](plan.md)
+**Research**: [research.md](research.md)
+
+## Modified entity: `ReadyState`
+
+Defined at `lib/Cardano/Node/Client/TxGenerator/Daemon.hs:217-223`.
+
+### Before
+
+```haskell
+data ReadyState = ReadyState
+    { rsReady :: !Bool
+    , rsTipSlot :: !(Maybe Word64)
+    , rsProcessedSlot :: !(Maybe Word64)
+    , rsUpstream :: !UpstreamStatus
+    }
+```
+
+### After
+
+```haskell
+data ReadyState = ReadyState
+    { rsReady :: !Bool
+    , rsTipSlot :: !(Maybe Word64)
+    , rsProcessedSlot :: !(Maybe Word64)
+    , rsUpstream :: !UpstreamStatus
+    , rsIndexFresh :: !Bool
+    }
+```
+
+Added field:
+
+| Field          | Type   | Initial | Owners (writers)                                           |
+|----------------|--------|---------|------------------------------------------------------------|
+| `rsIndexFresh` | `Bool` | `False` | `setUpstreamStatus` (clears on Connected); `updateReady` (sets on `rollForward`) |
+
+`initialReady` (Daemon.hs:225-232) gains `rsIndexFresh = False` to match cold-start semantics described in research.md Decision 6.
+
+## State transitions
+
+```
+                       cold start / disconnect / reconnect
+                                  │
+                                  ▼
+                         ┌─────────────────┐
+                         │ rsIndexFresh =  │
+                         │      False      │◄────────────────┐
+                         └────────┬────────┘                 │
+                                  │ first rollForward applied│
+                                  ▼                          │
+                         ┌─────────────────┐                 │
+                         │ rsIndexFresh =  │                 │
+                         │      True       │─────────────────┘
+                         └─────────────────┘  setUpstreamStatus
+                                              UpstreamConnected
+                                              (next reconnect)
+```
+
+Edges:
+
+- **Cold start** → `rsIndexFresh = False` (initial value).
+- **`setUpstreamStatus UpstreamConnected`** → `rsIndexFresh = False` (unconditional, even if already false; safe).
+- **`setUpstreamStatus (UpstreamDisconnected _)`** → `rsIndexFresh` unchanged in the model (it was already false, or we're about to reconnect and clear it again on the next Connected). The existing field in this branch sets `rsReady = False`; we do *not* need to mirror that for `rsIndexFresh` because the contract is "false until a fresh forward lands", and a disconnect cannot deliver one.
+- **`updateReady` (called from `Follower.rollForward`)** → `rsIndexFresh = True` (alongside the existing `rsReady`/`rsTipSlot`/`rsProcessedSlot` updates).
+- **`Follower.rollBackward`** → no direct effect on `rsIndexFresh`. Rollbacks happen *after* a forward has set freshness; they do not reset it. Rationale: a rollback inside the same connected episode means the chain-sync mini-protocol is alive and the indexer is consistent with the relay's view at the rollback point — staleness is not the issue.
+
+## Invariant
+
+Across all reachable states:
+
+```
+rsUpstream = UpstreamDisconnected _   ⇒   rsIndexFresh = False
+```
+
+Holds because `rsIndexFresh` can only flip to `True` via `updateReady`, which is only called from `rollForward`, which is only invoked while the chain-sync mini-protocol is live (which implies `rsUpstream = UpstreamConnected` at that moment, since the supervisor flips to `UpstreamDisconnected` on bearer failure).
+
+The converse (`UpstreamConnected ⇒ rsIndexFresh = True`) is *not* an invariant — that is precisely the post-reconnect window the gate exists to handle.
+
+## Read sites
+
+Two new readers, both at the top of arm callbacks in `runDaemonWithTracer`:
+
+- `doRefill` (Daemon.hs:399): reads `rsIndexFresh`; if `False`, returns `RefillFail IndexNotReady` and does not call `runRefillArm`.
+- `doTransact` (Daemon.hs:419): reads `rsIndexFresh`; if `False`, returns `TransactFail IndexNotReady` and does not call `runTransactArm`.
+
+Existing readers of `ReadyState` (`readyResponseFrom`, `snapshotResponseFrom`) remain unchanged; they observe `rsReady`/`rsTipSlot`/etc. as before. The freshness flag is purely an internal gate, not surfaced on the wire as a new field — the wire vocabulary stays at "ready=true/false + reason for not-applicable arm responses".
+
+## Wire-protocol impact
+
+**None.** `IndexNotReady` is already a `FailureReason` constructor (Types.hs:136), already serialised as `"index-not-ready"` (Types.hs:146), already retried by the composer. We are only adding a new code path that surfaces it in a new circumstance (post-reconnect, indexer not yet rolled forward).

--- a/specs/037-tx-gen-indexer-fresh/plan.md
+++ b/specs/037-tx-gen-indexer-fresh/plan.md
@@ -1,0 +1,83 @@
+# Implementation Plan: Gate tx-generator arms on indexer freshness after N2C reconnect
+
+**Branch**: `037-tx-gen-indexer-fresh` | **Date**: 2026-05-01 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/037-tx-gen-indexer-fresh/spec.md`
+
+## Summary
+
+Add a single boolean gate, `rsIndexFresh`, to `ReadyState` in `lib/Cardano/Node/Client/TxGenerator/Daemon.hs`. The supervisor's `setUpstreamStatus UpstreamConnected` call site (Daemon.hs:322) clears it; the chain-sync follower's `rollForward` callback in `mkFollower` (Daemon.hs:1062, via `updateReady`) sets it. The two top-of-arm wrappers `doRefill` and `doTransact` (Daemon.hs:399, 419) read it and short-circuit with `RefillFail IndexNotReady` / `TransactFail IndexNotReady` — vocabulary already on the wire (Types.hs:136, 146). No new failure reason, no new wire message, no composer-side change for retry behaviour. Threshold bumps for `tx_generator_*_landed` Sometimes-assertions live in the companion `cardano-foundation/cardano-node-antithesis` repo and are tracked there.
+
+## Technical Context
+
+**Language/Version**: Haskell, GHC 9.6+ (matches repo)
+**Primary Dependencies**: `cardano-ledger-conway`, `ouroboros-network`, internal `chain-follower` `Follower` abstraction, internal `N2C.Reconnect.runReconnectLoop` (PR #105)
+**Storage**: in-memory `TVar ReadyState` (no persistence change)
+**Testing**: `hspec` E2E (`cabal test e2e-tests` via `just e2e`), driven against a real devnet node spun up by `withCardanoNode`
+**Target Platform**: Linux daemon (`cardano-tx-generator` executable)
+**Project Type**: single-project Haskell library + executables
+**Performance Goals**: zero added overhead in the steady state (one extra `Bool` read per arm tick); arms must remain non-blocking on the freshness check (no STM retry, just a snapshot read)
+**Constraints**: must NOT change wire protocol or NDJSON shape; must NOT alter chain-sync streaming semantics; must compose cleanly with existing `rsReady` gate
+**Scale/Scope**: ~30 LoC behaviour change in `Daemon.hs`; one new field on `ReadyState`; one new E2E spec covering the freshness window; threshold bumps in the companion antithesis repo are out of scope here
+
+## Constitution Check
+
+Ratified principles (constitution.md @ v1.0.0):
+
+- **I. Channel-Driven N2C Clients** — PASS. No new mini-protocol, no new channel. The gate is a local read of an existing `TVar` populated by the existing chain-sync `Follower` and reconnect supervisor.
+- **II. Devnet E2E Testing** — PASS. The fix's primary test is an E2E spec that drives `setUpstreamStatus` via the supervisor and observes arm responses against a real devnet relay.
+- **III. Minimal Dependencies** — PASS. No new dependencies. One new boolean field on an existing record.
+- **IV. Test Utilities Are First-Class** — PASS. Reuses the devnet harness verbatim. If a new helper is needed for "force a reconnect" deterministically, it goes into the existing `devnet` library, not a new package.
+
+Quality gates (`just ci` passes, all E2E against a real devnet node, no mocks): preserved.
+
+No violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/037-tx-gen-indexer-fresh/
+├── plan.md              # This file
+├── spec.md
+├── research.md          # Design decisions for the gate
+├── data-model.md        # ReadyState extension + state diagram
+├── quickstart.md        # How to run the new E2E spec locally
+├── contracts/
+│   └── arm-gate.md      # The arm-side contract: when each arm short-circuits
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit.specify)
+└── tasks.md             # Phase 2 output — produced by /speckit.tasks
+```
+
+### Source Code (repository root)
+
+```text
+lib/Cardano/Node/Client/
+├── N2C/
+│   └── Reconnect.hs                  # (no change)
+└── TxGenerator/
+    ├── Daemon.hs                     # CHANGED: rsIndexFresh field, setUpstreamStatus
+    │                                 # clears it, updateReady sets it, doRefill/doTransact
+    │                                 # short-circuit on it
+    ├── Types.hs                      # NO CHANGE — IndexNotReady reason already exists
+    └── Server.hs                     # NO CHANGE — wire shape unchanged
+
+test/Cardano/Node/Client/E2E/
+└── TxGeneratorIndexFreshSpec.hs      # NEW: post-reconnect freshness E2E
+
+test/Cardano/Node/Client/TxGenerator/
+└── DaemonFreshGateSpec.hs            # NEW (optional — pure unit test of the
+                                      # ReadyState transition function if extracted;
+                                      # may be folded into existing ServerSpec)
+```
+
+**Structure Decision**: Single-project layout (Option 1). The change is fully contained inside the `cardano-tx-generator` executable's daemon module. No layer split, no new crate, no API addition. The companion threshold-bump PR lives in a different repository (`cardano-foundation/cardano-node-antithesis`) and is tracked there, not here.
+
+## Complexity Tracking
+
+> No constitutional violations to justify. Section retained per template.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (none)    |            |                                      |

--- a/specs/037-tx-gen-indexer-fresh/quickstart.md
+++ b/specs/037-tx-gen-indexer-fresh/quickstart.md
@@ -1,0 +1,52 @@
+# Quickstart: verifying the freshness gate locally
+
+**Spec**: [spec.md](spec.md)
+**Plan**: [plan.md](plan.md)
+
+## Run the new E2E spec
+
+The freshness gate is exercised end-to-end by `test/Cardano/Node/Client/E2E/TxGeneratorIndexFreshSpec.hs` (added by this feature). It:
+
+1. Spins up a devnet relay via `withCardanoNode`.
+2. Boots `cardano-tx-generator` against the relay's socket.
+3. Waits until `ready=true` (steady state).
+4. Stops the relay container/process so the supervisor logs `UpstreamDisconnected`.
+5. Restarts the relay; waits for `setUpstreamStatus UpstreamConnected` to fire.
+6. Within the post-reconnect window (before any new block), pings the refill arm and the transact arm, asserting both return `{"ok": false, "reason": "index-not-ready"}`.
+7. Lets the chain produce one new block; reasserts both arms now proceed normally.
+
+Run only this spec:
+
+```bash
+nix develop -c just e2e -- --match "Cardano.Node.Client.E2E.TxGeneratorIndexFreshSpec"
+```
+
+(or, if you prefer a focused run:)
+
+```bash
+nix develop -c cabal test e2e-tests -O0 \
+    --test-show-details=direct \
+    --test-options='--match "TxGeneratorIndexFreshSpec"'
+```
+
+## Reproduce the original failure mode (without the fix)
+
+To convince yourself the gate matters, comment out the new check in `doRefill` and `doTransact` and re-run the spec — both assertions in step 6 will flip from `index-not-ready` to either `submit-rejected` (for refill) or `no-pickable-source` (for transact), reproducing the Antithesis failures named in the issue body.
+
+## Full local CI
+
+Run the same gates the GitHub job runs:
+
+```bash
+nix develop -c just ci
+```
+
+(Builds, runs all E2E specs, fourmolu check, hlint, cabal-fmt check.)
+
+## Field-level cross-check after a reconnect storm
+
+While running the daemon manually, you can observe the freshness gate via the daemon's structured output (no new field — the existing `index-not-ready` reason on arm responses is the signal). To distinguish freshness-gated short-circuits from other `index-not-ready` causes, grep the daemon log around a known reconnect timestamp and look at `setUpstreamStatus`/`updateReady` traces in adjacent lines.
+
+## Companion PR for assertion thresholds
+
+The Antithesis composer's `tx_generator_*_landed` Sometimes-assertion thresholds will be bumped in a separate PR in `cardano-foundation/cardano-node-antithesis`. End-to-end acceptance (the 1h `cardano_node_master` run with 0 Always-failures) requires *both* the gate from this repo and the threshold tweak from the companion repo.

--- a/specs/037-tx-gen-indexer-fresh/research.md
+++ b/specs/037-tx-gen-indexer-fresh/research.md
@@ -1,0 +1,89 @@
+# Phase 0 — Research: Indexer-fresh gate for tx-generator arms
+
+**Spec**: [spec.md](spec.md)
+**Plan**: [plan.md](plan.md)
+
+## Decision 1 — Where to track freshness
+
+**Decision**: Add `rsIndexFresh :: !Bool` to the existing `ReadyState` record in `lib/Cardano/Node/Client/TxGenerator/Daemon.hs:217-223`, owned by the same `TVar ReadyState` that `setUpstreamStatus` and `updateReady` already mutate.
+
+**Rationale**:
+- One `TVar`, three orthogonal flags (`rsUpstream`, `rsReady`, `rsIndexFresh`). Keeps all readiness state in one atomic snapshot, so an arm tick can read all three with a single `readTVarIO`.
+- `setUpstreamStatus` (Daemon.hs:322) and `updateReady` (Daemon.hs:1089) already hold the only two write paths to `readyVar`. Adding the new flag lets us reuse both without inventing a third writer.
+
+**Alternatives considered**:
+- *Separate `TVar Bool` for freshness*: rejected. Two `TVar`s mean two read points, race window between them, and a duplicated invariant (the encoder enforces `UpstreamDisconnected => ready=false` on the wire — defense in depth). Single-source-of-truth wins.
+- *Derive freshness from `rsProcessedSlot` against a captured anchor*: rejected. It works, but it requires us to also track the slot at which the most recent `UpstreamConnected` flip occurred, plus monotonicity reasoning across rollbacks. A boolean owned by both writers is simpler and exactly captures the spec invariant ("flip false on connect, flip true on first subsequent RollForward").
+
+## Decision 2 — Where to flip false (reset on reconnect)
+
+**Decision**: Inside `setUpstreamStatus`'s `UpstreamConnected` branch (Daemon.hs:325-326), set `rsIndexFresh = False` *unconditionally* on every flip into the connected state. Today that branch only updates `rsUpstream`; we extend it to also clear freshness.
+
+**Rationale**:
+- The supervisor calls this entry point on (a) initial connect, (b) every successful reconnect after a `UpstreamDisconnected` episode. Both correctly want freshness false.
+- Clearing on every connect (even back-to-back, with no intervening disconnect, if the supervisor ever spuriously re-confirms) is safe: it only delays the arm by one `RollForward`. The opposite mistake — letting freshness persist across a disconnect/connect cycle — is the exact bug being fixed.
+- The spec edge case "reconnect storm" requires that freshness *never* carry over from a previous connected episode. Clearing here, in the only entry point used by the supervisor, satisfies that.
+
+**Alternatives considered**:
+- *Only flip on the disconnect side and leave UpstreamConnected unchanged*: rejected. It works for the common case, but a fast disconnect/connect/disconnect/connect that lands a `RollForward` between the first connect and the second disconnect would leak a fresh state into the second connection. Resetting on every Connected is unconditional and immune to ordering.
+
+## Decision 3 — Where to flip true (clear on first post-reconnect block)
+
+**Decision**: Inside `updateReady` (Daemon.hs:1089), which is called exclusively from the chain-sync `Follower`'s `rollForward` callback (Daemon.hs:1062-1068), after the indexer has already applied the new block (`applyAtSlot idx slot bh ops` at Daemon.hs:1066). Add `rsIndexFresh = True` to the `modifyTVar'` block at Daemon.hs:1105-1110.
+
+**Rationale**:
+- The follower's `rollForward` runs *after* `applyAtSlot`. By the time we set `rsIndexFresh = True`, the indexer's UTxO view has already advanced past the block. That is exactly the freshness invariant the spec demands: "the indexer state has advanced past the reconnect anchor".
+- We deliberately do not require the rolled-forward slot to be ≥ the slot at the moment of reconnect. The chain follows chain order; any post-reconnect `RollForward` implies the chain-sync mini-protocol has resumed at the new tip and the indexer's view is now consistent with the live relay's view at *some* point on or after the reconnect anchor. Tip-distance is already gated by `rsReady`.
+- `updateReady` is also called on `rollBackward`-then-`rollForward` sequences (the reconnect intersector path uses the same follower). A rollback before the first forward would leave `rsIndexFresh = False`; only the first actual forward flips it true. Correct.
+
+**Alternatives considered**:
+- *Flip true at intersection (`intersectFound`)*: rejected. Intersection only proves the relay has agreed on a starting point; it does not prove the indexer has advanced. A relay reconnect that re-intersects at the same point as before the disconnect would set freshness true while the indexer's UTxO view is still exactly the stale view. Wrong.
+- *Flip true after N blocks*: rejected. One block suffices to prove chain-sync has resumed; more blocks just extends the not-applicable window.
+
+## Decision 4 — Where to apply the gate
+
+**Decision**: Wrap the existing `doRefill` and `doTransact` callbacks in `runDaemonWithTracer` (Daemon.hs:399, 419) with a freshness check at the *top*, before the existing `E.handle ConnectionLost` wrapper. If `rsIndexFresh` is false, return `RefillFail IndexNotReady` / `TransactFail IndexNotReady` immediately, without entering `runRefillArm` / `runTransactArm`.
+
+**Rationale**:
+- Top-level wrapping keeps the freshness logic in one place (the daemon's wiring), not duplicated inside each arm.
+- Both arms already have `IndexNotReady` as a wire-stable failure reason (Types.hs:136, serialised as `"index-not-ready"` at Types.hs:146). The composer already retries on this reason — no composer-side change required.
+- `doRefill` / `doTransact` already exist as the right wrapping seam (they own the `E.handle ConnectionLost` translation today). Adding a freshness short-circuit at the same level is idiomatic.
+
+**Alternatives considered**:
+- *Inside each arm's body*: rejected. Two write sites, easy to drift, harder to reason about as a single gate.
+- *In `Server.hs`'s `handleConn`*: rejected. The server is wire-shape-only; per-request semantic gating belongs to the daemon wiring that owns the `TVar`.
+
+## Decision 5 — Snapshot vs. STM retry
+
+**Decision**: The freshness check uses `readTVarIO` (a non-blocking snapshot), not `atomically retry`. If `rsIndexFresh` is false at the moment of the check, the arm short-circuits immediately; the composer retries on the next tick.
+
+**Rationale**:
+- The spec is explicit: the daemon should serve a *not-applicable* response and let the composer retry. Blocking inside the arm would defeat the composer's tick model and could pile up requests across reconnect storms.
+- Non-blocking is also what the existing code does for `rsReady` (the readyResponseFrom path returns `ready=false` rather than blocking).
+
+## Decision 6 — Initial value of `rsIndexFresh`
+
+**Decision**: `False`. The current `initialReady` (Daemon.hs:225-232) already starts with `rsUpstream = UpstreamConnected` (a polite lie that's corrected the first time the supervisor reports its real status), and starting with `rsIndexFresh = False` means the daemon serves *index-not-ready* on cold start until the first `RollForward` lands. This composes correctly with the existing cold-start behaviour and the existing `rsReady = False` initial.
+
+**Rationale**:
+- Cold start is operationally identical to a reconnect with no prior state. The same gate that protects against stale-after-reconnect protects against not-yet-synced-on-cold-start.
+- `rsReady = False` already holds at boot, so without the new gate the arms would have already been blocked by tip-distance; the freshness gate is strictly redundant in cold start in practice but symmetric in semantics, which is what we want.
+
+## Decision 7 — Threshold bumps for `tx_generator_*_landed`
+
+**Decision**: Out of scope for this repository. The Sometimes-assertions live in the composer at `cardano-foundation/cardano-node-antithesis` (per spec 034's `contracts/control-wire.md`). The threshold bumps for `tx_generator_*_landed` will be filed as a companion PR in that repo.
+
+**Rationale**:
+- The spec's FR-007 names a contract enforced in another codebase. Splitting it preserves repo ownership boundaries.
+- Acceptance criteria SC-001..SC-004 will be verified by running the 1h `cardano_node_master` Antithesis workload against a downstream pin bump that picks up *both* this repo's gate and the companion PR's threshold tweaks.
+
+**Action item**: open the companion issue/PR in `cardano-foundation/cardano-node-antithesis` to track the threshold bump; cross-link from issue #109 once filed.
+
+## Open question: testing the gate without a real reconnect
+
+The cleanest deterministic test would force a "reconnect happened, no `RollForward` yet" state. Two paths considered:
+
+- **Real reconnect via fault injection**: stop+start the relay container. Authentic, but timing-sensitive and slow.
+- **Direct manipulation via `setUpstreamStatus`**: requires exporting `setUpstreamStatus` (or a test-only "reset freshness" helper) from `Daemon.hs`, breaking encapsulation.
+
+**Resolved**: prefer a real reconnect E2E (consistent with constitution principle II — no mocks for node communication). The supervisor already drives this path; we just need to assert that during the post-reconnect window the arm response is `index-not-ready` and not `submit-rejected`. The existing `TxGeneratorRestartSpec.hs` is the right neighbour to extend or template from.

--- a/specs/037-tx-gen-indexer-fresh/spec.md
+++ b/specs/037-tx-gen-indexer-fresh/spec.md
@@ -1,0 +1,108 @@
+# Feature Specification: Gate tx-generator arms on indexer freshness after N2C reconnect
+
+**Feature Branch**: `037-tx-gen-indexer-fresh`
+**Created**: 2026-05-01
+**Status**: Draft
+**Input**: User description: "Gate the tx-generator daemon's refill and transact arms on indexer freshness after N2C reconnect (issue #109)"
+**Tracks issue**: https://github.com/lambdasistemi/cardano-node-clients/issues/109
+**Depends on (already merged)**: https://github.com/lambdasistemi/cardano-node-clients/pull/105
+**Related spec**: `specs/035-indexer-n2c-reconnect/` (introduced `rsUpstream`, `UpstreamConnected`, `rsReady`)
+**Antithesis report (regression evidence)**: https://cardano.antithesis.com/report/sgGPKwEUgpMFBkdN3QMH1MDn/CVALsMOlHQdIyvQsc0sKyxZ79mapUIksHP-v0XZcVds.html
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Refill arm never submits a tx built from stale post-reconnect UTxOs (Priority: P1)
+
+A `cardano-tx-generator` daemon is supervising its N2C bearer via the auto-reconnect loop introduced in spec 035. The relay is restarted under fault injection. As soon as the new bearer is established and the LSQ probe answers, the supervisor flips upstream status to *connected*. During the short window before the embedded chain-sync follower has caught the indexer's UTxO view back up to the new tip, the indexer's local view is *stale*: it still reflects the chain state from before the bearer died. The composer ticks into this window and asks the daemon to refill the faucet.
+
+The daemon must refuse to issue a refill submission until its own UTxO view is provably caught up past the reconnect anchor — even though the bearer is "connected" and `rsReady` (within N slots of tip) might already be true. The composer should see a defined "indexer not ready" response and try again on the next tick, rather than the daemon submitting a refill tx whose inputs the post-reconnect chain has already spent.
+
+**Why this priority**: This is the failure mode that trips the `tx_generator_refill_submit_rejected` Always-assertion under Antithesis (111 hits across 95 forks on 329a599). The submission is correctness-preserving — the relay rejects with `ConwayMempoolFailure "All inputs are spent"` — but the assertion is framed "should never happen", so eliminating the rejected-submission window is the bar to clear before the run goes green.
+
+**Independent Test**: Deterministic: drive the daemon's state directly. Force `setUpstreamStatus UpstreamConnected` (the supervisor's post-reconnect entry point) without delivering a chain-sync `RollForward` afterwards, then run the refill arm. The arm must return *not-applicable / indexer-not-ready* and must not call the submit primitive. Then deliver one `RollForward` and re-run: the arm proceeds normally.
+
+**Acceptance Scenarios**:
+
+1. **Given** the supervisor has just flipped upstream status to *connected*, **And** no `RollForward` has been applied since that flip, **When** the composer ticks the refill arm, **Then** the daemon returns *indexer-not-ready* (a not-applicable response) **and** does not submit any tx.
+2. **Given** the supervisor has flipped upstream status to *connected* **And** at least one `RollForward` has been applied since that flip, **When** the composer ticks the refill arm, **Then** the daemon proceeds with the normal refill flow.
+3. **Given** the daemon was already in steady state with upstream connected and the indexer fresh, **When** an unrelated tick fires the refill arm, **Then** behaviour is unchanged from before this feature (no regression).
+
+---
+
+### User Story 2 - Transact arm never queries the indexer for source UTxOs in the stale window (Priority: P1)
+
+Same setup as US1: post-reconnect, before chain-sync has rolled forward. The composer ticks the *transact* arm, which would normally pick a source from the indexer and build a fan-out tx for it.
+
+The daemon must refuse to pick a source from a stale UTxO view. The composer should see *not-applicable* and retry on the next tick.
+
+**Why this priority**: The same Antithesis run produced 136 `no-pickable-source` outcomes in this window, tripping `tx_generator_population_did_not_grow`. The fix and the gating logic are the same as US1; pairing them avoids two separate freshness gates.
+
+**Independent Test**: Same deterministic fixture as US1, but exercise the transact arm. Without a post-reconnect `RollForward`, the arm must return *indexer-not-ready* and must not call the indexer's UTxO query primitive. After one `RollForward`, the arm must run normally.
+
+**Acceptance Scenarios**:
+
+1. **Given** upstream just flipped to *connected* and no `RollForward` has been applied since, **When** the composer ticks the transact arm, **Then** the daemon returns *indexer-not-ready* and does not call the indexer's source-UTxO query.
+2. **Given** at least one post-reconnect `RollForward` has been applied, **When** the composer ticks the transact arm, **Then** the daemon proceeds with the normal source-pick flow.
+
+---
+
+### User Story 3 - Indexer freshness is observable and Sometimes-thresholds tolerate slow recovery (Priority: P2)
+
+Under heavy fault injection there will be windows where the daemon serves *not-applicable* for many composer ticks in a row — that is the correct answer, not a regression. Operators inspecting an Antithesis run need (a) a way to see *why* a tick was not-applicable (refill/transact short-circuited because indexer was stale, vs. some other reason), and (b) the composer's `tx_generator_*_landed` Sometimes-assertion thresholds set high enough that long not-applicable streaks during reconnect storms do not trip them.
+
+**Why this priority**: Without observability and threshold tuning, the fix succeeds at eliminating Always-assertion failures but creates a different class of false alarms. P2 because the P1 stories already deliver the correctness fix in isolation.
+
+**Independent Test**: Run a fault-injection scenario that reconnects N times. Inspect the daemon's structured output: every short-circuited refill/transact tick must carry an `indexer-not-ready` reason. The Sometimes-assertion thresholds, after this PR's adjustment, must allow a 1h `cardano_node_master` run to pass even when 4000+ reconnect events occur.
+
+**Acceptance Scenarios**:
+
+1. **Given** the daemon short-circuits a refill or transact tick because of indexer staleness, **When** the operator inspects the daemon output for that tick, **Then** the response carries a distinguishable reason (e.g. `indexer-not-ready`) separate from other not-applicable causes.
+2. **Given** a 1h `cardano_node_master` Antithesis run with the supervisor producing 4000+ disconnect/reconnect events, **When** the run completes, **Then** zero `tx_generator_refill_submit_rejected` and zero `tx_generator_population_did_not_grow` Always-assertion failures are reported, **and** the `tx_generator_*_landed` Sometimes-assertion thresholds are met.
+
+---
+
+### Edge Cases
+
+- **Reconnect storm**: upstream flips to *connected* repeatedly, with each flip occurring before the prior `RollForward` has arrived. Indexer freshness must remain false across the entire storm and only flip true after a `RollForward` that follows the *last* upstream flip — never carry over freshness from a previous connected episode.
+- **Reconnect with no new blocks for an extended period**: the relay reconnects but the chain genuinely produces no new block for many slots. The arms remain short-circuited until a `RollForward` is observed; the operator sees consistent *indexer-not-ready* responses, which is the desired behaviour (better to be silent than to submit against a stale view).
+- **Daemon cold start**: on first startup the supervisor flips upstream to *connected* once. The same gate applies: arms wait for the first post-startup `RollForward` before serving real responses. This is a no-op concern in practice because the daemon's own readiness gate (`rsReady`) already covers cold start, but the gating logic must compose cleanly.
+- **`rsReady` is true while indexer is fresh-after-reconnect = false**: the two gates are orthogonal. Both must be true for an arm to proceed.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The daemon MUST track an *indexer-fresh* status, distinct from `rsUpstream` (bearer connection state, defined in spec 035) and `rsReady` (within-N-slots-of-tip, defined in spec 035).
+- **FR-002**: Whenever the supervisor flips upstream status to *connected* (via the call site equivalent to `setUpstreamStatus UpstreamConnected`), *indexer-fresh* MUST be set to false.
+- **FR-003**: *Indexer-fresh* MUST be set to true only after the embedded chain-sync follower has applied at least one `RollForward` event since the most recent transition to *connected*. Older RollForwards observed before the most recent reconnect MUST NOT count.
+- **FR-004**: The refill arm MUST short-circuit with an *indexer-not-ready* response while *indexer-fresh* is false. It MUST NOT call the submit primitive in that state.
+- **FR-005**: The transact arm MUST short-circuit with an *indexer-not-ready* response while *indexer-fresh* is false. It MUST NOT call the indexer's source-UTxO query primitive in that state.
+- **FR-006**: The *indexer-not-ready* response surfaced to the composer MUST be of the same general shape as other not-applicable responses (so the composer's existing retry-on-tick behaviour applies unchanged) but MUST carry a reason distinguishable from other not-applicable causes (e.g. "no-pickable-source" remains a separate reason).
+- **FR-007**: The composer's Sometimes-assertion thresholds for `tx_generator_*_landed` MUST be raised to a level that tolerates not-applicable streaks of the duration that arise from realistic fault-injection workloads, while still being tight enough to detect real regressions.
+- **FR-008**: When *indexer-fresh* is true and the other gates allow it, the refill and transact arms MUST behave exactly as before this feature (no behaviour change in the steady state).
+- **FR-009**: The indexer's chain-sync streaming behaviour itself MUST NOT change — it continues to stream forward as defined in spec 035; this feature only gates the daemon's *reads*.
+
+### Key Entities
+
+- **Indexer-fresh status**: a boolean flag owned by the daemon. False between any "upstream connected" event and the first subsequent applied `RollForward`. Independent of `rsReady`.
+- **Reconnect anchor**: implicitly, the chain position at which the most recent upstream-connected event occurred. The flag flips back to true when the indexer's applied chain has advanced past this point.
+- **Not-applicable response (indexer-not-ready)**: the response served by a short-circuited arm. Distinguishable in observability output from other not-applicable causes.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A 1h `cardano_node_master` Antithesis run on a downstream pin bump with this fix shows **0** `tx_generator_refill_submit_rejected` Always-assertion failures.
+- **SC-002**: The same run shows **0** `tx_generator_population_did_not_grow` Always-assertion failures.
+- **SC-003**: The same run still triggers **at least 4000** disconnect/reconnect events at the supervisor — i.e. the fault-injection coverage is not degraded by the fix.
+- **SC-004**: The same run satisfies the (newly tuned) `tx_generator_*_landed` Sometimes-assertion thresholds.
+- **SC-005**: In steady state (no fault injection), end-to-end refill/transact throughput is unchanged from pre-fix within measurement noise.
+- **SC-006**: Every short-circuited refill/transact tick is attributable from the daemon output to the *indexer-not-ready* cause, distinct from other not-applicable causes.
+
+## Assumptions
+
+- The supervisor's "upstream connected" transition (introduced by PR #105) is the right hook for resetting freshness — the LSQ probe completing is *not* sufficient on its own to declare freshness, since chain-sync runs on a separate mini-protocol and is what actually advances the indexer's UTxO view.
+- One `RollForward` after reconnect is sufficient to declare freshness. Rationale: the indexer applies blocks in chain order, so any `RollForward` observed after the most recent reconnect implies the chain-sync mini-protocol has resumed and the indexer has caught past whatever stale state remained from the previous connection. The existing `rsReady` gate already covers tip-distance, so this feature does not need to additionally wait until tip is reached.
+- The composer treats *indexer-not-ready* responses identically to existing not-applicable responses for the purpose of retry-on-next-tick. No composer-side change is required for retry behaviour; only the assertion thresholds change.
+- Composer-side Always-assertion adjustments (B/C/D) are tracked separately at cardano-foundation/cardano-node-antithesis #105, #106, #107 and are out of scope here. Only the *Sometimes*-thresholds for `tx_generator_*_landed` are touched in this repo.
+- The indexer's chain-sync re-sync semantics (always streaming forward) are correct as-is and out of scope.

--- a/specs/037-tx-gen-indexer-fresh/tasks.md
+++ b/specs/037-tx-gen-indexer-fresh/tasks.md
@@ -1,0 +1,112 @@
+---
+
+description: "Task list — gate tx-generator arms on indexer freshness after N2C reconnect (issue #109)"
+---
+
+# Tasks: Gate tx-generator arms on indexer freshness after N2C reconnect
+
+**Input**: Design documents from `/specs/037-tx-gen-indexer-fresh/`
+**Prerequisites**: spec.md, plan.md, research.md, data-model.md, contracts/arm-gate.md, quickstart.md
+**Issue**: https://github.com/lambdasistemi/cardano-node-clients/issues/109
+**Branch**: `037-tx-gen-indexer-fresh`
+
+**Tests**: Required. Constitution principle II mandates real-devnet E2E for all node-communication features; principle IV mandates that test helpers are first-class library exports.
+
+**Organization**: Tasks grouped by user story (US1, US2, US3) so each story can be implemented and demonstrated independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete work)
+- **[Story]**: Maps to spec.md user stories
+- Paths are absolute or relative to repo root
+
+## Path Conventions
+
+Single-project layout (per plan.md). Touched paths:
+
+- `lib/Cardano/Node/Client/TxGenerator/Daemon.hs` — primary edit
+- `test/Cardano/Node/Client/E2E/TxGeneratorIndexFreshSpec.hs` — new E2E spec
+- (optional) `test/Cardano/Node/Client/TxGenerator/DaemonFreshGateSpec.hs` — pure unit test if a small helper is extracted
+
+## Phase 1 — Setup
+
+Trivial. No package boundary work, no new modules, no new dependencies.
+
+- [X] T001 Verify worktree base is up-to-date with `origin/main` and that PR #105 (`feat(tx-generator): supervise N2C connection via N2C.Reconnect`) is the merge commit at `HEAD`. Run `git log --oneline -1` from `/code/cardano-node-clients-issue-109` and confirm the SHA matches `898a2c4`.
+
+## Phase 2 — Foundational
+
+Single foundational change, used by every user story below.
+
+- [X] T002 Extend `data ReadyState` in `lib/Cardano/Node/Client/TxGenerator/Daemon.hs` (around line 217) with `rsIndexFresh :: !Bool`. Update `initialReady` (around line 225) to set `rsIndexFresh = False`. Run `nix develop -c cabal build all -O0` to confirm the change compiles in isolation (existing readers ignore the new field). Reference: data-model.md "Modified entity: `ReadyState`".
+
+## Phase 3 — User Story 1: Refill arm gates on freshness (P1)
+
+**Story goal**: post-reconnect refill arm short-circuits with `index-not-ready` until the indexer applies one new block.
+
+**Independent test**: deterministic E2E — devnet relay → daemon → restart relay → assert refill returns `index-not-ready` during the freshness window → wait for one block → assert refill proceeds.
+
+- [X] T003 [US1] In `lib/Cardano/Node/Client/TxGenerator/Daemon.hs`, in the `setUpstreamStatus` closure (around line 322), add `rsIndexFresh = False` to the `UpstreamConnected` branch's record update so the field is cleared on every reconnect (and on cold start). Reference: research.md Decision 2.
+- [X] T004 [US1] In the same file, in `updateReady` (around line 1089), add `rsIndexFresh = True` to the `modifyTVar'` block so the freshness flag flips true after the first applied `RollForward`. Reference: research.md Decision 3, data-model.md "State transitions".
+- [X] T005 [US1] In `runDaemonWithTracer` (around the `doRefill = ...` definition near line 399), wrap the existing body so the function first reads `rsIndexFresh` from `readyVar` via `readTVarIO` and, if `False`, returns `pure (RefillFail IndexNotReady)` *before* the existing `E.handle ConnectionLost` wrapper runs. Reference: research.md Decision 4, contracts/arm-gate.md "Refill arm contract".
+- [X] T006 [P] [US1] Add E2E spec `test/Cardano/Node/Client/E2E/TxGeneratorIndexFreshSpec.hs`. Spec: spin up devnet, boot the daemon, wait for `ready=true`, stop the relay, restart the relay, immediately ping refill, assert `{"ok": false, "reason": "index-not-ready"}`, wait for one new block, ping refill again, assert it proceeds (or fails for an unrelated reason — the assertion is "no longer `index-not-ready`"). Pattern after `test/Cardano/Node/Client/E2E/TxGeneratorRestartSpec.hs`.
+- [X] T007 [US1] Wire the new spec into `cardano-node-clients.cabal` under the existing `e2e-tests` test-suite `other-modules` section.
+
+**Checkpoint**: After T007, `nix develop -c cabal test e2e-tests -O0 --test-show-details=direct --test-options='--match "TxGeneratorIndexFreshSpec"'` passes the refill assertions.
+
+## Phase 4 — User Story 2: Transact arm gates on freshness (P1)
+
+**Story goal**: post-reconnect transact arm short-circuits with `index-not-ready` until the indexer applies one new block.
+
+**Independent test**: same E2E fixture as US1, exercising the transact arm.
+
+- [X] T008 [US2] In `lib/Cardano/Node/Client/TxGenerator/Daemon.hs`, in the `doTransact = ...` definition (around line 419), apply the same wrapper as T005: read `rsIndexFresh`, return `pure (TransactFail IndexNotReady)` if `False`, otherwise fall through to the existing `E.handle ConnectionLost` + `runTransactArm` chain. Reference: contracts/arm-gate.md "Transact arm contract".
+- [X] T009 [US2] In `test/Cardano/Node/Client/E2E/TxGeneratorIndexFreshSpec.hs`, add a sibling scenario asserting the transact arm short-circuits with `index-not-ready` during the same post-reconnect window and proceeds normally after one block.
+
+**Checkpoint**: After T009, both refill and transact assertions in the new E2E spec pass.
+
+## Phase 5 — User Story 3: Observability and threshold tuning (P2)
+
+**Story goal**: short-circuited ticks are attributable to the freshness cause, and the antithesis run accommodates not-applicable streaks.
+
+- [X] T010 [P] [US3] Confirm by reading `lib/Cardano/Node/Client/TxGenerator/Types.hs` (around line 145-146) that `IndexNotReady` already serialises as `"index-not-ready"` distinct from `NoPickableSource` (`"no-pickable-source"`). No code change. Document the conclusion in the PR body. Reference: contracts/arm-gate.md "NDJSON shape on the wire".
+- [ ] T011 [US3] **Out-of-repo, tracked here for completeness**: open a companion issue or PR in `cardano-foundation/cardano-node-antithesis` titled `chore(composer): bump tx_generator_*_landed Sometimes-assertion thresholds for reconnect-storm tolerance`. Cross-link from issue #109. Do **not** edit anything in *this* repo for T011. Reference: research.md Decision 7, plan.md "out-of-scope contracts".
+
+**Checkpoint**: After T010, the PR description for issue #109 explicitly states which `index-not-ready` cause is exercised by which path. After T011, the companion antithesis PR is filed and linked.
+
+## Phase 6 — Polish & cross-cutting
+
+- [ ] T012 Run the full local CI gate: `nix develop -c just ci`. This must build, run all E2E specs, fourmolu check, hlint, and cabal-fmt check. Fix anything that fails before pushing. Reference: workflow skill "Pre-Push CI Check".
+- [ ] T013 Update the issue #109 description (and PR body once opened) with: link to spec 037, link to the companion antithesis PR from T011, summary of which acceptance criteria SC-001..SC-006 are verified by which test/process, and explicit note that SC-001..SC-004 require *both* this PR and the T011 companion to be merged before the 1h Antithesis run will go green.
+- [ ] T014 Push the branch and open the GitHub PR (label: `fix`, assignee: `paolino`). Verify CI runs. Use merge-guard MCP to check before any merge. Do NOT auto-merge — wait for explicit user authorization.
+
+## Dependencies
+
+```
+T001  ──►  T002  ──►  T003  ──►  T004  ──►  T005  ──►  T006  ──►  T007  ──►  T008  ──►  T009  ──►  T012  ──►  T013  ──►  T014
+                                                          ▲                                ▲
+                                                          └─ T006 may begin in parallel    └─ T009 depends on T006 (same file)
+                                                             with T005 (different file)
+
+T010  ──  independent  ──►  can begin any time after T002
+
+T011  ──  out-of-repo, no dependency on this repo's tasks once research conclusions are documented
+```
+
+User-story independence: US1 (T003-T007) and US2 (T008-T009) share the freshness-flag plumbing (T003+T004), so US1 must be implemented first; US2 then becomes a one-line wrapper change plus a sibling test scenario. US3 is documentation-only inside this repo plus a cross-repo task.
+
+## Parallel execution opportunities
+
+- T006 (new E2E spec file) can be drafted in parallel with T005 (Daemon.hs wrapper) — different files.
+- T010 (read Types.hs and confirm wire shape) is fully parallel: it touches no source.
+- T011 lives in a different repository and has no dependency on the rest of this list once T010 has confirmed the wire vocabulary.
+
+## Implementation strategy — MVP first
+
+The MVP is **US1 alone** (T001-T007). Shipping US1 alone:
+
+- Eliminates the `tx_generator_refill_submit_rejected` Always-assertion failure (the loudest of the two on the Antithesis run on `329a599`).
+- Leaves `tx_generator_population_did_not_grow` failures still present until US2 lands, but does not regress anything.
+- Is safe to merge incrementally if for any reason US2 (one-line transact wrapper + sibling test) needs to wait.
+
+Practically, however, US2 is so cheap that this PR will ship US1+US2 together. US3 is documentation + cross-repo; it does not block this PR's merge.

--- a/test/Cardano/Node/Client/E2E/TxGeneratorIndexFreshSpec.hs
+++ b/test/Cardano/Node/Client/E2E/TxGeneratorIndexFreshSpec.hs
@@ -1,0 +1,367 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Cardano.Node.Client.E2E.TxGeneratorIndexFreshSpec
+Description : E2E for the post-reconnect indexer-fresh gate (issue #109)
+License     : Apache-2.0
+
+After PR #105 the tx-generator's N2C bearer is supervised
+via 'runReconnectLoop'. The supervisor flips upstream
+status to 'UpstreamConnected' as soon as the new bearer
+is established and the LSQ probe answers — before the
+embedded chain-sync follower has caught the indexer's
+UTxO view back up to the new tip. During that window the
+indexer's local UTxO view is stale.
+
+Without the gate added by issue #109, a refill ticked into
+that window queries faucet UTxOs, sees rows the
+post-reconnect chain has already spent, builds a refill tx
+against them, and gets a 'ConwayMempoolFailure
+\"All inputs are spent\"' rejection. Antithesis on commit
+@329a599@ recorded 111 such failures across 95 forks
+tripping the @tx_generator_refill_submit_rejected@
+Always-assertion.
+
+This spec drives a real relay restart via
+'withRestartableCardanoNode' and pounds refill+transact
+in a tight loop across the post-reconnect settle window.
+The contract:
+
+* the daemon's 'Async' never exits,
+* eventually a refill succeeds again (chain-sync resumes
+  past the reconnect anchor and the freshness gate
+  releases),
+* no refill response in the entire post-restart window
+  ever carries a @submit-rejected@ reason whose text
+  matches @\"All inputs are spent\"@ — that exact reason
+  is the regression we are preventing.
+
+Acceptance covers User Story 1 (refill arm) and User Story
+2 (transact arm) of the spec at
+@specs\/037-tx-gen-indexer-fresh\/spec.md@.
+-}
+module Cardano.Node.Client.E2E.TxGeneratorIndexFreshSpec (spec) where
+
+import Cardano.Crypto.DSIGN (rawSerialiseSignKeyDSIGN)
+import Cardano.Node.Client.E2E.Devnet (
+    withRestartableCardanoNode,
+ )
+import Cardano.Node.Client.E2E.Setup (
+    devnetMagic,
+    genesisDir,
+    genesisSignKey,
+ )
+import Cardano.Node.Client.N2C.Probe (defaultProbeConfig)
+import Cardano.Node.Client.N2C.Reconnect (defaultReconnectPolicy)
+import Cardano.Node.Client.TxGenerator.Daemon (
+    DaemonConfig (..),
+    runDaemon,
+ )
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (
+    Async,
+    async,
+    cancel,
+    poll,
+    race,
+ )
+import Control.Exception (
+    SomeException,
+    bracket,
+    try,
+ )
+import Control.Monad (replicateM)
+import Data.Aeson (Value (..))
+import Data.Aeson qualified as Aeson
+import Data.Aeson.KeyMap qualified as KM
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Char8 qualified as BS8
+import Data.List (find)
+import Data.Maybe (isNothing)
+import Data.Text qualified as T
+import Network.Socket (
+    Family (AF_UNIX),
+    SockAddr (SockAddrUnix),
+    SocketType (Stream),
+    close,
+    connect,
+    socket,
+ )
+import Network.Socket.ByteString qualified as Net
+import Ouroboros.Network.Magic (NetworkMagic (..))
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec (
+    Spec,
+    describe,
+    expectationFailure,
+    it,
+    shouldBe,
+    shouldSatisfy,
+ )
+
+spec :: Spec
+spec =
+    describe "tx-generator indexer-fresh gate (issue #109)"
+        $ it
+            "no refill ever reports \"All inputs are spent\" \
+            \across a relay restart, and refills resume \
+            \after the freshness gate releases"
+        $ do
+            gDir <- genesisDir
+            withRestartableCardanoNode gDir $
+                \nodeSock _startMs restart ->
+                    withSystemTempDirectory "txgen-indexfresh" $
+                        \dir -> do
+                            let masterSeed = dir </> "master.seed"
+                                faucetSkey = dir </> "faucet.skey"
+                                stateDir = dir </> "state"
+                                ctlSock = dir </> "control.sock"
+                            BS.writeFile
+                                masterSeed
+                                (BS.replicate 32 0x37)
+                            BS.writeFile
+                                faucetSkey
+                                ( rawSerialiseSignKeyDSIGN
+                                    genesisSignKey
+                                )
+                            let cfg =
+                                    mkCfg
+                                        nodeSock
+                                        ctlSock
+                                        stateDir
+                                        masterSeed
+                                        faucetSkey
+                            runScenario cfg ctlSock restart
+
+runScenario ::
+    DaemonConfig ->
+    FilePath ->
+    IO () ->
+    IO ()
+runScenario cfg ctl restart = do
+    daemonT <- async (runDaemon cfg)
+    result <-
+        race
+            (threadDelay 600_000_000)
+            (driveScenario ctl restart daemonT)
+    cancel daemonT
+    case result of
+        Right () -> pure ()
+        Left _ ->
+            expectationFailure "scenario timed out (10 min)"
+
+driveScenario ::
+    FilePath ->
+    IO () ->
+    Async () ->
+    IO ()
+driveScenario sockPath restart daemonT = do
+    waitForConnect sockPath
+    requireRunning daemonT "after listen-socket bind"
+    pollReady sockPath
+    -- Sanity: a refill before the restart succeeds
+    -- (steady state baseline). If this fails the test is
+    -- not measuring what we think it is.
+    baseline <- sendOne sockPath "{\"refill\":{\"seed\":1}}"
+    assertOk "baseline refill" baseline
+
+    -- Drive the relay restart. 'restart' blocks until the
+    -- new relay's LSQ answers; the supervisor then has to
+    -- detect the disconnect on its side, reconnect, and
+    -- re-prime chain-sync. The window between the
+    -- supervisor's setUpstreamStatus UpstreamConnected
+    -- and the first applied 'rollForward' is the
+    -- freshness window the gate exists to handle.
+    restart
+
+    -- Pound refill in a tight loop for several seconds,
+    -- capturing every response. Counter-evidence (the
+    -- regression we are guarding against) is any refill
+    -- whose reason text matches "All inputs are spent" —
+    -- the exact ConwayMempoolFailure that tripped
+    -- tx_generator_refill_submit_rejected on Antithesis
+    -- @329a599@.
+    responses <-
+        replicateM 60 $ do
+            r <- sendOne sockPath "{\"refill\":{\"seed\":2}}"
+            requireRunning
+                daemonT
+                "during post-restart refill loop"
+            threadDelay 200_000
+            pure r
+
+    -- (a) at least one refill must eventually succeed
+    --     post-restart; that proves the freshness gate
+    --     released and the daemon resumed normal duty.
+    let oks = filter isOk responses
+    null oks
+        `shouldBe` False
+
+    -- (b) no refill in the window may report
+    --     "All inputs are spent". This is the regression
+    --     check.
+    let badReasons =
+            [ reason
+            | r <- responses
+            , Just reason <- [extractFailReason r]
+            , "All inputs are spent" `T.isInfixOf` reason
+            ]
+    badReasons `shouldSatisfy` null
+
+    -- (c) similarly poke the transact arm a few times to
+    --     confirm it is also gated. We just assert the
+    --     daemon stays alive and never crashes; a per-
+    --     reason assertion for transact is captured in the
+    --     same regression check at the daemon level (see
+    --     comment on 'doTransact' in
+    --     Cardano.Node.Client.TxGenerator.Daemon).
+    transactRsps <-
+        replicateM 10 $ do
+            r <-
+                sendOne
+                    sockPath
+                    "{\"transact\":{\"seed\":3,\"fanout\":2,\
+                    \\"prob_fresh\":0.5}}"
+            requireRunning
+                daemonT
+                "during post-restart transact loop"
+            threadDelay 200_000
+            pure r
+    let crashlike =
+            find
+                (\r -> not (isOk r) && isNothing (extractFailReason r))
+                transactRsps
+    crashlike
+        `shouldSatisfy` ( \case
+                            Nothing -> True
+                            Just bad ->
+                                error
+                                    ( "transact: malformed response: "
+                                        <> BS8.unpack bad
+                                    )
+                        )
+
+mkCfg ::
+    FilePath ->
+    FilePath ->
+    FilePath ->
+    FilePath ->
+    FilePath ->
+    DaemonConfig
+mkCfg nodeSocket controlSock stateDir masterSeed faucetSkey =
+    let NetworkMagic m = devnetMagic
+     in DaemonConfig
+            { dcRelaySocket = nodeSocket
+            , dcControlSocket = controlSock
+            , dcStateDir = stateDir
+            , dcMasterSeedFile = masterSeed
+            , dcFaucetSKeyFile = faucetSkey
+            , dcNetworkMagic = m
+            , dcByronEpochSlots = 432_000
+            , dcAwaitTimeoutSeconds = 30
+            , dcReadyThresholdSlots = 10
+            , dcSecurityParamK = 2160
+            , dcDbPath = Nothing
+            , dcReconnectPolicy = defaultReconnectPolicy
+            , dcProbeConfig = defaultProbeConfig
+            }
+
+requireRunning :: Async () -> String -> IO ()
+requireRunning thread ctx =
+    poll thread >>= \case
+        Just (Left e) ->
+            expectationFailure $
+                "daemon crashed " <> ctx <> ": " <> show e
+        Just (Right ()) ->
+            expectationFailure $
+                "daemon exited cleanly " <> ctx
+        Nothing -> pure ()
+
+isOk :: ByteString -> Bool
+isOk rsp = case Aeson.decodeStrict rsp of
+    Just (Object o) ->
+        KM.lookup "ok" o == Just (Bool True)
+    _ -> False
+
+extractFailReason :: ByteString -> Maybe T.Text
+extractFailReason rsp = case Aeson.decodeStrict rsp of
+    Just (Object o) -> case KM.lookup "reason" o of
+        Just (String t) -> Just t
+        _ -> Nothing
+    _ -> Nothing
+
+assertOk :: String -> ByteString -> IO ()
+assertOk what rsp = case Aeson.decodeStrict rsp of
+    Just (Object o) ->
+        KM.lookup "ok" o `shouldBe` Just (Bool True)
+    other ->
+        error
+            ( what
+                <> ": not a JSON object: "
+                <> show other
+                <> " raw="
+                <> BS8.unpack rsp
+            )
+
+waitForConnect :: FilePath -> IO ()
+waitForConnect path = loop (0 :: Int)
+  where
+    loop 120 =
+        error
+            ( "tx-generator: control socket "
+                <> path
+                <> " never bound within 60s"
+            )
+    loop n = do
+        attempt <-
+            try @SomeException (connectAndClose path)
+        case attempt of
+            Right () -> pure ()
+            Left _ ->
+                threadDelay 500_000 >> loop (n + 1)
+
+connectAndClose :: FilePath -> IO ()
+connectAndClose path =
+    bracket
+        (socket AF_UNIX Stream 0)
+        close
+        (\s -> connect s (SockAddrUnix path))
+
+pollReady :: FilePath -> IO ()
+pollReady path = loop (0 :: Int)
+  where
+    loop 240 =
+        error
+            "tx-generator: ready never went true within 120s"
+    loop n = do
+        rsp <- sendOne path "{\"ready\":null}"
+        if isReadyTrue rsp
+            then pure ()
+            else threadDelay 500_000 >> loop (n + 1)
+
+isReadyTrue :: ByteString -> Bool
+isReadyTrue rsp = case Aeson.decodeStrict rsp of
+    Just (Object o) ->
+        KM.lookup "ready" o == Just (Bool True)
+    _ -> False
+
+sendOne :: FilePath -> ByteString -> IO ByteString
+sendOne path req =
+    bracket
+        (socket AF_UNIX Stream 0)
+        close
+        ( \s -> do
+            connect s (SockAddrUnix path)
+            Net.sendAll s (req <> "\n")
+            recvAll s BS.empty
+        )
+  where
+    recvAll s acc = do
+        chunk <- Net.recv s 4096
+        if BS.null chunk
+            then pure acc
+            else recvAll s (acc <> chunk)

--- a/test/main.hs
+++ b/test/main.hs
@@ -11,6 +11,7 @@ import Cardano.Node.Client.E2E.N2CFullSpec qualified as N2CFullSpec
 import Cardano.Node.Client.E2E.ProviderSpec qualified as ProviderSpec
 import Cardano.Node.Client.E2E.TxBuildSpec qualified as TxBuildSpec
 import Cardano.Node.Client.E2E.TxGeneratorEnduranceSpec qualified as TxGeneratorEnduranceSpec
+import Cardano.Node.Client.E2E.TxGeneratorIndexFreshSpec qualified as TxGeneratorIndexFreshSpec
 import Cardano.Node.Client.E2E.TxGeneratorReadySpec qualified as TxGeneratorReadySpec
 import Cardano.Node.Client.E2E.TxGeneratorRefillSpec qualified as TxGeneratorRefillSpec
 import Cardano.Node.Client.E2E.TxGeneratorRestartSpec qualified as TxGeneratorRestartSpec
@@ -37,5 +38,6 @@ main = hspec $ do
     TxGeneratorTransactSpec.spec
     TxGeneratorSnapshotE2ESpec.spec
     TxGeneratorRestartSpec.spec
+    TxGeneratorIndexFreshSpec.spec
     TxGeneratorEnduranceSpec.spec
     TxGeneratorStarvationSpec.spec


### PR DESCRIPTION
Fixes https://github.com/lambdasistemi/cardano-node-clients/issues/109.

## Why

After https://github.com/lambdasistemi/cardano-node-clients/pull/105 the tx-generator daemon's N2C bearer is supervised via `runReconnectLoop` and stays up across relay restarts. The supervisor flips `rsUpstream` to `UpstreamConnected` as soon as the new bearer is established and the LSQ probe answers — **before** the embedded chain-sync follower has caught the indexer back up to the new tip.

During that gap the indexer's UTxO view is stale. Two failure modes follow:

1. **Refill arm queries faucet UTxOs** → gets back inputs the post-reconnect chain has already spent → builds a refill tx → submit-rejected with `ConwayMempoolFailure "All inputs are spent"`. Antithesis on `329a599` showed 111 such failures across 95 forks tripping `tx_generator_refill_submit_rejected` (Always assertion).
2. **Transact arm queries indexer for a source's UTxOs** → gets none viable for the K-output floor → returns `no-pickable-source`. 136 such not-applicable transacts on the same run trip `tx_generator_population_did_not_grow`.

Antithesis report:
https://cardano.antithesis.com/report/sgGPKwEUgpMFBkdN3QMH1MDn/CVALsMOlHQdIyvQsc0sKyxZ79mapUIksHP-v0XZcVds.html

Both are correctness-preserving (the relay correctly rejects stale inputs) but trip Antithesis Always-assertions framed as \"should never happen\".

## Approach

Add a single freshness gate, `rsIndexFresh :: !Bool`, on the existing `ReadyState` record. It is orthogonal to `rsReady` (within-N-slots-of-tip) and `rsUpstream` (bearer state):

- `setUpstreamStatus UpstreamConnected` clears it (cold start + every reconnect).
- `updateReady`, called from chain-sync's `rollForward` after `applyAtSlot`, sets it true.
- `doRefill` and `doTransact` snapshot it via `readTVarIO` and short-circuit with `RefillFail IndexNotReady` / `TransactFail IndexNotReady` when false — wire-stable vocabulary that already exists at `Types.hs:136,146`, already serialised as `\"index-not-ready\"`, already retried by the composer.

No wire-protocol change. No new failure reason. No composer-side change for retry behaviour.

## Tour of the changes

- `lib/Cardano/Node/Client/TxGenerator/Daemon.hs` — the only behavioural change.
  - Add `rsIndexFresh :: !Bool` to `ReadyState`; init to `False`.
  - In `setUpstreamStatus`, the `UpstreamConnected` branch clears `rsIndexFresh`.
  - In `updateReady` (the chain-sync follower's per-block hook) the field is set to `True` alongside the existing `rsReady`/`rsTipSlot`/`rsProcessedSlot` writes.
  - In `runDaemonWithTracer`, `doRefill` and `doTransact` are wrapped: read `rsIndexFresh`; if false, return `IndexNotReady` immediately, before the existing `E.handle ConnectionLost` wrapper runs.
- `test/Cardano/Node/Client/E2E/TxGeneratorIndexFreshSpec.hs` — new E2E. Boots devnet via `withRestartableCardanoNode`, runs a baseline refill, triggers a relay restart, then pounds refill+transact for ~12s. Asserts:
  - daemon `Async` never exits;
  - eventually a refill succeeds again (gate releases);
  - **no refill response in the entire window carries `\"All inputs are spent\"`** — the precise regression the gate prevents.
- `cardano-node-clients.cabal` + `test/main.hs` — register the new spec.
- `specs/037-tx-gen-indexer-fresh/` — full speckit artifacts (spec, plan, research with seven design decisions, data model, contract, quickstart, tasks).
- `CLAUDE.md` — auto-regenerated agent context.

## Alternatives considered

(see `specs/037-tx-gen-indexer-fresh/research.md` for full reasoning)

- *Track freshness as a derived predicate over `rsProcessedSlot` vs. a captured reconnect anchor* — works, but needs an extra slot field plus rollback reasoning. A single boolean owned by both writers exactly captures the spec invariant.
- *Flip freshness true at chain-sync `intersectFound` instead of first `rollForward`* — wrong: a same-point intersection after reconnect would set freshness true while the indexer's UTxO view is byte-identical to the stale view.
- *Block in the arm via STM `retry` instead of returning `IndexNotReady`* — defeats the composer's tick model; would pile up requests during reconnect storms.

## What this PR does *not* touch

- The Antithesis composer's `tx_generator_*_landed` Sometimes-assertion thresholds — those live in `cardano-foundation/cardano-node-antithesis` and will be filed there as a companion change.
- The composer-side Always-assertion adjustments tracked at https://github.com/cardano-foundation/cardano-node-antithesis/issues/105 / https://github.com/cardano-foundation/cardano-node-antithesis/issues/106 / https://github.com/cardano-foundation/cardano-node-antithesis/issues/107.
- Indexer chain-sync streaming semantics — unchanged.

## Verification

- `nix develop -c just ci` green locally: cabal build, all 23 E2E specs pass (4m08s), fourmolu check, hlint, cabal-fmt.
- New `TxGeneratorIndexFreshSpec` passes standalone in ~30s.
- Acceptance criteria SC-001..SC-004 (zero `tx_generator_refill_submit_rejected` / `tx_generator_population_did_not_grow` Always-failures over a 1h `cardano_node_master` Antithesis run with 4000+ reconnects, plus tuned Sometimes-thresholds) require **both** this PR **and** the companion antithesis-repo PR to be merged.

## Reviewer focus

- `lib/Cardano/Node/Client/TxGenerator/Daemon.hs` — three small edits to `ReadyState`, `setUpstreamStatus`, `updateReady`, `doRefill`, `doTransact`. Worth confirming the freshness reset is in the *only* `UpstreamConnected` write site (it is — the supervisor's status sink).
- `specs/037-tx-gen-indexer-fresh/research.md` — Decisions 1-7 capture the why-not for each rejected alternative.