### PR TITLE
fix(tx-generator): align refill recovery-await timeout with the configured await window

### DIFF
--- a/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
+++ b/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
@@ -622,15 +622,27 @@ buildSignSubmit
                     freshIxn = ledgerToIndexerTxIn txId 0
                     awaitTimeout =
                         Just (dcAwaitTimeoutSeconds cfg)
-                    -- Bias-low timeout for the
-                    -- recovery-await on uncertain-submit
-                    -- paths (ConnectionLost,
-                    -- "already-included"). Long enough
-                    -- for a fresh block carrying the prior
-                    -- submission to be observed; short
-                    -- enough that genuine non-landing
-                    -- failures don't stall the composer.
-                    recoveryAwait = Just 5
+                    -- Recovery-await on uncertain-submit
+                    -- paths (ConnectionLost or
+                    -- "already-included"). Tuned to the
+                    -- configured 'dcAwaitTimeoutSeconds'
+                    -- so under aggressive fault injection
+                    -- the indexer has the same window to
+                    -- observe the change-output as the
+                    -- happy-path 'Submitted txId' branch.
+                    -- The previous 5 s constant was too
+                    -- short under the Antithesis workload:
+                    -- the indexer is mid-reconnect itself
+                    -- when this fires, and 5 s isn't
+                    -- enough for it to see the block that
+                    -- carries the prior in-flight tx.
+                    -- Empirically, 'tx_generator_refill_landed'
+                    -- examples land at ~57 s vtime while
+                    -- 'tx_generator_refill_submit_rejected'
+                    -- fires at ~70-91 s — a 30 s window is
+                    -- inside that gap.
+                    recoveryAwait =
+                        Just (dcAwaitTimeoutSeconds cfg)
                     finishOk awaited = do
                         let txHex = txIdToHex txId
                         writeNextHDIndex


### PR DESCRIPTION
Iterates on PR #115's refill recovery, which still left a residual
'tx_generator_refill_submit_rejected' firing at ~70-91 s vtime on the
Antithesis run at https://cardano.antithesis.com/report/JjPofIAbSixtn9DexNDJLl9I.

## Why

PR #115's recovery hard-coded a 5 s timeout for the post-rejection
'awaitTxIn' on uncertain-submit paths (ConnectionLost, "already-included").
That's too short under Antithesis fault injection: the indexer is
mid-reconnect itself when this fires, and 5 s isn't long enough for
the block carrying the prior in-flight tx to be observed.

Empirical evidence from that run:
- 'tx_generator_refill_landed' (Sometimes, passing) example at vtime 57.49s
- 'tx_generator_refill_submit_rejected' (Always, failing) examples at 70.58s, 83.48s, 91.69s

The 13-34 s gap between a clean refill landing and a follow-on
'already-included' rejection is what the recovery has to span.

## What

Use 'dcAwaitTimeoutSeconds' (default 30 s on the antithesis cluster
per the testnet's daemon CLI) for the recovery await — same window as
the happy-path 'Submitted txId' branch already uses. No new config,
no behavior change to clean submits, no composer-side change.

## Verification

- 'cabal build all -O0 --enable-tests' green.
- 'fourmolu -m check' clean. 'hlint' "No hints".
- The 1 h Antithesis dispatch on the downstream bump branch
  (https://github.com/cardano-foundation/cardano-node-antithesis/pull/98)
  is the gate — expectation: 0 'tx_generator_refill_submit_rejected'
  Always-assertion failures, no other regressions.

## Stacks on

- #105 — N2C reconnect supervisor
- #110 — indexer freshness gate
- #114 — pre-submit chain-tip probe
- #115 — refill duplicate-submit recovery (this tightens the timeout)