### PR TITLE
fix(tx-generator): mirror refill duplicate-submit recovery in transact arm (PR #118)

### DIFF
--- a/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
+++ b/lib/Cardano/Node/Client/TxGenerator/Daemon.hs
@@ -989,6 +989,68 @@ transactWithSource
                         let signed = addKeyWitness srcSKey tx
                             inputs =
                                 signed ^. bodyTxL . inputsTxBodyL
+                            -- Computed locally; matches the
+                            -- txId the relay would assign on
+                            -- accept. transactTx is
+                            -- deterministic in the picked
+                            -- (srcIn, dests, srcAddr) so a
+                            -- prior submit attempt that
+                            -- elicited "already-included"
+                            -- would have produced the SAME
+                            -- txId — the recovery-await path
+                            -- can use it.
+                            txId = txIdTx signed
+                            -- The change output is at index K
+                            -- (after the K explicit
+                            -- destinations).
+                            changeIxn =
+                                ledgerToIndexerTxIn
+                                    txId
+                                    ( fromIntegral
+                                        ( txReqFanout req
+                                        ) ::
+                                        Word16
+                                    )
+                            awaitTimeout =
+                                Just (dcAwaitTimeoutSeconds cfg)
+                            recoveryAwait =
+                                Just (dcAwaitTimeoutSeconds cfg)
+                            finishOk awaited = do
+                                let txHex = txIdToHex txId
+                                    freshCount =
+                                        fromIntegral
+                                            ( length
+                                                ( filter
+                                                    destFresh
+                                                    dests
+                                                )
+                                            )
+                                writeNextHDIndex
+                                    ( nextHDIndexPath
+                                        (dcStateDir cfg)
+                                    )
+                                    newNextIdx
+                                atomically
+                                    ( writeTVar
+                                        lastTxIdVar
+                                        (Just txHex)
+                                    )
+                                pure
+                                    ( newNextIdx
+                                    , TransactOk
+                                        { txOkTxId = txHex
+                                        , txOkSrc = srcIdx
+                                        , txOkDsts =
+                                            fmap destIndex dests
+                                        , txOkValuesLovelace =
+                                            fmap
+                                                (unCoin . destValue)
+                                                dests
+                                        , txOkFreshCount =
+                                            freshCount
+                                        , txOkAwaited = awaited
+                                        }
+                                    )
                         inputsOk <-
                             verifyInputsUnspent provider inputs
                         if not inputsOk
@@ -1000,76 +1062,66 @@ transactWithSource
                             else do
                                 result <- submitTx submitter signed
                                 case result of
+                                    Submitted _ -> do
+                                        obs <-
+                                            awaitTxIn
+                                                idx
+                                                changeIxn
+                                                awaitTimeout
+                                        finishOk
+                                            ( isJust
+                                                ( obs ::
+                                                    Maybe AwaitObservation
+                                                )
+                                            )
                                     Rejected reason -> do
                                         let reasonText =
                                                 Text.decodeUtf8With
                                                     (\_ _ -> Just '\xFFFD')
                                                     reason
-                                        pure
-                                            ( currentIdx
-                                            , TransactFail
-                                                (SubmitRejected reasonText)
-                                            )
-                                    Submitted txId -> do
-                                        -- The change output is at
-                                        -- index K (after the K
-                                        -- explicit destinations).
-                                        let changeIxn =
-                                                ledgerToIndexerTxIn
-                                                    txId
-                                                    ( fromIntegral
-                                                        ( txReqFanout req
-                                                        ) ::
-                                                        Word16
-                                                    )
-                                            timeoutS =
-                                                Just
-                                                    (dcAwaitTimeoutSeconds cfg)
-                                        obs <-
-                                            awaitTxIn
-                                                idx
-                                                changeIxn
-                                                timeoutS
-                                        let awaited =
-                                                isJust
-                                                    ( obs ::
-                                                        Maybe AwaitObservation
-                                                    )
-                                            txHex = txIdToHex txId
-                                            freshCount =
-                                                fromIntegral
-                                                    ( length
-                                                        ( filter
-                                                            destFresh
-                                                            dests
+                                        -- Same recovery as the
+                                        -- refill arm (PR #115):
+                                        -- the relay says our
+                                        -- deterministic tx
+                                        -- already landed.
+                                        -- Verify by awaiting the
+                                        -- change-output; on
+                                        -- observation, treat as
+                                        -- having succeeded
+                                        -- against the prior
+                                        -- submission. Otherwise
+                                        -- the carrying block
+                                        -- was likely rolled
+                                        -- back — return
+                                        -- IndexNotReady so the
+                                        -- composer retries on
+                                        -- the next tick (per
+                                        -- PR #117).
+                                        if "already been included"
+                                            `Text.isInfixOf` reasonText
+                                            then do
+                                                obs <-
+                                                    awaitTxIn
+                                                        idx
+                                                        changeIxn
+                                                        recoveryAwait
+                                                case obs of
+                                                    Just _ ->
+                                                        finishOk True
+                                                    Nothing ->
+                                                        pure
+                                                            ( currentIdx
+                                                            , TransactFail
+                                                                IndexNotReady
+                                                            )
+                                            else
+                                                pure
+                                                    ( currentIdx
+                                                    , TransactFail
+                                                        ( SubmitRejected
+                                                            reasonText
                                                         )
                                                     )
-                                        writeNextHDIndex
-                                            ( nextHDIndexPath
-                                                (dcStateDir cfg)
-                                            )
-                                            newNextIdx
-                                        atomically
-                                            ( writeTVar
-                                                lastTxIdVar
-                                                (Just txHex)
-                                            )
-                                        pure
-                                            ( newNextIdx
-                                            , TransactOk
-                                                { txOkTxId = txHex
-                                                , txOkSrc = srcIdx
-                                                , txOkDsts =
-                                                    fmap destIndex dests
-                                                , txOkValuesLovelace =
-                                                    fmap
-                                                        (unCoin . destValue)
-                                                        dests
-                                                , txOkFreshCount =
-                                                    freshCount
-                                                , txOkAwaited = awaited
-                                                }
-                                            )
 
 -- ----------------------------------------------------------------------
 -- Server hooks


### PR DESCRIPTION
## Summary

Mirrors the refill arm's PR #115/#116/#117 recovery shape into the
**transact** arm.

## The finding

Antithesis 1h on the post-#117 image (commit `247a781`) — session
`efe17477e94dfcef7503548edab28ecd-50-7`,
[report](https://cardano.antithesis.com/report/Ld3icJ6K4ITBccWDzoS4v9B-/F-Cq805KT3qPwSYL2PRHAJCONnt-9Xd5ldEh29UTJjQ.html?auth=v2.public.eyJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoiRi1DcTgwNUtUM3FQd1NZTDJQUkhBSkNPTm50LTlYZDVsZEVoMjlVVEpqUS5odG1sIiwicmVwb3J0X2lkIjoiTGQzaWNKNks0SVRCY2NXRHpvUzR2OUItIn19LCJuYmYiOiIyMDI2LTA1LTAyVDEzOjQ1OjQ3LjkwNzgxNzM3NloifQY55RAK6Vv45eRs7rSaFmb95jQ-8PMnO-8vEeT9cnRQzbBCstyRWRANZiwglKyFQsTK2Gqxswbgs1kOBrVrhQE):
- ✅ \`tx_generator_refill_submit_rejected\` count: **0** (PR #117 worked)
- ❌ \`tx_generator_transact_submit_rejected\` count: **4** with reason
  \`ConwayMempoolFailure "All inputs are spent. Transaction has probably already been included"\`

Same root cause as the refill bug, but in the transact path. The
pre-submit \`verifyInputsUnspent\` probe catches most cases but is
non-atomic w.r.t. relay rollbacks: a tx the daemon submitted on one
fork can survive in the relay's mempool while the indexer/probe see
the post-rollback chain where the input appears unspent. The relay
then rejects the duplicate submit with "already been included".

## The fix

Mirror the refill arm's recovery shape:

- Compute the deterministic \`txId\` locally (transactTx is
  deterministic in the picked srcIn/dests/srcAddr).
- Extract the change-output index (K = \`txReqFanout req\`) once.
- Factor a \`finishOk\` helper so success and recovery share the
  \`TransactOk\` construction + state writes.
- On \`Rejected\` with "already been included", \`awaitTxIn\` the
  change-output for \`dcAwaitTimeoutSeconds\`; on observation,
  \`finishOk True\` (prior submission landed); on timeout, return
  \`TransactFail IndexNotReady\` (composer retries on next tick,
  per PR #117 reasoning).

\`ConnectionLost\` is already handled at the outer \`runTransactArm\`
\`E.handle\` so the inner submit path doesn't need a separate \`try\`
wrapper — the bearer-died case becomes \`IndexNotReady\` at the seam.

## Test plan

- [x] \`just ci\` — 24/24 e2e green, fourmolu/hlint/cabal-fmt clean.
- [ ] Downstream Antithesis 1h on this commit (via tx-gen-reconnect
      branch) — verify \`tx_generator_transact_submit_rejected\` is
      no longer in the findings list.

## Stack

- PR #105 — supervisor + BlockedIndefinitelyOnSTM catch
- PR #110 — post-reconnect indexer freshness gate
- PR #114 — pre-submit chain-tip UTxO probe
- PR #115 — refill duplicate-submit recovery
- PR #116 — recovery-await timeout aligned with dcAwaitTimeoutSeconds
- PR #117 — refill recovery-await timeout → IndexNotReady
- **PR #118 (this) — transact duplicate-submit recovery**