### PR TITLE
fix(tx-generator): refill recovery on duplicate-submit / ConnectionLost mid-submit

### DIFF
--- a/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
+++ b/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
@@ -171,6 +171,7 @@ import Data.List (maximumBy)
 import Data.Maybe (isJust)
 import Data.Set qualified as Set
 import Data.Text (Text)
+import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.Void (Void)
 import Data.Word (Word16, Word32, Word64)
@@ -608,6 +609,48 @@ buildSignSubmit
             Right tx -> do
                 let signed = addKeyWitness faucetSKey tx
                     inputs = signed ^. bodyTxL . inputsTxBodyL
+                    -- Computed locally from the signed
+                    -- bytes; matches the txId that the
+                    -- relay would assign on accept.
+                    -- 'refillTx' is deterministic in
+                    -- 'currentIdx' + 'amount' + the chosen
+                    -- faucet input, so a prior submit
+                    -- attempt that elicited
+                    -- 'ConnectionLost' would have produced
+                    -- the SAME txId.
+                    txId = txIdTx signed
+                    freshIxn = ledgerToIndexerTxIn txId 0
+                    awaitTimeout =
+                        Just (dcAwaitTimeoutSeconds cfg)
+                    -- Bias-low timeout for the
+                    -- recovery-await on uncertain-submit
+                    -- paths (ConnectionLost,
+                    -- "already-included"). Long enough
+                    -- for a fresh block carrying the prior
+                    -- submission to be observed; short
+                    -- enough that genuine non-landing
+                    -- failures don't stall the composer.
+                    recoveryAwait = Just 5
+                    finishOk awaited = do
+                        let txHex = txIdToHex txId
+                        writeNextHDIndex
+                            (nextHDIndexPath (dcStateDir cfg))
+                            (currentIdx + 1)
+                        atomically
+                            ( writeTVar
+                                lastTxIdVar
+                                (Just txHex)
+                            )
+                        pure
+                            ( currentIdx + 1
+                            , RefillOk
+                                { rfOkTxId = txHex
+                                , rfOkFreshIndex = currentIdx
+                                , rfOkValueLovelace =
+                                    unCoin amount
+                                , rfOkAwaited = awaited
+                                }
+                            )
                 inputsOk <- verifyInputsUnspent provider inputs
                 if not inputsOk
                     then
@@ -616,43 +659,97 @@ buildSignSubmit
                             , RefillFail IndexNotReady
                             )
                     else do
-                        result <- submitTx submitter signed
-                        case result of
-                            Rejected reason -> do
+                        -- Wrap submitTx narrowly so a
+                        -- bearer-close mid-submit can be
+                        -- recovered via awaitTxIn — the
+                        -- relay may have already accepted
+                        -- our tx and the daemon just lost
+                        -- the response.
+                        submitOutcome <-
+                            E.try @ConnectionLost
+                                (submitTx submitter signed)
+                        case submitOutcome of
+                            Right (Submitted _) -> do
+                                obs <-
+                                    awaitTxIn
+                                        idx
+                                        freshIxn
+                                        awaitTimeout
+                                finishOk
+                                    ( isJust
+                                        ( obs ::
+                                            Maybe AwaitObservation
+                                        )
+                                    )
+                            Right (Rejected reason) -> do
                                 let reasonText =
                                         Text.decodeUtf8With
                                             (\_ _ -> Just '\xFFFD')
                                             reason
-                                pure
-                                    ( currentIdx
-                                    , RefillFail
-                                        (SubmitRejected reasonText)
-                                    )
-                            Submitted txId -> do
-                                let freshIxn =
-                                        ledgerToIndexerTxIn txId 0
-                                    timeoutS =
-                                        Just (dcAwaitTimeoutSeconds cfg)
-                                obs <- awaitTxIn idx freshIxn timeoutS
-                                let awaited = isJust (obs :: Maybe AwaitObservation)
-                                    txHex = txIdToHex txId
-                                writeNextHDIndex
-                                    (nextHDIndexPath (dcStateDir cfg))
-                                    (currentIdx + 1)
-                                atomically
-                                    ( writeTVar
-                                        lastTxIdVar
-                                        (Just txHex)
-                                    )
-                                pure
-                                    ( currentIdx + 1
-                                    , RefillOk
-                                        { rfOkTxId = txHex
-                                        , rfOkFreshIndex = currentIdx
-                                        , rfOkValueLovelace = unCoin amount
-                                        , rfOkAwaited = awaited
-                                        }
-                                    )
+                                -- The relay's
+                                -- "already been included"
+                                -- rejection means a prior
+                                -- in-flight submission of
+                                -- THIS exact tx (build is
+                                -- deterministic) landed on
+                                -- the chain. Verify by
+                                -- awaiting the
+                                -- change-output briefly;
+                                -- on observation, treat
+                                -- the request as having
+                                -- succeeded against the
+                                -- prior submission.
+                                if "already been included"
+                                    `Text.isInfixOf` reasonText
+                                    then do
+                                        obs <-
+                                            awaitTxIn
+                                                idx
+                                                freshIxn
+                                                recoveryAwait
+                                        case obs of
+                                            Just _ ->
+                                                finishOk True
+                                            Nothing ->
+                                                pure
+                                                    ( currentIdx
+                                                    , RefillFail
+                                                        ( SubmitRejected
+                                                            reasonText
+                                                        )
+                                                    )
+                                    else
+                                        pure
+                                            ( currentIdx
+                                            , RefillFail
+                                                ( SubmitRejected
+                                                    reasonText
+                                                )
+                                            )
+                            Left ConnectionLost -> do
+                                -- Bearer died mid-submit.
+                                -- The submission may or
+                                -- may not have landed on
+                                -- the relay. Wait briefly
+                                -- for the change-output;
+                                -- on observation, treat
+                                -- as success. Otherwise
+                                -- IndexNotReady so the
+                                -- composer retries on the
+                                -- next tick.
+                                obs <-
+                                    awaitTxIn
+                                        idx
+                                        freshIxn
+                                        recoveryAwait
+                                case obs of
+                                    Just _ -> finishOk True
+                                    Nothing ->
+                                        pure
+                                            ( currentIdx
+                                            , RefillFail
+                                                IndexNotReady
+                                            )
 
 -- ----------------------------------------------------------------------
 -- Transact arm (User Story 1 / T011)


### PR DESCRIPTION
Iterates on the residual race that survived #114 for the refill arm.

## Problem

Antithesis 1h run on cardano-foundation/cardano-node-antithesis@11cfc40 (full reconnect-resilience stack: PRs #105/#110/#114 in pin) finished with **2 tx-generator findings**, both correlated:

* `tx_generator_refill_submit_rejected` (Always)
* `tx_generator_population_did_not_grow` (Always — on forks where refill never lands, populationSize stays 0)

The relay's reason on the rejected refills is the same string as before:

```
ConwayMempoolFailure "All inputs are spent. Transaction has probably already been included"
```

Mechanism (see commit body for full trace):

1. Refill arm submits Tx1 — the relay accepts it into its chain.
2. Bearer dies before `MsgAcceptTx` round-trips back. `submitTxN2C` raises `ConnectionLost`.
3. Daemon arm catches it, returns `RefillFail IndexNotReady`. Composer retries on the next tick.
4. Refill arm rebuilds — deterministically — the SAME tx body with the SAME txId (same `currentIdx`, same faucet input, same amount, same change address).
5. PR #114's pre-submit probe sees the input still unspent on the mempool view at the moment of the probe. Between probe and submit Tx1 lands; the relay rejects the resubmission as a duplicate.

The probe is structurally non-atomic. The faucet has only one funded UTxO so every refill retry collides on the same input — this only manifests on the refill arm, which is why transact_submit_rejected is already at zero.

## Fix

Post-submit verification on the duplicate path, scoped entirely inside `buildSignSubmit`:

* On `Submitted txId` (clean ack) — unchanged: await change-output for the configured timeout, return `RefillOk`.
* On `Rejected reason` containing `"already been included"` — compute the txId locally from the signed bytes (build is deterministic), `awaitTxIn idx freshIxn (Just 5)`, and on observation return `RefillOk` with that txId. Otherwise fall through to the existing `RefillFail (SubmitRejected …)` path — genuine rejection.
* On `ConnectionLost` (bearer died mid-submit, ack unknown) — same recovery: short await on the change-output, `RefillOk` on observation, otherwise `RefillFail IndexNotReady` so the composer retries.

The outer `E.handle ConnectionLost` wrapper remains for catching ConnectionLost from the pre-submit LSQ paths (queryUTxOs, verifyInputsUnspent) where there is no submission to recover.

## Diff size

1 file, +130 / -33. No API change to `Submitter` or `Provider`. No in-flight tx-id persistence. No new module. The transact arm is intentionally untouched.

## Verification

* `cabal build all -O0 --enable-tests` — green.
* `cabal test unit-tests` — 238/239 (one pre-existing flake `TxBuild.build fee-dependent outputs converge` fails on plain main too).
* fourmolu / hlint clean.

The acceptance gate is the next 1h `cardano-node-antithesis` workflow_dispatch on the bumped pin: 0 `tx_generator_refill_submit_rejected` and 0 `tx_generator_population_did_not_grow` Always-assertion failures.

## Related

* https://github.com/lambdasistemi/cardano-node-clients/pull/105 — supervisor
* https://github.com/lambdasistemi/cardano-node-clients/pull/110 — freshness gate
* https://github.com/lambdasistemi/cardano-node-clients/pull/114 — pre-submit chain-tip probe (this stacks on top)
* https://github.com/cardano-foundation/cardano-node-antithesis/pull/98 — downstream consumer that validates this end-to-end