### PR TITLE
fix(tx-generator): refill recovery-await timeout → IndexNotReady (PR #117)

### DIFF
--- a/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
+++ b/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
@@ -714,6 +714,28 @@ buildSignSubmit
                                 if "already been included"
                                     `Text.isInfixOf` reasonText
                                     then do
+                                        -- awaitTxIn timeout
+                                        -- here is *uncertain*:
+                                        -- the prior submission
+                                        -- landed on the relay
+                                        -- but the change-output
+                                        -- never appeared on the
+                                        -- best chain — most
+                                        -- likely the carrying
+                                        -- block was rolled
+                                        -- back. Treat as
+                                        -- transient
+                                        -- (IndexNotReady) so
+                                        -- the composer retries;
+                                        -- next tick the rebuilt
+                                        -- tx will spend a
+                                        -- different
+                                        -- (post-rollback)
+                                        -- faucet UTxO and
+                                        -- submit cleanly,
+                                        -- instead of firing the
+                                        -- always-assertion on
+                                        -- SubmitRejected.
                                         obs <-
                                             awaitTxIn
                                                 idx
@@ -726,9 +748,7 @@ buildSignSubmit
                                                 pure
                                                     ( currentIdx
                                                     , RefillFail
-                                                        ( SubmitRejected
-                                                            reasonText
-                                                        )
+                                                        IndexNotReady
                                                     )
                                     else
                                         pure

--- a/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
+++ b/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
@@ -622,15 +622,27 @@ buildSignSubmit
                     freshIxn = ledgerToIndexerTxIn txId 0
                     awaitTimeout =
                         Just (dcAwaitTimeoutSeconds cfg)
-                    -- Bias-low timeout for the
-                    -- recovery-await on uncertain-submit
-                    -- paths (ConnectionLost,
-                    -- "already-included"). Long enough
-                    -- for a fresh block carrying the prior
-                    -- submission to be observed; short
-                    -- enough that genuine non-landing
-                    -- failures don't stall the composer.
-                    recoveryAwait = Just 5
+                    -- Recovery-await on uncertain-submit
+                    -- paths (ConnectionLost or
+                    -- "already-included"). Tuned to the
+                    -- configured 'dcAwaitTimeoutSeconds'
+                    -- so under aggressive fault injection
+                    -- the indexer has the same window to
+                    -- observe the change-output as the
+                    -- happy-path 'Submitted txId' branch.
+                    -- The previous 5 s constant was too
+                    -- short under the Antithesis workload:
+                    -- the indexer is mid-reconnect itself
+                    -- when this fires, and 5 s isn't
+                    -- enough for it to see the block that
+                    -- carries the prior in-flight tx.
+                    -- Empirically, 'tx_generator_refill_landed'
+                    -- examples land at ~57 s vtime while
+                    -- 'tx_generator_refill_submit_rejected'
+                    -- fires at ~70-91 s — a 30 s window is
+                    -- inside that gap.
+                    recoveryAwait =
+                        Just (dcAwaitTimeoutSeconds cfg)
                     finishOk awaited = do
                         let txHex = txIdToHex txId
                         writeNextHDIndex


### PR DESCRIPTION
## Summary

Refines PR #115 / #116 by reclassifying the refill arm's *uncertain*
recovery-await outcome from \`SubmitRejected\` (hard failure → fires
Always assertion \`tx_generator_refill_submit_rejected\`) to
\`IndexNotReady\` (transient → composer retries on next tick).

## The bug

PR #116 bumped the refill recovery-await window to
\`dcAwaitTimeoutSeconds\` (30s) so the daemon has the same budget to
observe the change-output as a fresh submission. That fixed most
"already-included" recovery cases.

But the latest Antithesis run on commit \`41213dc\`
([report](https://cardano.antithesis.com/report/AIMsrMfUpLbllKSviAJdHodj/1QTFzVtIkxIJrOMTjKe_7IPNkOI9dzThBbvIRBXabF4.html))
still shows \`tx_generator_refill_submit_rejected\` firing once at
vtime 117s with \`reason="All inputs are spent. Transaction has
probably already been included"\`. Decoded: the prior submission of
the deterministically-built refill tx landed on the relay, but the
indexer never observed the change-output on the best chain within
30s — most likely because the carrying block was rolled back.

## The fix

Treat awaitTxIn timeout in this branch as
\`IndexNotReady\` instead of \`SubmitRejected\`. Rationale:

- The submission *did* hit the relay (we got the explicit
  "already been included" rejection).
- The change-output *isn't* on the best chain (awaitTxIn timed out).
- The most likely cause is a rollback of the carrying block.
- On the next tick, the rebuilt refill tx will spend a different
  (post-rollback) faucet UTxO and submit cleanly.

This is symmetric to the existing \`ConnectionLost\` recovery branch
in the same function, which already returns \`IndexNotReady\` on
awaitTxIn timeout (see lines 749-764 of \`Daemon.hs\`).

## Test plan

- [x] \`just ci\` — 24/24 e2e green, fourmolu/hlint/cabal-fmt clean
- [ ] Downstream Antithesis 1h on this commit (via tx-gen-reconnect
      branch) — verify \`tx_generator_refill_submit_rejected\` is no
      longer in the findings list.

## Stack

- PR #105 — supervisor + BlockedIndefinitelyOnSTM catch
- PR #110 — post-reconnect indexer freshness gate
- PR #114 — pre-submit chain-tip UTxO probe
- PR #115 — refill duplicate-submit recovery (await change-output on ConnectionLost / "already-included")
- PR #116 — recovery-await timeout aligned with dcAwaitTimeoutSeconds
- **PR #117 (this) — uncertain awaitTxIn outcome → IndexNotReady, not SubmitRejected**