### PR TITLE
Fix balance-aware ExUnits convergence

### DIFF
--- a/lib/Cardano/Node/Client/Evaluate.hs
+++ b/lib/Cardano/Node/Client/Evaluate.hs
@@ -5,7 +5,10 @@ License     : Apache-2.0
 
 Combines script evaluation, execution unit patching,
 integrity hash recomputation, and transaction
-balancing into a single function.
+balancing into a single function. Evaluation is
+iterated against the balanced transaction body so
+validators see the same TxInfo shape during local
+evaluation and submission.
 
 This is the standard workflow for submitting
 transactions with Plutus scripts:
@@ -39,10 +42,14 @@ import Cardano.Ledger.Api.Tx (
     witsTxL,
  )
 import Cardano.Ledger.Api.Tx.Body (
+    feeTxBodyL,
     inputsTxBodyL,
  )
 import Cardano.Ledger.Api.Tx.Out (TxOut)
 import Cardano.Ledger.Api.Tx.Wits (rdmrsTxWitsL)
+import Cardano.Ledger.BaseTypes (
+    StrictMaybe (SNothing),
+ )
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core (PParams)
 import Cardano.Ledger.Plutus.Language (Language)
@@ -52,6 +59,7 @@ import Cardano.Node.Client.Balance (
     BalanceResult (..),
     balanceTx,
     computeScriptIntegrity,
+    evalBudgetExUnits,
  )
 import Cardano.Node.Client.Ledger (ConwayTx)
 import Cardano.Node.Client.Provider (Provider (..))
@@ -73,6 +81,8 @@ The workflow:
    redeemers.
 5. Call 'balanceTx' to add fee inputs and a change
    output.
+6. Re-evaluate the balanced transaction and repeat
+   until fee and redeemer ExUnits are stable.
 
 Throws an error if script evaluation fails or
 balancing fails (insufficient funds).
@@ -96,38 +106,82 @@ evaluateAndBalance ::
     ConwayTx ->
     IO ConwayTx
 evaluateAndBalance lang prov pp inputUtxos refUtxos changeAddr tx =
-    do
-        -- Pre-add all inputs so the evaluator sees
-        -- the complete input set and spending indices
-        -- match the redeemers.
-        let existingIns =
-                tx ^. bodyTxL . inputsTxBodyL
-            allIns =
-                foldl
-                    ( \s (tin, _) ->
-                        Set.insert tin s
-                    )
-                    existingIns
-                    inputUtxos
-            txForEval =
-                tx
-                    & bodyTxL . inputsTxBodyL
-                        .~ allIns
-        evalResult <- evaluateTx prov txForEval
-        -- Check for script evaluation failures
-        let failures =
-                [ (p, e)
-                | (p, Left e) <-
-                    Map.toList evalResult
-                ]
-        if null failures
-            then pure ()
-            else
-                error $
-                    "evaluateAndBalance: \
-                    \script eval failed: "
-                        <> show failures
-        -- Patch ExUnits from eval result
+    go (0 :: Int) txForEval
+  where
+    -- Pre-add all inputs so the evaluator sees
+    -- the complete input set and spending indices
+    -- match the redeemers.
+    existingIns =
+        tx ^. bodyTxL . inputsTxBodyL
+    allIns =
+        foldl
+            ( \s (tin, _) ->
+                Set.insert tin s
+            )
+            existingIns
+            inputUtxos
+    txForEval =
+        tx
+            & bodyTxL . inputsTxBodyL
+                .~ allIns
+
+    go n candidate
+        | n > (10 :: Int) =
+            error
+                "evaluateAndBalance: ExUnits did not converge"
+        | otherwise = do
+            evalResult <-
+                evaluateTx
+                    prov
+                    (inflateRedeemerBudgets candidate)
+            case evalFailures evalResult of
+                [] -> do
+                    balanced <-
+                        balanceFromEval evalResult
+                    if n > 0
+                        && stableFeeAndExUnits
+                            candidate
+                            balanced
+                        then pure balanced
+                        else go (n + 1) balanced
+                failures ->
+                    error $
+                        "evaluateAndBalance: \
+                        \script eval failed: "
+                            <> show failures
+
+    inflateRedeemerBudgets candidate =
+        let Redeemers rdmrMap =
+                candidate ^. witsTxL . rdmrsTxWitsL
+            inflated =
+                Redeemers $
+                    fmap
+                        ( \(dat, _) ->
+                            (dat, evalBudgetExUnits)
+                        )
+                        rdmrMap
+            integrity =
+                if Map.null rdmrMap
+                    then SNothing
+                    else
+                        computeScriptIntegrity
+                            lang
+                            pp
+                            inflated
+         in candidate
+                & witsTxL . rdmrsTxWitsL
+                    .~ inflated
+                & bodyTxL
+                    . scriptIntegrityHashTxBodyL
+                    .~ integrity
+
+    evalFailures evalResult =
+        [ (p, e)
+        | (p, Left e) <-
+            Map.toList evalResult
+        ]
+
+    balanceFromEval evalResult =
         let Redeemers rdmrMap =
                 tx ^. witsTxL . rdmrsTxWitsL
             patched =
@@ -154,14 +208,25 @@ evaluateAndBalance lang prov pp inputUtxos refUtxos changeAddr tx =
                     & bodyTxL
                         . scriptIntegrityHashTxBodyL
                         .~ integrity
-        case balanceTx
-            pp
-            inputUtxos
-            refUtxos
-            changeAddr
-            patched' of
-            Left err ->
-                error $
-                    "evaluateAndBalance: "
-                        <> show err
-            Right br -> pure (balancedTx br)
+         in case balanceTx
+                pp
+                inputUtxos
+                refUtxos
+                changeAddr
+                patched' of
+                Left err ->
+                    error $
+                        "evaluateAndBalance: "
+                            <> show err
+                Right br -> pure (balancedTx br)
+
+    stableFeeAndExUnits candidate balanced =
+        candidate ^. bodyTxL . feeTxBodyL
+            == balanced ^. bodyTxL . feeTxBodyL
+            && redeemerExUnits candidate
+                == redeemerExUnits balanced
+
+    redeemerExUnits candidate =
+        let Redeemers rdmrMap =
+                candidate ^. witsTxL . rdmrsTxWitsL
+         in fmap snd rdmrMap

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -864,10 +864,15 @@ the Tx body stabilizes:
 
 1. Interpret program with current Tx (resolve Peek)
 2. Assemble Tx from steps
-3. Add input UTxOs, evaluate scripts → ExUnits
-4. Patch redeemers, recompute integrity hash
-5. Balance (fee + change)
-6. If any Peek returned Iterate or Tx changed → 1
+3. Add input UTxOs, evaluate scripts with inflated
+   budgets → ExUnits
+4. Patch redeemers, recompute integrity hash, and
+   balance (fee + change)
+5. Re-evaluate the balanced body, patch the
+   original unbalanced body with those ExUnits, and
+   balance again
+6. If any Peek returned Iterate, fee changed, or
+   ExUnits changed after balancing → 1
 -}
 
 {- | Knobs that influence 'buildWith'. New options
@@ -968,6 +973,48 @@ buildWith opts pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
             (tx ^. bodyTxL . referenceInputsTxBodyL)
             refUtxos
 
+    inflateRedeemerBudgets tx =
+        let Redeemers rdmrs =
+                tx ^. witsTxL . rdmrsTxWitsL
+            inflated =
+                Redeemers $
+                    fmap
+                        ( \(d, _) ->
+                            (d, evalBudgetExUnits)
+                        )
+                        rdmrs
+            integrity =
+                if Map.null rdmrs
+                    then SNothing
+                    else
+                        computeScriptIntegrity
+                            PlutusV3
+                            pp
+                            inflated
+         in tx
+                & witsTxL . rdmrsTxWitsL
+                    .~ inflated
+                & bodyTxL
+                    . scriptIntegrityHashTxBodyL
+                    .~ integrity
+
+    evaluateForBudget tx =
+        evaluateTx (inflateRedeemerBudgets tx)
+
+    evalFailures evalResult =
+        [ (p, e)
+        | (p, Left e) <-
+            Map.toList evalResult
+        ]
+
+    balanceWithEval tx evalResult =
+        balanceTx
+            pp
+            inputUtxos
+            refUtxos
+            changeAddr
+            (patchExUnits tx evalResult)
+
     -- \| One iteration: interpret, assemble, eval,
     -- patch, balance. Track seen fees to detect
     -- oscillation and bisect.
@@ -990,36 +1037,8 @@ buildWith opts pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
         --    so the evaluator gives scripts enough
         --    room to execute. The real ExUnits come
         --    back in evalResult.
-        let Redeemers evalRdmrs =
-                txForEval ^. witsTxL . rdmrsTxWitsL
-            inflated =
-                Redeemers $
-                    fmap
-                        ( \(d, _) ->
-                            (d, evalBudgetExUnits)
-                        )
-                        evalRdmrs
-            budgetIntegrity =
-                if Map.null evalRdmrs
-                    then SNothing
-                    else
-                        computeScriptIntegrity
-                            PlutusV3
-                            pp
-                            inflated
-            txForEvalBudget =
-                txForEval
-                    & witsTxL . rdmrsTxWitsL
-                        .~ inflated
-                    & bodyTxL
-                        . scriptIntegrityHashTxBodyL
-                        .~ budgetIntegrity
-        evalResult <- evaluateTx txForEvalBudget
-        let failures =
-                [ (p, e)
-                | (p, Left e) <-
-                    Map.toList evalResult
-                ]
+        evalResult <- evaluateForBudget txForEval
+        let failures = evalFailures evalResult
         case failures of
             ((purpose, msg) : _) -> do
                 -- Eval failed. Distinguish terminal
@@ -1108,111 +1127,143 @@ buildWith opts pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
                                     (evalRetries + 1)
                                     retryTx
             [] -> do
-                -- 3. Patch ExUnits THEN balance.
-                --    This way balanceTx sees the
-                --    real script cost.
-                let patchedTx =
-                        patchExUnits tx evalResult
-                case balanceTx
-                    pp
-                    inputUtxos
-                    refUtxos
-                    changeAddr
-                    patchedTx of
+                -- 3. Balance once from the
+                --    pre-balance evaluation, then
+                --    evaluate the balanced body that
+                --    validators will actually see.
+                case balanceWithEval tx evalResult of
                     Left err ->
                         pure $
                             Left $
                                 BalanceFailed err
-                    Right BalanceResult{balancedTx = balanced, changeIndex = chIx} -> do
-                        let finalFee =
-                                balanced
-                                    ^. bodyTxL
-                                        . feeTxBodyL
-                            newMax =
-                                max maxFee finalFee
-                        if finalFee == prevFee
-                            then
-                                if newMax > finalFee
-                                    then
-                                        -- Fee converged
-                                        -- but below max.
-                                        -- Re-iterate
-                                        -- once with max
-                                        -- so Peek sees
-                                        -- the right fee.
-                                        case bumpFee
-                                            chIx
-                                            balanced
-                                            newMax of
-                                            Left msg ->
-                                                pure $
-                                                    Left $
-                                                        BumpFeeFailed
-                                                            msg
-                                            Right bumped ->
-                                                step
-                                                    seenFees
-                                                    newMax
-                                                    0
-                                                    bumped
-                                    else
-                                        if not peekConverged
-                                            && finalFee
-                                                > Coin 0
-                                            then
-                                                -- Fee converged
-                                                -- but Peek has
-                                                -- not. Re-iterate.
-                                                step
-                                                    seenFees
-                                                    newMax
-                                                    0
-                                                    balanced
-                                            else
-                                                -- Truly
-                                                -- converged.
-                                                case failedChecks
-                                                    (tsChecks st)
-                                                    balanced of
-                                                    [] ->
-                                                        pure $
-                                                            Right
-                                                                balanced
-                                                    errs ->
-                                                        pure $
-                                                            Left $
-                                                                ChecksFailed
-                                                                    errs
-                            else
-                                if Set.member
-                                    finalFee
+                    Right BalanceResult{balancedTx = balanced0} -> do
+                        balancedEvalResult <-
+                            evaluateForBudget balanced0
+                        case evalFailures balancedEvalResult of
+                            ((purpose, msg) : _) ->
+                                pure $
+                                    Left $
+                                        EvalFailure
+                                            purpose
+                                            msg
+                            [] ->
+                                continueAfterBalancedEval
+                                    st
+                                    peekConverged
+                                    prevFee
                                     seenFees
-                                    then do
-                                        -- Oscillation!
-                                        let lo =
-                                                min
-                                                    finalFee
-                                                    prevFee
-                                            hi =
-                                                max
-                                                    finalFee
-                                                    prevFee
-                                        bisect
-                                            st
-                                            evalResult
-                                            chIx
-                                            balanced
-                                            lo
-                                            hi
-                                    else
-                                        step
-                                            ( Set.insert
-                                                finalFee
+                                    maxFee
+                                    tx
+                                    balancedEvalResult
+
+    continueAfterBalancedEval
+        st
+        peekConverged
+        prevFee
+        seenFees
+        maxFee
+        tx
+        balancedEvalResult =
+            -- Patch the original unbalanced body with
+            -- the balanced-body ExUnits, then balance
+            -- again so fee and change account for
+            -- those final costs without appending a
+            -- second change output.
+            case balanceWithEval tx balancedEvalResult of
+                Left err ->
+                    pure $
+                        Left $
+                            BalanceFailed err
+                Right BalanceResult{balancedTx = balanced, changeIndex = chIx} -> do
+                    let finalFee =
+                            balanced
+                                ^. bodyTxL
+                                    . feeTxBodyL
+                        newMax =
+                            max maxFee finalFee
+                    if finalFee == prevFee
+                        then
+                            if newMax > finalFee
+                                then
+                                    -- Fee converged
+                                    -- but below max.
+                                    -- Re-iterate
+                                    -- once with max
+                                    -- so Peek sees
+                                    -- the right fee.
+                                    case bumpFee
+                                        chIx
+                                        balanced
+                                        newMax of
+                                        Left msg ->
+                                            pure $
+                                                Left $
+                                                    BumpFeeFailed
+                                                        msg
+                                        Right bumped ->
+                                            step
                                                 seenFees
-                                            )
-                                            newMax
-                                            0
-                                            balanced
+                                                newMax
+                                                0
+                                                bumped
+                                else
+                                    if not peekConverged
+                                        && finalFee
+                                            > Coin 0
+                                        then
+                                            -- Fee converged
+                                            -- but Peek has
+                                            -- not. Re-iterate.
+                                            step
+                                                seenFees
+                                                newMax
+                                                0
+                                                balanced
+                                        else
+                                            -- Truly
+                                            -- converged.
+                                            case failedChecks
+                                                (tsChecks st)
+                                                balanced of
+                                                [] ->
+                                                    pure $
+                                                        Right
+                                                            balanced
+                                                errs ->
+                                                    pure $
+                                                        Left $
+                                                            ChecksFailed
+                                                                errs
+                        else
+                            if Set.member
+                                finalFee
+                                seenFees
+                                then do
+                                    -- Oscillation!
+                                    let lo =
+                                            min
+                                                finalFee
+                                                prevFee
+                                        hi =
+                                            max
+                                                finalFee
+                                                prevFee
+                                    bisect
+                                        st
+                                        balancedEvalResult
+                                        chIx
+                                        balanced
+                                        lo
+                                        hi
+                                else
+                                    step
+                                        ( Set.insert
+                                            finalFee
+                                            seenFees
+                                        )
+                                        newMax
+                                        0
+                                        balanced
 
     -- \| Binary search for the smallest fee where
     -- eval passes. lo fails eval, hi passes.

--- a/specs/039-exunits-after-balance/data-model.md
+++ b/specs/039-exunits-after-balance/data-model.md
@@ -1,0 +1,42 @@
+# Data Model: Balance-Aware ExUnits
+
+## Entities
+
+### Evaluation Result
+
+- Key: Plutus purpose.
+- Value: either script failure or evaluated ExUnits.
+- Constraint: only successful ExUnits are patched into matching
+  redeemers.
+
+### Redeemer ExUnits Snapshot
+
+- Representation: map from Plutus purpose to ExUnits.
+- Used to compare whether a later balance-aware evaluation changed any
+  redeemer cost.
+
+### Balanced Transaction Candidate
+
+- Transaction after redeemer patching, script-integrity recomputation,
+  fee calculation, fee-input selection, and change-output creation.
+- Constraint: the final returned candidate must have redeemer ExUnits
+  equal to the successful evaluation result for that same candidate
+  after applying the configured margin.
+
+### Convergence State
+
+- Existing fee state: previous fee, seen fees, maximum fee, and retry
+  count.
+- New ExUnits state: redeemer ExUnits snapshot from the latest
+  balance-aware evaluation.
+- Stable when final fee and final ExUnits match the latest balanced
+  candidate, and existing `Peek` checks have converged.
+
+## Relationships
+
+- An Evaluation Result patches a transaction's redeemers.
+- Patched redeemers determine script integrity hash and minimum fee.
+- Balancing can change the transaction body observed by the next
+  Evaluation Result.
+- Convergence compares the patched Balanced Transaction Candidate
+  against the next Evaluation Result.

--- a/specs/039-exunits-after-balance/plan.md
+++ b/specs/039-exunits-after-balance/plan.md
@@ -6,9 +6,11 @@
 ## Status
 
 **Completed**: Baseline CI gate passed on the branch before edits. Speckit
-specification created from issue #112.  
-**Current**: Implement regression tests and balance-aware ExUnits
-convergence.  
+specification created from issue #112. Regression tests added for `build`
+and `evaluateAndBalance`. Balance-aware ExUnits convergence implemented
+and verified with focused unit tests, `just ci`, and the CI-parity Nix
+gate.  
+**Current**: Draft PR review.  
 **Blockers**: None.
 
 ## Summary

--- a/specs/039-exunits-after-balance/plan.md
+++ b/specs/039-exunits-after-balance/plan.md
@@ -1,0 +1,91 @@
+# Implementation Plan: Balance-Aware ExUnits
+
+**Branch**: `039-exunits-after-balance` | **Date**: 2026-05-01 | **Spec**: `specs/039-exunits-after-balance/spec.md`
+**Input**: Feature specification from `/specs/039-exunits-after-balance/spec.md`
+
+## Status
+
+**Completed**: Baseline CI gate passed on the branch before edits. Speckit
+specification created from issue #112.  
+**Current**: Implement regression tests and balance-aware ExUnits
+convergence.  
+**Blockers**: None.
+
+## Summary
+
+`build` and `evaluateAndBalance` currently patch redeemer ExUnits from an
+evaluation that does not include later balancing mutations such as change
+outputs and fee inputs. The fix is to make both workflows evaluate the
+balanced transaction before deciding that redeemer ExUnits are final, and
+to rebalance when that final evaluation changes ExUnits.
+
+## Technical Context
+
+**Language/Version**: Haskell, GHC 9.6+ via repository Nix shell  
+**Primary Dependencies**: `cardano-ledger-*`, `plutus-*`, existing
+`Cardano.Node.Client.Balance` and transaction builder modules  
+**Storage**: N/A  
+**Testing**: Hspec unit tests, repository e2e suite  
+**Target Platform**: Haskell library on Linux/Nix CI  
+**Project Type**: Library  
+**Performance Goals**: Maintain existing convergence behavior; add only
+the evaluations needed to prove the balanced transaction's ExUnits.  
+**Constraints**: Preserve public APIs; preserve deterministic error
+reporting; keep existing margin semantics.  
+**Scale/Scope**: `TxBuild.buildWith`, `TxBuild.build`, and
+`Evaluate.evaluateAndBalance`.
+
+## Constitution Check
+
+- Channel-driven N2C clients: no changes to node communication APIs.
+- Devnet E2E testing: existing e2e suite remains the integration gate.
+- Minimal dependencies: no new dependencies planned.
+- Test utilities first-class: regression coverage stays in the existing
+  Hspec unit suite with deterministic evaluator functions.
+- Quality gate: CI command is
+  `nix build --quiet .#checks.x86_64-linux.build .#checks.x86_64-linux.e2e .#checks.x86_64-linux.lint`.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/039-exunits-after-balance/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+lib/Cardano/Node/Client/
+├── Evaluate.hs
+└── TxBuild.hs
+
+test/Cardano/Node/Client/
+└── TxBuildSpec.hs
+```
+
+**Structure Decision**: Keep the change in the existing transaction
+assembly modules and existing TxBuild test module. No new library module
+or public API is required.
+
+## Implementation Notes
+
+- Factor common redeemer patching/evaluation helpers only if it reduces
+  duplication without changing exported APIs.
+- For `buildWith`, convergence must include ExUnits stability in
+  addition to the existing fee and `Peek` convergence checks.
+- For `evaluateAndBalance`, a small local convergence loop is sufficient:
+  evaluate, patch, balance, evaluate balanced, patch again, rebalance
+  until redeemer ExUnits and fee are stable.
+- Existing `boExUnitsMargin` applies at the point ExUnits are patched
+  into redeemers.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/039-exunits-after-balance/quickstart.md
+++ b/specs/039-exunits-after-balance/quickstart.md
@@ -1,0 +1,19 @@
+# Quickstart: Balance-Aware ExUnits
+
+1. Run the focused unit tests:
+
+   ```bash
+   cabal test unit-tests -O0 --test-options='--match "/TxBuild/"'
+   ```
+
+2. Run the repository local CI equivalent:
+
+   ```bash
+   just ci
+   ```
+
+3. Run the CI-parity Nix gate:
+
+   ```bash
+   nix build --quiet .#checks.x86_64-linux.build .#checks.x86_64-linux.e2e .#checks.x86_64-linux.lint
+   ```

--- a/specs/039-exunits-after-balance/research.md
+++ b/specs/039-exunits-after-balance/research.md
@@ -1,0 +1,47 @@
+# Research: Balance-Aware ExUnits
+
+## Findings
+
+- `Cardano.Node.Client.TxBuild.buildWith` assembles a transaction,
+  inflates redeemers for evaluation, patches ExUnits from that
+  evaluation, then calls `balanceTx`.
+- `balanceTx` may add fee inputs and a change output. Those fields are
+  visible to Plutus validators through TxInfo, so any validator that
+  traverses outputs, inputs, mint, or reference inputs can cost more
+  after balancing than it did during pre-balance evaluation.
+- `buildWith` already has fee convergence and bisection logic. The
+  missing condition is ExUnits stability for the balanced transaction.
+- `Cardano.Node.Client.Evaluate.evaluateAndBalance` has the simpler
+  eval-patch-balance shape and needs the same post-balance evaluation
+  and rebalancing logic.
+- `Cardano.Node.Client.Balance.computeScriptIntegrity` and
+  `evalBudgetExUnits` are the existing primitives for safe evaluation
+  and integrity hash recomputation.
+
+## Decision
+
+Use a balance-aware convergence loop rather than relying on
+`boExUnitsMargin`.
+
+## Rationale
+
+Margins hide the specific failure but do not bound all validator shapes.
+Evaluating the balanced transaction makes the patched redeemers match
+the transaction body that validators actually see.
+
+## Alternatives Considered
+
+- Increase the default ExUnits margin: rejected because validators can
+  traverse balance-added fields any number of times.
+- Avoid adding change outputs before evaluation: rejected because fee
+  and change are part of the submitted transaction and are validator
+  visible.
+- Add a new public API: rejected because the current APIs should become
+  correct without caller changes.
+
+## Test Strategy
+
+Use deterministic evaluators in unit tests. The evaluator returns
+`ExUnits mem steps` where `steps` is proportional to the number of
+outputs in the transaction it receives. The test then asserts that the
+final redeemer ExUnits match the final balanced output count.

--- a/specs/039-exunits-after-balance/spec.md
+++ b/specs/039-exunits-after-balance/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: Balance-Aware ExUnits
+
+**Feature Branch**: `039-exunits-after-balance`  
+**Created**: 2026-05-01  
+**Status**: Draft  
+**Input**: GitHub issue #112: `TxBuild.build patches ExUnits before balance, so post-balance change-output blows the per-script budget`
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Build Covers Final TxInfo Cost (Priority: P1)
+
+As an off-chain transaction author using `TxBuild.build`, I need the
+patched redeemer execution units to cover the transaction body that is
+submitted, not an earlier unbalanced draft, so validators that inspect
+outputs, inputs, mint, or reference inputs do not fail at submission
+with a small post-balance budget deficit.
+
+**Why this priority**: This is the reported production failure path.
+`build` is the primary transaction assembly API and downstream users
+already follow the documented workflow.
+
+**Independent Test**: A unit test can provide a deterministic evaluator
+whose returned CPU depends on the number of outputs visible in the
+transaction. The resulting built transaction must contain redeemer
+ExUnits equal to the balanced transaction's output count cost.
+
+**Acceptance Scenarios**:
+
+1. **Given** a transaction program with one script spend and one paid
+   output, **When** balancing adds a change output, **Then** the final
+   redeemer ExUnits reflect the two-output balanced transaction.
+2. **Given** a transaction program whose fee and change converge across
+   multiple build iterations, **When** the final transaction is returned,
+   **Then** the final redeemer ExUnits match a final evaluation of that
+   returned transaction.
+
+---
+
+### User Story 2 - evaluateAndBalance Covers Final TxInfo Cost (Priority: P1)
+
+As a caller that already has an unbalanced transaction, I need
+`evaluateAndBalance` to produce the same balance-aware ExUnits guarantee
+as `build`, so both documented transaction workflows are safe for
+validators that traverse transaction fields.
+
+**Why this priority**: The issue identifies `evaluateAndBalance` as
+having the same eval-patch-balance ordering bug.
+
+**Independent Test**: A unit test can call `evaluateAndBalance` with a
+provider whose evaluator returns CPU proportional to output count. The
+final redeemer ExUnits must equal the balanced transaction's output
+count cost.
+
+**Acceptance Scenarios**:
+
+1. **Given** an unbalanced transaction with a script redeemer and one
+   output, **When** `evaluateAndBalance` adds change, **Then** the final
+   redeemer ExUnits reflect the balanced transaction.
+2. **Given** script evaluation fails at any evaluation point, **When**
+   `evaluateAndBalance` runs, **Then** the failure is surfaced instead
+   of returning an under-budgeted transaction.
+
+### Edge Cases
+
+- Transactions without redeemers must continue to balance without
+  forcing unnecessary script-evaluation assumptions.
+- Evaluation failures during the initial or balance-aware evaluation
+  must remain visible as errors.
+- Existing fee convergence and fee-oscillation handling in `build` must
+  continue to terminate and preserve `Peek` semantics.
+- Existing explicit ExUnits margin configuration must remain applied to
+  the evaluated values that are finally patched.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `build` MUST return transactions whose patched redeemer
+  ExUnits are based on evaluation of the balanced transaction body that
+  will be submitted.
+- **FR-002**: `evaluateAndBalance` MUST return transactions whose
+  patched redeemer ExUnits are based on evaluation of the balanced
+  transaction body that will be submitted.
+- **FR-003**: If balance-aware evaluation changes any redeemer ExUnits,
+  the transaction MUST be rebalanced so fees and change are consistent
+  with the patched units.
+- **FR-004**: The convergence process MUST stop only when both the fee
+  and patched ExUnits are stable for the final balanced transaction.
+- **FR-005**: Existing script evaluation failures MUST continue to be
+  reported to callers rather than hidden by balancing retries.
+- **FR-006**: The existing ExUnits margin option MUST still be applied
+  to ExUnits before the script integrity hash is recomputed.
+
+### Key Entities
+
+- **Balanced Transaction**: The transaction body after fee calculation,
+  fee inputs, and change output have been applied.
+- **Evaluation Result**: The per-redeemer ExUnits or script failure
+  returned by the evaluator for a specific transaction body.
+- **Patched Redeemers**: Redeemers in the transaction witness set after
+  replacing placeholder or prior ExUnits with evaluated ExUnits.
+- **Convergence State**: The observed fee and ExUnits values used to
+  decide whether another build/balance iteration is required.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A regression test for `build` fails on the old
+  eval-patch-balance ordering and passes when ExUnits are patched from
+  the balanced transaction evaluation.
+- **SC-002**: A regression test for `evaluateAndBalance` fails on the
+  old eval-patch-balance ordering and passes when ExUnits are patched
+  from the balanced transaction evaluation.
+- **SC-003**: Existing unit and e2e tests continue to pass.
+- **SC-004**: The CI gate
+  `nix build --quiet .#checks.x86_64-linux.build .#checks.x86_64-linux.e2e .#checks.x86_64-linux.lint`
+  passes.
+
+## Assumptions
+
+- The evaluator is deterministic for a fixed transaction body and
+  protocol-parameter set.
+- Balancing may add fee inputs and a change output, and validators can
+  observe those fields through TxInfo.
+- The implementation can reuse the existing evaluator and balancer
+  interfaces without introducing a new public API.
+- Unit tests may use deterministic in-process evaluators because the
+  behavior under test is the library's ordering and convergence logic,
+  not node communication.

--- a/specs/039-exunits-after-balance/tasks.md
+++ b/specs/039-exunits-after-balance/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: Balance-Aware ExUnits
+
+**Input**: Design documents from `/specs/039-exunits-after-balance/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`
+
+## Phase 1: Regression Coverage
+
+- [ ] T001 [US1] Add a `build` unit regression in `test/Cardano/Node/Client/TxBuildSpec.hs` where evaluator CPU depends on final output count.
+- [ ] T002 [US2] Add an `evaluateAndBalance` unit regression in `test/Cardano/Node/Client/TxBuildSpec.hs` with the same output-count evaluator.
+- [ ] T003 Run the focused unit tests and confirm the new regressions fail before implementation.
+
+## Phase 2: Implementation
+
+- [ ] T004 [US1] Update `lib/Cardano/Node/Client/TxBuild.hs` so `buildWith` only converges when final balanced redeemer ExUnits are stable.
+- [ ] T005 [US2] Update `lib/Cardano/Node/Client/Evaluate.hs` so `evaluateAndBalance` evaluates the balanced transaction, repatches redeemers, and rebalances until fee and ExUnits stabilize.
+- [ ] T006 Preserve `boExUnitsMargin` semantics and script integrity recomputation for all patched redeemers.
+
+## Phase 3: Verification
+
+- [ ] T007 Run focused unit tests for TxBuild.
+- [ ] T008 Run `just ci`.
+- [ ] T009 Run the CI-parity Nix gate.
+- [ ] T010 Update this task list and plan status with verification results.

--- a/specs/039-exunits-after-balance/tasks.md
+++ b/specs/039-exunits-after-balance/tasks.md
@@ -5,19 +5,19 @@
 
 ## Phase 1: Regression Coverage
 
-- [ ] T001 [US1] Add a `build` unit regression in `test/Cardano/Node/Client/TxBuildSpec.hs` where evaluator CPU depends on final output count.
-- [ ] T002 [US2] Add an `evaluateAndBalance` unit regression in `test/Cardano/Node/Client/TxBuildSpec.hs` with the same output-count evaluator.
-- [ ] T003 Run the focused unit tests and confirm the new regressions fail before implementation.
+- [X] T001 [US1] Add a `build` unit regression in `test/Cardano/Node/Client/TxBuildSpec.hs` where evaluator CPU depends on final output count.
+- [X] T002 [US2] Add an `evaluateAndBalance` unit regression in `test/Cardano/Node/Client/TxBuildSpec.hs` with the same output-count evaluator.
+- [X] T003 Run the focused unit tests and confirm the new regressions fail before implementation.
 
 ## Phase 2: Implementation
 
-- [ ] T004 [US1] Update `lib/Cardano/Node/Client/TxBuild.hs` so `buildWith` only converges when final balanced redeemer ExUnits are stable.
-- [ ] T005 [US2] Update `lib/Cardano/Node/Client/Evaluate.hs` so `evaluateAndBalance` evaluates the balanced transaction, repatches redeemers, and rebalances until fee and ExUnits stabilize.
-- [ ] T006 Preserve `boExUnitsMargin` semantics and script integrity recomputation for all patched redeemers.
+- [X] T004 [US1] Update `lib/Cardano/Node/Client/TxBuild.hs` so `buildWith` only converges when final balanced redeemer ExUnits are stable.
+- [X] T005 [US2] Update `lib/Cardano/Node/Client/Evaluate.hs` so `evaluateAndBalance` evaluates the balanced transaction, repatches redeemers, and rebalances until fee and ExUnits stabilize.
+- [X] T006 Preserve `boExUnitsMargin` semantics and script integrity recomputation for all patched redeemers.
 
 ## Phase 3: Verification
 
-- [ ] T007 Run focused unit tests for TxBuild.
-- [ ] T008 Run `just ci`.
-- [ ] T009 Run the CI-parity Nix gate.
-- [ ] T010 Update this task list and plan status with verification results.
+- [X] T007 Run focused unit tests for TxBuild.
+- [X] T008 Run `just ci`.
+- [X] T009 Run the CI-parity Nix gate.
+- [X] T010 Update this task list and plan status with verification results.

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -75,6 +75,7 @@ import Cardano.Ledger.Conway.Scripts (
     ConwayPlutusPurpose (..),
  )
 import Cardano.Ledger.Core (
+    PParams,
     bodyTxL,
     hashTxAuxData,
     metadataTxAuxDataL,
@@ -99,6 +100,9 @@ import Cardano.Ledger.Mary.Value (
  )
 import Cardano.Ledger.Metadata (Metadatum (..))
 import Cardano.Ledger.Plutus (ExUnits (..))
+import Cardano.Ledger.Plutus.Language (
+    Language (PlutusV3),
+ )
 import Cardano.Ledger.TxIn (
     TxId (..),
     TxIn (..),
@@ -107,7 +111,9 @@ import Cardano.Node.Client.Balance (
     BalanceResult (..),
     balanceTx,
  )
+import Cardano.Node.Client.Evaluate (evaluateAndBalance)
 import Cardano.Node.Client.Ledger (ConwayTx)
+import Cardano.Node.Client.Provider (Provider (..))
 import Cardano.Node.Client.TxBuild
 import Cardano.Slotting.Slot (SlotNo (..))
 import Lens.Micro ((&), (.~), (^.))
@@ -1010,6 +1016,125 @@ buildSpec =
                         fee
                             `shouldSatisfy` (> 0)
 
+        it "patches ExUnits from balanced output count" $ do
+            let pp =
+                    emptyPParams @ConwayEra
+                        & ppTxFeePerByteL
+                            .~ CoinPerByte
+                                (compactCoinOrError (Coin 44))
+                        & ppTxFeeFixedL .~ Coin 155381
+                        & ppMaxTxSizeL .~ 100_000
+                perOutput = 200_000
+                scriptUtxo =
+                    ( mkTxIn 2
+                    , mkBasicTxOut
+                        (mkAddr 3)
+                        (inject (Coin 5_000_000))
+                    )
+                feeUtxo =
+                    ( mkTxIn 9
+                    , mkBasicTxOut
+                        (mkAddr 1)
+                        (inject (Coin 10_000_000))
+                    )
+                prog :: TxBuild TestQ TestErr ()
+                prog = do
+                    _ <-
+                        spendScript
+                            (mkTxIn 2)
+                            (42 :: Integer)
+                    _ <-
+                        payTo
+                            (mkAddr 4)
+                            (inject (Coin 3_000_000))
+                    collateral (mkTxIn 9)
+                mockEval =
+                    outputCountingEval perOutput
+            result <-
+                build
+                    pp
+                    noCtxInterpretIO
+                    mockEval
+                    [feeUtxo, scriptUtxo]
+                    []
+                    (mkAddr 1)
+                    prog
+            case result of
+                Left err ->
+                    expectationFailure $ show err
+                Right tx -> do
+                    length
+                        ( toList $
+                            tx
+                                ^. bodyTxL
+                                    . outputsTxBodyL
+                        )
+                        `shouldBe` 2
+                    redeemerExUnits
+                        (ConwaySpending (AsIx 0))
+                        tx
+                        `shouldBe` Just
+                            (outputCountExUnits perOutput tx)
+
+        it
+            "evaluateAndBalance patches ExUnits from \
+            \balanced output count"
+            $ do
+                let pp =
+                        emptyPParams @ConwayEra
+                            & ppTxFeePerByteL
+                                .~ CoinPerByte
+                                    (compactCoinOrError (Coin 44))
+                            & ppTxFeeFixedL .~ Coin 155381
+                            & ppMaxTxSizeL .~ 100_000
+                    perOutput = 200_000
+                    scriptUtxo =
+                        ( mkTxIn 2
+                        , mkBasicTxOut
+                            (mkAddr 3)
+                            (inject (Coin 5_000_000))
+                        )
+                    feeUtxo =
+                        ( mkTxIn 9
+                        , mkBasicTxOut
+                            (mkAddr 1)
+                            (inject (Coin 10_000_000))
+                        )
+                    unbalanced =
+                        draft pp $ do
+                            _ <-
+                                spendScript
+                                    (mkTxIn 2)
+                                    (42 :: Integer)
+                            _ <-
+                                payTo
+                                    (mkAddr 4)
+                                    (inject (Coin 3_000_000))
+                            collateral (mkTxIn 9)
+                    provider =
+                        outputCountingProvider pp perOutput
+                tx <-
+                    evaluateAndBalance
+                        PlutusV3
+                        provider
+                        pp
+                        [feeUtxo, scriptUtxo]
+                        []
+                        (mkAddr 1)
+                        unbalanced
+                length
+                    ( toList $
+                        tx
+                            ^. bodyTxL
+                                . outputsTxBodyL
+                    )
+                    `shouldBe` 2
+                redeemerExUnits
+                    (ConwaySpending (AsIx 0))
+                    tx
+                    `shouldBe` Just
+                        (outputCountExUnits perOutput tx)
+
         it "retries with an estimated fee after eval failure" $ do
             feeHistoryRef <- newIORef []
             let pp =
@@ -1345,6 +1470,61 @@ isMint ::
     ConwayPlutusPurpose AsIx ConwayEra -> Bool
 isMint (ConwayMinting _) = True
 isMint _ = False
+
+outputCountExUnits :: Int -> ConwayTx -> ExUnits
+outputCountExUnits perOutput tx =
+    ExUnits
+        0
+        ( fromIntegral perOutput
+            * fromIntegral
+                ( length $
+                    toList $
+                        tx ^. bodyTxL . outputsTxBodyL
+                )
+        )
+
+outputCountingEval ::
+    Int ->
+    ConwayTx ->
+    IO
+        ( Map.Map
+            (ConwayPlutusPurpose AsIx ConwayEra)
+            (Either String ExUnits)
+        )
+outputCountingEval perOutput tx =
+    pure $
+        Map.singleton
+            (ConwaySpending (AsIx 0))
+            (Right (outputCountExUnits perOutput tx))
+
+outputCountingProvider ::
+    PParams ConwayEra ->
+    Int ->
+    Provider IO
+outputCountingProvider pp perOutput =
+    Provider
+        { queryUTxOs = const (pure [])
+        , queryProtocolParams = pure pp
+        , evaluateTx =
+            pure
+                . Map.singleton
+                    (ConwaySpending (AsIx 0))
+                . Right
+                . outputCountExUnits perOutput
+        , posixMsToSlot =
+            pure . SlotNo . fromIntegral
+        , posixMsCeilSlot =
+            pure . SlotNo . fromIntegral
+        }
+
+redeemerExUnits ::
+    ConwayPlutusPurpose AsIx ConwayEra ->
+    ConwayTx ->
+    Maybe ExUnits
+redeemerExUnits purpose tx =
+    let Redeemers rdmrs =
+            tx ^. witsTxL . rdmrsTxWitsL
+     in snd <$> Map.lookup purpose rdmrs
 
 {- | Run draft and return both the Tx and the
 program's result.


### PR DESCRIPTION
Closes #112

## Summary
- add Speckit spec/plan/tasks for balance-aware ExUnits convergence
- update TxBuild.buildWith to re-evaluate the balanced body and patch the original unbalanced body with those balanced ExUnits before final balancing
- update evaluateAndBalance with a fee/ExUnits convergence loop over the balanced transaction body
- add regressions for output-count-sensitive evaluators through both public workflows

## Verification
- nix develop --quiet -c cabal test unit-tests -O0 --test-options='--match "ExUnits from balanced output count" --format=progress'
- nix develop --quiet -c just ci
- nix build --quiet .#checks.x86_64-linux.build .#checks.x86_64-linux.e2e .#checks.x86_64-linux.lint