### PR TITLE
fix: re-derive rsReady on reconnect (#119) + run unit-tests in CI + conservation regression (#121)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           nix build --quiet
           .#checks.x86_64-linux.build
           .#checks.x86_64-linux.e2e
+          .#checks.x86_64-linux.unit
           .#checks.x86_64-linux.lint
   build:
     needs: build-gate
@@ -45,6 +46,17 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: E2E tests
         run: nix run --quiet .#e2e
+  unit:
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v17
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Unit tests
+        run: nix run --quiet .#unit
   lint:
     needs: build-gate
     runs-on: nixos
@@ -59,7 +71,7 @@ jobs:
   docs:
     runs-on: nixos
     if: github.ref == 'refs/heads/main'
-    needs: [build, e2e, lint]
+    needs: [build, e2e, unit, lint]
     steps:
       - uses: actions/checkout@v6
       - uses: cachix/cachix-action@v17

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -255,6 +255,7 @@ test-suite unit-tests
     Cardano.Node.Client.TxGenerator.SelectionSpec
     Cardano.Node.Client.TxGenerator.ServerSpec
     Cardano.Node.Client.TxGenerator.SnapshotSpec
+    Cardano.Node.Client.UTxOIndexer.DaemonSpec
     Cardano.Node.Client.UTxOIndexer.IndexerSpec
     Cardano.Node.Client.UTxOIndexer.PersistenceSpec
     Cardano.Node.Client.UTxOIndexer.ServerSpec

--- a/justfile
+++ b/justfile
@@ -14,9 +14,13 @@ build:
 e2e:
     cabal test e2e-tests -O0 --test-show-details=direct
 
+unit:
+    cabal test cardano-node-clients:unit-tests -O0 --test-show-details=direct
+
 ci:
     just build
     just e2e
+    just unit
     cabal-fmt -c cardano-node-clients.cabal
     find . -type f -name '*.hs' -not -path '*/dist-newstyle/*' -exec fourmolu -m check {} +
     find . -type f -name '*.hs' -not -path '*/dist-newstyle/*' -exec hlint {} +

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -1141,11 +1141,47 @@ buildWith opts pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
                             evaluateForBudget balanced0
                         case evalFailures balancedEvalResult of
                             ((purpose, msg) : _) ->
-                                pure $
-                                    Left $
-                                        EvalFailure
-                                            purpose
-                                            msg
+                                -- Balanced eval can legitimately
+                                -- fail when scripts read fee via
+                                -- 'Peek': the pre-balance eval
+                                -- saw fee=prevFee but the
+                                -- post-balance body has a fresh
+                                -- fee that violates whatever
+                                -- conservation the script was
+                                -- enforcing. The next interpret
+                                -- will re-read 'Peek' against
+                                -- the balanced body and the
+                                -- script will see the new fee,
+                                -- so iterate with 'balanced0' as
+                                -- the new prevTx. Fall through
+                                -- to a terminal error only when
+                                -- we've already seen the same
+                                -- fee before (no progress) or
+                                -- after one retry past prevFee>0
+                                -- — same shape as the
+                                -- pre-balance eval-failure path.
+                                let finalFee =
+                                        balanced0
+                                            ^. bodyTxL
+                                                . feeTxBodyL
+                                 in if Set.member finalFee seenFees
+                                        || evalRetries
+                                            >= (1 :: Int)
+                                        then
+                                            pure $
+                                                Left $
+                                                    EvalFailure
+                                                        purpose
+                                                        msg
+                                        else
+                                            step
+                                                ( Set.insert
+                                                    finalFee
+                                                    seenFees
+                                                )
+                                                (max maxFee finalFee)
+                                                (evalRetries + 1)
+                                                balanced0
                             [] ->
                                 continueAfterBalancedEval
                                     st

--- a/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
@@ -22,6 +22,7 @@ catch-up state.
 module Cardano.Node.Client.UTxOIndexer.Daemon (
     DaemonConfig (..),
     runDaemon,
+    applyUpstreamStatus,
 ) where
 
 import Cardano.Chain.Slotting (EpochSlots (..))
@@ -161,20 +162,15 @@ runDaemon tracer cfg = do
                             resumePoints
                         )
                 -- Wire the supervisor's status sink into the same
-                -- TVar that the server reads from. On
-                -- UpstreamDisconnected we also force rsReady=False
-                -- at the producer (the encoder enforces the same
-                -- invariant on the wire — defense in depth).
+                -- TVar that the server reads from. The state
+                -- transition is captured by 'applyUpstreamStatus'
+                -- (a pure function for testability — see
+                -- 'DaemonSpec.applyUpstreamStatus'). The wire
+                -- encoder enforces the same invariant as defense
+                -- in depth.
                 setUpstreamStatus newStatus =
-                    atomically $ modifyTVar' readyVar $ \rs ->
-                        case newStatus of
-                            UpstreamConnected ->
-                                rs{rsUpstream = UpstreamConnected}
-                            UpstreamDisconnected _ ->
-                                rs
-                                    { rsUpstream = newStatus
-                                    , rsReady = False
-                                    }
+                    atomically $
+                        modifyTVar' readyVar (applyUpstreamStatus cfg newStatus)
                 getProcessedSlot =
                     rsProcessedSlot <$> readTVarIO readyVar
                 chainAction =
@@ -340,6 +336,39 @@ pointToBlockHash p =
         Network.Point Network.Point.Origin -> BlockHash mempty
         Network.Point (Network.Point.At (Network.Point.Block _ h)) ->
             BlockHash (SBS.fromShort (getOneEraHash h))
+
+{- | Apply a supervisor status transition to a 'ReadyStatus'.
+
+  * @'UpstreamDisconnected' _@ → keep slot fields, force
+    @rsReady = False@.
+  * @'UpstreamConnected'@      → keep slot fields, re-derive
+    @rsReady@ from the current @rsSlotsBehind@ against
+    @dcReadyThresholdSlots@. This is what makes the daemon
+    flip back to @ready=true@ on reconnect to a chain that is
+    already at the last seen tip — without this re-derive,
+    @rsReady@ stays @False@ until the next 'rollForward'
+    fires 'updateReady' (which never happens if the chain
+    has stopped producing blocks). See issue #119.
+-}
+applyUpstreamStatus ::
+    DaemonConfig ->
+    UpstreamStatus ->
+    ReadyStatus ->
+    ReadyStatus
+applyUpstreamStatus cfg newStatus rs =
+    case newStatus of
+        UpstreamConnected ->
+            rs
+                { rsUpstream = UpstreamConnected
+                , rsReady = case rsSlotsBehind rs of
+                    Just b -> b <= dcReadyThresholdSlots cfg
+                    Nothing -> False
+                }
+        UpstreamDisconnected _ ->
+            rs
+                { rsUpstream = newStatus
+                , rsReady = False
+                }
 
 updateReady ::
     DaemonConfig ->

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -20,6 +20,16 @@ let
     '';
   };
 
+  unit = pkgs.writeShellApplication {
+    name = "unit";
+    runtimeInputs = [
+      components.tests.unit-tests
+    ];
+    text = ''
+      exec unit-tests
+    '';
+  };
+
   lint = pkgs.writeShellApplication {
     name = "lint";
     runtimeInputs = with pkgs.haskellPackages; [
@@ -36,5 +46,5 @@ let
   };
 in
 {
-  inherit build e2e lint;
+  inherit build e2e lint unit;
 }

--- a/test/Cardano/Node/Client/UTxOIndexer/DaemonSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/DaemonSpec.hs
@@ -1,0 +1,132 @@
+{- |
+Module      : Cardano.Node.Client.UTxOIndexer.DaemonSpec
+Description : Regression tests for the supervisor → ReadyStatus
+              transition in 'Cardano.Node.Client.UTxOIndexer.Daemon'.
+License     : Apache-2.0
+
+Covers issue #119: under fault injection, the supervisor flips
+@UpstreamStatus@ from @Connected@ → @Disconnected@ → @Connected@
+without any 'rollForward' in between (because the chain hasn't
+moved past the indexer's last seen tip while the relay was
+restarting). With the old asymmetric handler, @rsReady@ was
+clobbered to @False@ on disconnect and never restored on
+reconnect — the next 'updateReady' is the only writer of the
+field. This test asserts the symmetric behavior:
+
+  * disconnect clobbers @rsReady = False@, preserves slot fields
+  * reconnect re-derives @rsReady@ from @rsSlotsBehind@ against
+    @dcReadyThresholdSlots@.
+-}
+module Cardano.Node.Client.UTxOIndexer.DaemonSpec (spec) where
+
+import Cardano.Node.Client.N2C.Probe (defaultProbeConfig)
+import Cardano.Node.Client.N2C.Reconnect (
+    DisconnectInfo (..),
+    UpstreamStatus (..),
+    defaultReconnectPolicy,
+ )
+import Cardano.Node.Client.UTxOIndexer.Daemon (
+    DaemonConfig (..),
+    applyUpstreamStatus,
+ )
+import Cardano.Node.Client.UTxOIndexer.Server (ReadyStatus (..))
+import Cardano.Node.Client.UTxOIndexer.Types (SlotNo (..))
+import Data.Text qualified as Text
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec = describe "applyUpstreamStatus" $ do
+    it "Disconnected clobbers rsReady to False, preserves slot fields" $ do
+        let rs0 = caughtUp
+            rs1 = applyUpstreamStatus testCfg disconnect rs0
+        rsReady rs1 `shouldBe` False
+        rsTipSlot rs1 `shouldBe` rsTipSlot rs0
+        rsProcessedSlot rs1 `shouldBe` rsProcessedSlot rs0
+        rsSlotsBehind rs1 `shouldBe` rsSlotsBehind rs0
+        rsUpstream rs1 `shouldBe` disconnect
+
+    it "Connected re-derives rsReady=True when slotsBehind is at or under threshold" $ do
+        -- Regression for issue #119 — without the
+        -- re-derive, rsReady stayed at False after the
+        -- disconnect/reconnect cycle until the next
+        -- rollForward.
+        let rs0 = caughtUp{rsReady = False, rsUpstream = disconnect}
+            rs1 = applyUpstreamStatus testCfg UpstreamConnected rs0
+        rsReady rs1 `shouldBe` True
+        rsUpstream rs1 `shouldBe` UpstreamConnected
+        rsTipSlot rs1 `shouldBe` rsTipSlot rs0
+        rsProcessedSlot rs1 `shouldBe` rsProcessedSlot rs0
+        rsSlotsBehind rs1 `shouldBe` rsSlotsBehind rs0
+
+    it "Connected leaves rsReady=False when slotsBehind exceeds threshold" $ do
+        let rs0 =
+                caughtUp
+                    { rsReady = False
+                    , rsUpstream = disconnect
+                    , rsSlotsBehind = Just 100
+                    , rsProcessedSlot = Just (SlotNo 60)
+                    , rsTipSlot = Just (SlotNo 160)
+                    }
+            rs1 = applyUpstreamStatus testCfg UpstreamConnected rs0
+        rsReady rs1 `shouldBe` False
+        rsUpstream rs1 `shouldBe` UpstreamConnected
+        rsSlotsBehind rs1 `shouldBe` Just 100
+
+    it "Connected leaves rsReady=False when slot fields are unset (never rolled forward)" $ do
+        let rs0 =
+                ReadyStatus
+                    { rsReady = False
+                    , rsTipSlot = Nothing
+                    , rsProcessedSlot = Nothing
+                    , rsSlotsBehind = Nothing
+                    , rsUpstream = disconnect
+                    }
+            rs1 = applyUpstreamStatus testCfg UpstreamConnected rs0
+        rsReady rs1 `shouldBe` False
+        rsUpstream rs1 `shouldBe` UpstreamConnected
+
+    it "disconnect → reconnect cycle on a caught-up indexer is idempotent" $ do
+        -- The full sequence the supervisor exhibits during
+        -- a fault: connected → disconnect → connected.
+        let rs0 = caughtUp
+            rs1 = applyUpstreamStatus testCfg disconnect rs0
+            rs2 = applyUpstreamStatus testCfg UpstreamConnected rs1
+        rsReady rs0 `shouldBe` True
+        rsReady rs1 `shouldBe` False
+        rsReady rs2 `shouldBe` True
+        rsTipSlot rs2 `shouldBe` rsTipSlot rs0
+
+-- Test fixtures -----------------------------------------------------
+
+testCfg :: DaemonConfig
+testCfg =
+    DaemonConfig
+        { dcRelaySocket = "/dev/null"
+        , dcListenSocket = "/dev/null"
+        , dcNetworkMagic = 42
+        , dcByronEpochSlots = 86_400
+        , dcReadyThresholdSlots = 5
+        , dcSecurityParamK = 432
+        , dcDbPath = Nothing
+        , dcReconnectPolicy = defaultReconnectPolicy
+        , dcProbeConfig = defaultProbeConfig
+        }
+
+caughtUp :: ReadyStatus
+caughtUp =
+    ReadyStatus
+        { rsReady = True
+        , rsTipSlot = Just (SlotNo 60)
+        , rsProcessedSlot = Just (SlotNo 60)
+        , rsSlotsBehind = Just 0
+        , rsUpstream = UpstreamConnected
+        }
+
+disconnect :: UpstreamStatus
+disconnect =
+    UpstreamDisconnected
+        DisconnectInfo
+            { diReason = Text.pack "test-eviction"
+            , diAttempt = 1
+            , diSinceMs = 0
+            }

--- a/test/unit-main.hs
+++ b/test/unit-main.hs
@@ -15,6 +15,7 @@ import Cardano.Node.Client.TxGenerator.PopulationSpec qualified as TxGeneratorPo
 import Cardano.Node.Client.TxGenerator.SelectionSpec qualified as TxGeneratorSelectionSpec
 import Cardano.Node.Client.TxGenerator.ServerSpec qualified as TxGeneratorServerSpec
 import Cardano.Node.Client.TxGenerator.SnapshotSpec qualified as TxGeneratorSnapshotSpec
+import Cardano.Node.Client.UTxOIndexer.DaemonSpec qualified as UTxOIndexerDaemonSpec
 import Cardano.Node.Client.UTxOIndexer.IndexerSpec qualified as UTxOIndexerSpec
 import Cardano.Node.Client.UTxOIndexer.PersistenceSpec qualified as UTxOIndexerPersistenceSpec
 import Cardano.Node.Client.UTxOIndexer.ServerSpec qualified as UTxOIndexerServerSpec
@@ -33,6 +34,7 @@ main = hspec $ do
     UTxOIndexerSpec.spec
     UTxOIndexerServerSpec.spec
     UTxOIndexerPersistenceSpec.spec
+    UTxOIndexerDaemonSpec.spec
     N2CProbeSpec.spec
     N2CTraceSpec.spec
     TxGeneratorFanoutSpec.spec


### PR DESCRIPTION
## Summary

Two related fixes folded onto the same PR (the second was discovered while bisecting the first's red CI):

### 1. Re-derive \`rsReady\` on \`UpstreamConnected\` (closes #119)

Symptom: under fault injection, the supervisor flips \`UpstreamStatus\` Connected → Disconnected → Connected without any \`rollForward\` in between. With the previous asymmetric handler in \`Cardano.Node.Client.UTxOIndexer.Daemon.setUpstreamStatus\`, \`rsReady\` was clobbered to False on disconnect and never restored on reconnect — \`updateReady\` is the only other writer of \`rsReady\` and it only fires from \`rollForward\`. JSON output looked like \`{processedSlot:60, ready:false, slotsBehind:0, tipSlot:60}\` indefinitely.

Fix: extract the transition into a top-level pure function \`applyUpstreamStatus :: DaemonConfig -> UpstreamStatus -> ReadyStatus -> ReadyStatus\`. The \`UpstreamConnected\` branch now re-derives \`rsReady = (rsSlotsBehind <= dcReadyThresholdSlots cfg)\` from the slot fields kept current by the last pre-disconnect \`updateReady\`.

### 2. Run unit-tests in CI + close conservation regression (closes #121)

Bisecting #121 surfaced two issues:

**a) The unit-tests suite was never executed by CI.** \`nix/checks.nix\` exposed only \`build\`/\`e2e\`/\`lint\`, \`.github/workflows/ci.yml\` only ran those three, and \`just ci\` mirrored that. The \`unit-tests\` cabal stanza had 244 examples — none of them ran on PR or push. Adds a \`unit\` check, a corresponding \`unit\` job in ci.yml, and \`just unit\` / \`just ci\` recipes.

**b) Conservation regression introduced by 9db6672a (the eval-after-balance fix from PR #113).** That commit's second \`evaluateForBudget\` on the post-balance body bailed with \`Left EvalFailure\` when the balanced eval failed, instead of iterating. Scripts that read \`fee\` via \`Peek\` only see the new post-balance fee on the *next* interpret; if the script's conservation check broke under the post-balance fee, the build had to iterate one more round so \`Peek\` picks up the fresh fee. The pre-balance eval-failure path already had this retry shape; the post-balance path was missing it. Mirrors the same logic, bounded by \`seenFees\` cycle detection and the existing \`evalRetries\` cap.

## Tests

Adds \`Cardano.Node.Client.UTxOIndexer.DaemonSpec\` for issue #119 covering 5 transitions:

1. Disconnect clobbers \`rsReady=False\`, preserves slot fields ✓
2. **Reconnect with \`slotsBehind ≤ threshold\`** flips \`rsReady\` back to True ← the regression
3. Reconnect with \`slotsBehind > threshold\` leaves \`rsReady=False\`
4. Reconnect with \`rsSlotsBehind = Nothing\` (never rolled forward) leaves \`rsReady=False\`
5. disconnect → reconnect round-trip is idempotent on a caught-up indexer

The pre-existing \"fee-dependent outputs converge (conservation equation)\" test in \`TxBuildSpec\` now passes again.

\`cabal test cardano-node-clients:unit-tests\` reports **244 examples, 0 failures** on this branch (was 1 failure on \`origin/main\`).

## Test plan

- [x] \`cabal test cardano-node-clients:unit-tests\` — all 244 examples pass
- [x] \`fourmolu -m check\`, \`hlint\`, \`cabal-fmt -c cardano-node-clients.cabal\` clean
- [ ] CI green on push (will exercise the new \`unit\` job for the first time on this PR)

## Tracks

- Closes #119, closes #121
- Downstream surfacing: https://github.com/cardano-foundation/cardano-node-antithesis/pull/100