### PR TITLE
feat(040): emit Conway total_collateral and collateral_return

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,14 @@
 # cardano-node-clients-tx-builder Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-05-01
+Auto-generated from all feature plans. Last updated: 2026-05-05
 
 ## Active Technologies
 - Haskell, GHC 9.6+ (matches repo). (034-cardano-tx-generator)
 - two files in `--state-dir` (`master.seed` 32 bytes, (034-cardano-tx-generator)
 - Haskell, GHC 9.6+ (matches repo) + `cardano-ledger-conway`, `ouroboros-network`, internal `chain-follower` `Follower` abstraction, internal `N2C.Reconnect.runReconnectLoop` (PR #105) (037-tx-gen-indexer-fresh)
 - in-memory `TVar ReadyState` (no persistence change) (037-tx-gen-indexer-fresh)
+- Haskell, GHC 9.12.2 (matches existing flake-pinned toolchain). + `cardano-ledger-conway` (1.21), `cardano-ledger-babbage` (1.13, supplies `totalCollateralTxBodyL` / `collateralReturnTxBodyL`), `cardano-ledger-alonzo` (supplies `ppCollateralPercentageL`), `cardano-ledger-api` (`estimateMinFeeTx`). All are already in the closure. (040-txbuild-conway-collateral)
+- N/A — pure tx assembly; no persistence change. (040-txbuild-conway-collateral)
 
 - Haskell (GHC 9.6+, same as cardano-node-clients) + cardano-ledger-api, cardano-ledger-conway, plutus-ledger-api, plutus-tx (ToData/FromData) (003-tx-builder-dsl)
 
@@ -26,6 +28,7 @@ tests/
 Haskell (GHC 9.6+, same as cardano-node-clients): Follow standard conventions
 
 ## Recent Changes
+- 040-txbuild-conway-collateral: Added Haskell, GHC 9.12.2 (matches existing flake-pinned toolchain). + `cardano-ledger-conway` (1.21), `cardano-ledger-babbage` (1.13, supplies `totalCollateralTxBodyL` / `collateralReturnTxBodyL`), `cardano-ledger-alonzo` (supplies `ppCollateralPercentageL`), `cardano-ledger-api` (`estimateMinFeeTx`). All are already in the closure.
 - 037-tx-gen-indexer-fresh: Added Haskell, GHC 9.6+ (matches repo) + `cardano-ledger-conway`, `ouroboros-network`, internal `chain-follower` `Follower` abstraction, internal `N2C.Reconnect.runReconnectLoop` (PR #105)
 - 034-cardano-tx-generator: Added Haskell, GHC 9.6+ (matches repo).
 

--- a/lib/Cardano/Node/Client/Balance.hs
+++ b/lib/Cardano/Node/Client/Balance.hs
@@ -29,6 +29,7 @@ only folds the leftover into a single change output.
 module Cardano.Node.Client.Balance (
     -- * Balancing
     balanceTx,
+    balanceTxWith,
     BalanceResult (..),
     balanceFeeLoop,
     refScriptsSize,
@@ -45,6 +46,7 @@ module Cardano.Node.Client.Balance (
 ) where
 
 import Data.ByteString qualified as BS
+import Data.Maybe (fromMaybe)
 import Data.Sequence.Strict (StrictSeq, (|>))
 import Data.Set qualified as Set
 import Data.Word (Word32)
@@ -54,6 +56,7 @@ import Cardano.Ledger.Address (Addr)
 import Cardano.Ledger.Alonzo.PParams (
     LangDepView,
     getLanguageView,
+    ppCollateralPercentageL,
  )
 import Cardano.Ledger.Alonzo.Tx (
     ScriptIntegrity (..),
@@ -67,19 +70,27 @@ import Cardano.Ledger.Alonzo.TxWits (
 import Cardano.Ledger.Api.Tx (
     bodyTxL,
     estimateMinFeeTx,
+    witsTxL,
  )
 import Cardano.Ledger.Api.Tx.Body (
+    collateralInputsTxBodyL,
+    collateralReturnTxBodyL,
     feeTxBodyL,
     inputsTxBodyL,
     mintTxBodyL,
     outputsTxBodyL,
     referenceInputsTxBodyL,
+    totalCollateralTxBodyL,
  )
 import Cardano.Ledger.Api.Tx.Out (
     TxOut,
+    coinTxOutL,
     mkBasicTxOut,
     referenceScriptTxOutL,
     valueTxOutL,
+ )
+import Cardano.Ledger.Api.Tx.Wits (
+    rdmrsTxWitsL,
  )
 import Cardano.Ledger.BaseTypes (
     StrictMaybe (SJust, SNothing),
@@ -150,127 +161,261 @@ balanceTx ::
     -- | Unbalanced transaction
     ConwayTx ->
     Either BalanceError BalanceResult
-balanceTx pp inputUtxos refUtxos changeAddr tx =
-    let body = tx ^. bodyTxL
-        refScriptBytes =
-            refScriptsSize
-                (body ^. referenceInputsTxBodyL)
-                refUtxos
-        valueOf o = let MaryValue c m = o ^. valueTxOutL in (c, m)
-        sumValues ::
-            (Foldable t) =>
-            t (TxOut ConwayEra) ->
-            (Coin, MultiAsset)
-        sumValues =
-            foldl'
-                ( \(Coin a, ma) o ->
-                    let (Coin c, m) = valueOf o
-                     in (Coin (a + c), ma <> m)
-                )
-                (Coin 0, mempty)
-        (inputCoin, inputMA) = sumValues (map snd inputUtxos)
-        newInputs =
-            foldl'
-                (\s (tin, _) -> Set.insert tin s)
-                (body ^. inputsTxBodyL)
-                inputUtxos
-        origOutputs = body ^. outputsTxBodyL
-        -- Sum ADA / multi-assets already committed
-        -- in existing outputs (e.g. asteria + ship
-        -- outputs in a spawn-ship tx).
-        (Coin origAda, origMA) = sumValues origOutputs
-        bodyMint :: MultiAsset
-        bodyMint = body ^. mintTxBodyL
-        -- Residual multi-assets that no existing
-        -- output absorbed: input + mint − output.
-        -- A positive residual indicates minted tokens
-        -- (e.g. a PILOT NFT) or unspent input assets
-        -- that must land in the change output to
-        -- satisfy the ledger's value-conservation
-        -- equation.
-        --
-        -- Negative entries — output references assets
-        -- the balancer wasn't told about — are
-        -- filtered out: the caller has already
-        -- balanced those via inputs not surfaced in
-        -- @inputUtxos@, and the ledger checks
-        -- conservation against the real UTxO state
-        -- at submission time.
-        changeMA :: MultiAsset
-        changeMA =
-            filterMultiAsset
-                (\_ _ q -> q > 0)
-                ( inputMA
-                    <> bodyMint
-                    <> mapMaybeMultiAsset
-                        (\_ _ q -> Just (negate q))
-                        origMA
-                )
-        -- Build a candidate tx for a given fee.
-        -- Change is clamped to 0 so fee estimation
-        -- works even when funds are insufficient.
-        buildTx f =
-            let Coin avail = inputCoin
-                Coin req = f
-                change =
-                    max
-                        0
-                        (avail - req - origAda)
-                changeOut =
-                    mkBasicTxOut
-                        changeAddr
-                        (MaryValue (Coin change) changeMA)
-                finalBody =
-                    body
-                        & inputsTxBodyL
-                            .~ newInputs
-                        & outputsTxBodyL
-                            .~ ( origOutputs
-                                    |> changeOut
-                               )
-                        & feeTxBodyL .~ f
-             in tx & bodyTxL .~ finalBody
-        -- Iterate until the fee stabilises.
-        go !n currentFee
-            | n > (10 :: Int) =
-                Left FeeNotConverged
-            | otherwise =
-                let candidate =
-                        buildTx currentFee
-                    newFee =
-                        estimateMinFeeTx
-                            pp
-                            candidate
-                            1 -- key witnesses
-                            0 -- Byron witnesses
-                            refScriptBytes
-                 in if newFee <= currentFee
-                        then Right currentFee
-                        else go (n + 1) newFee
-        initFee = Coin 0
-     in case go 0 initFee of
-            Left err -> Left err
-            Right fee ->
-                let Coin available = inputCoin
-                    Coin required = fee
-                    changeAmount =
-                        available - required - origAda
-                 in if changeAmount < 0
-                        then
-                            Left
-                                ( InsufficientFee
-                                    fee
-                                    inputCoin
-                                )
-                        else
-                            let result = buildTx fee
-                                chIdx =
-                                    length origOutputs
-                             in Right
-                                    ( BalanceResult
-                                        result
-                                        chIdx
+balanceTx pp inputUtxos refUtxos changeAddr =
+    balanceTxWith pp inputUtxos [] refUtxos changeAddr Nothing
+
+{- | Like 'balanceTx', but also populates the Conway
+@total_collateral@ and @collateral_return@ body
+fields whenever the tx has at least one redeemer
+(a script witness) and at least one collateral
+input. See issue #124.
+
+The third argument is the resolution map for the
+body's @collateral_inputs@ — the TxOuts the body
+already references via 'collateral'. These UTxOs are
+NOT added to @inputs@ (they only contribute lovelace
+to the @total_collateral@ / @collateral_return@
+arithmetic). When the same UTxO is used as both a
+regular spend AND collateral, it's enough to list it
+in @inputUtxos@: this function resolves collateral
+lovelace from the union of both lists.
+
+The fourth-from-last argument is an optional
+override for the @collateral_return@ output's
+address; when 'Nothing', the change address is
+reused. When the body has no redeemers, both fields
+stay absent — this preserves existing behaviour for
+non-script flows.
+-}
+balanceTxWith ::
+    PParams ConwayEra ->
+    -- | Regular spend input UTxOs (added to the body).
+    [(TxIn, TxOut ConwayEra)] ->
+    -- | Collateral-only input UTxOs. Used to look up
+    --     lovelace for @total_collateral@ /
+    --     @collateral_return@ arithmetic; not added
+    --     to the body's @inputs@. Pass @[]@ when no
+    --     collateral resolution is needed (or when
+    --     collateral UTxOs are already in
+    --     @inputUtxos@ because they double as spends).
+    [(TxIn, TxOut ConwayEra)] ->
+    [(TxIn, TxOut ConwayEra)] ->
+    Addr ->
+    -- | Optional collateral-return address override.
+    --     When 'Nothing', the change address is reused.
+    Maybe Addr ->
+    ConwayTx ->
+    Either BalanceError BalanceResult
+balanceTxWith
+    pp
+    inputUtxos
+    collateralUtxos
+    refUtxos
+    changeAddr
+    mCollReturnAddr
+    tx =
+        let body = tx ^. bodyTxL
+            refScriptBytes =
+                refScriptsSize
+                    (body ^. referenceInputsTxBodyL)
+                    refUtxos
+            valueOf o = let MaryValue c m = o ^. valueTxOutL in (c, m)
+            sumValues ::
+                (Foldable t) =>
+                t (TxOut ConwayEra) ->
+                (Coin, MultiAsset)
+            sumValues =
+                foldl'
+                    ( \(Coin a, ma) o ->
+                        let (Coin c, m) = valueOf o
+                         in (Coin (a + c), ma <> m)
+                    )
+                    (Coin 0, mempty)
+            (inputCoin, inputMA) = sumValues (map snd inputUtxos)
+            newInputs =
+                foldl'
+                    (\s (tin, _) -> Set.insert tin s)
+                    (body ^. inputsTxBodyL)
+                    inputUtxos
+            origOutputs = body ^. outputsTxBodyL
+            -- Sum ADA / multi-assets already committed
+            -- in existing outputs (e.g. asteria + ship
+            -- outputs in a spawn-ship tx).
+            (Coin origAda, origMA) = sumValues origOutputs
+            bodyMint :: MultiAsset
+            bodyMint = body ^. mintTxBodyL
+            -- Residual multi-assets that no existing
+            -- output absorbed: input + mint − output.
+            -- A positive residual indicates minted tokens
+            -- (e.g. a PILOT NFT) or unspent input assets
+            -- that must land in the change output to
+            -- satisfy the ledger's value-conservation
+            -- equation.
+            --
+            -- Negative entries — output references assets
+            -- the balancer wasn't told about — are
+            -- filtered out: the caller has already
+            -- balanced those via inputs not surfaced in
+            -- @inputUtxos@, and the ledger checks
+            -- conservation against the real UTxO state
+            -- at submission time.
+            changeMA :: MultiAsset
+            changeMA =
+                filterMultiAsset
+                    (\_ _ q -> q > 0)
+                    ( inputMA
+                        <> bodyMint
+                        <> mapMaybeMultiAsset
+                            (\_ _ q -> Just (negate q))
+                            origMA
+                    )
+            bodyCollIns = body ^. collateralInputsTxBodyL
+            hasRedeemers =
+                let Redeemers rdmrs =
+                        tx ^. witsTxL . rdmrsTxWitsL
+                 in not (null rdmrs)
+            -- Whether the tx requires explicit Conway
+            -- collateral arithmetic (CIP-40).
+            needsCollateralFields =
+                not (Set.null bodyCollIns) && hasRedeemers
+            -- Lovelace sum of the UTxOs referenced by the
+            -- collateral input set. Resolved from the
+            -- union of @collateralUtxos@ and @inputUtxos@
+            -- (the same UTxO can legitimately appear in
+            -- both, e.g. a fee UTxO that is also offered
+            -- as collateral; 'Set'-deduplication of TxIns
+            -- via the membership test prevents
+            -- double-counting).
+            collateralLovelace =
+                let lookupSum =
+                        foldl'
+                            ( \(seen, Coin acc) (tin, o) ->
+                                if Set.member tin bodyCollIns
+                                    && not (Set.member tin seen)
+                                    then
+                                        let Coin c =
+                                                o ^. coinTxOutL
+                                         in ( Set.insert tin seen
+                                            , Coin (acc + c)
+                                            )
+                                    else (seen, Coin acc)
+                            )
+                            (Set.empty, Coin 0)
+                    (_, total) =
+                        lookupSum (collateralUtxos ++ inputUtxos)
+                 in total
+            collReturnAddr = fromMaybe changeAddr mCollReturnAddr
+            -- Compute total_collateral for a given fee:
+            -- ceil(fee × collateralPercent / 100). The
+            -- ledger requires this exact formula.
+            collateralPercent :: Integer
+            collateralPercent =
+                fromIntegral (pp ^. ppCollateralPercentageL)
+            ceilDiv a b = (a + b - 1) `div` b
+            totalCollateralFor (Coin f) =
+                Coin (ceilDiv (f * collateralPercent) 100)
+            -- Apply the Conway collateral fields to a
+            -- body (or leave them absent). Returns the
+            -- result so the fee loop can spot a shortfall
+            -- and abort.
+            applyCollateralFields f b =
+                if needsCollateralFields
+                    then
+                        let totalColl@(Coin tc) =
+                                totalCollateralFor f
+                            Coin avail = collateralLovelace
+                         in if avail < tc
+                                then
+                                    Left
+                                        ( CollateralShortfall
+                                            totalColl
+                                            collateralLovelace
+                                        )
+                                else
+                                    let returnOut =
+                                            mkBasicTxOut
+                                                collReturnAddr
+                                                ( MaryValue
+                                                    (Coin (avail - tc))
+                                                    mempty
+                                                )
+                                     in Right $
+                                            b
+                                                & totalCollateralTxBodyL
+                                                    .~ SJust totalColl
+                                                & collateralReturnTxBodyL
+                                                    .~ SJust returnOut
+                    else Right b
+            -- Build a candidate tx for a given fee.
+            -- Change is clamped to 0 so fee estimation
+            -- works even when funds are insufficient.
+            buildTx f =
+                let Coin avail = inputCoin
+                    Coin req = f
+                    change =
+                        max
+                            0
+                            (avail - req - origAda)
+                    changeOut =
+                        mkBasicTxOut
+                            changeAddr
+                            (MaryValue (Coin change) changeMA)
+                    baseBody =
+                        body
+                            & inputsTxBodyL
+                                .~ newInputs
+                            & outputsTxBodyL
+                                .~ ( origOutputs
+                                        |> changeOut
+                                   )
+                            & feeTxBodyL .~ f
+                 in case applyCollateralFields f baseBody of
+                        Left err -> Left err
+                        Right finalBody ->
+                            Right (tx & bodyTxL .~ finalBody)
+            -- Iterate until the fee stabilises.
+            go !n currentFee
+                | n > (10 :: Int) =
+                    Left FeeNotConverged
+                | otherwise =
+                    case buildTx currentFee of
+                        Left err -> Left err
+                        Right candidate ->
+                            let newFee =
+                                    estimateMinFeeTx
+                                        pp
+                                        candidate
+                                        1 -- key witnesses
+                                        0 -- Byron witnesses
+                                        refScriptBytes
+                             in if newFee <= currentFee
+                                    then Right currentFee
+                                    else go (n + 1) newFee
+            initFee = Coin 0
+         in case go 0 initFee of
+                Left err -> Left err
+                Right fee ->
+                    let Coin available = inputCoin
+                        Coin required = fee
+                        changeAmount =
+                            available - required - origAda
+                     in if changeAmount < 0
+                            then
+                                Left
+                                    ( InsufficientFee
+                                        fee
+                                        inputCoin
                                     )
+                            else case buildTx fee of
+                                Left err -> Left err
+                                Right result ->
+                                    let chIdx =
+                                            length origOutputs
+                                     in Right
+                                            ( BalanceResult
+                                                result
+                                                chIdx
+                                            )
 
 {- | Output function rejected the fee, or the
 iteration did not converge.

--- a/lib/Cardano/Node/Client/Balance.hs
+++ b/lib/Cardano/Node/Client/Balance.hs
@@ -31,6 +31,7 @@ module Cardano.Node.Client.Balance (
     balanceTx,
     balanceTxWith,
     BalanceResult (..),
+    CollateralUtxos (..),
     balanceFeeLoop,
     refScriptsSize,
 
@@ -85,6 +86,7 @@ import Cardano.Ledger.Api.Tx.Body (
 import Cardano.Ledger.Api.Tx.Out (
     TxOut,
     coinTxOutL,
+    getMinCoinTxOut,
     mkBasicTxOut,
     referenceScriptTxOutL,
     valueTxOutL,
@@ -162,7 +164,24 @@ balanceTx ::
     ConwayTx ->
     Either BalanceError BalanceResult
 balanceTx pp inputUtxos refUtxos changeAddr =
-    balanceTxWith pp inputUtxos [] refUtxos changeAddr Nothing
+    balanceTxWith
+        pp
+        inputUtxos
+        (CollateralUtxos [])
+        refUtxos
+        changeAddr
+        Nothing
+
+{- | Newtype wrapper around the resolution map for
+@collateral_inputs@. Distinct from @inputUtxos@ /
+@refUtxos@ at the type level so the three positional
+@[(TxIn, TxOut ConwayEra)]@ arguments to 'balanceTxWith'
+cannot be transposed by accident.
+-}
+newtype CollateralUtxos = CollateralUtxos
+    { unCollateralUtxos :: [(TxIn, TxOut ConwayEra)]
+    }
+    deriving (Eq, Show)
 
 {- | Like 'balanceTx', but also populates the Conway
 @total_collateral@ and @collateral_return@ body
@@ -194,11 +213,11 @@ balanceTxWith ::
     -- | Collateral-only input UTxOs. Used to look up
     --     lovelace for @total_collateral@ /
     --     @collateral_return@ arithmetic; not added
-    --     to the body's @inputs@. Pass @[]@ when no
-    --     collateral resolution is needed (or when
-    --     collateral UTxOs are already in
+    --     to the body's @inputs@. Pass @'CollateralUtxos' []@
+    --     when no collateral resolution is needed
+    --     (or when collateral UTxOs are already in
     --     @inputUtxos@ because they double as spends).
-    [(TxIn, TxOut ConwayEra)] ->
+    CollateralUtxos ->
     [(TxIn, TxOut ConwayEra)] ->
     Addr ->
     -- | Optional collateral-return address override.
@@ -209,7 +228,7 @@ balanceTxWith ::
 balanceTxWith
     pp
     inputUtxos
-    collateralUtxos
+    (CollateralUtxos collateralUtxos)
     refUtxos
     changeAddr
     mCollReturnAddr
@@ -318,33 +337,69 @@ balanceTxWith
             -- body (or leave them absent). Returns the
             -- result so the fee loop can spot a shortfall
             -- and abort.
+            --
+            -- Edge cases the ledger imposes:
+            --   * @collateral_return@, when present, is
+            --     subject to @minUtxo@ like any output;
+            --     a tiny residual would be rejected with
+            --     @BabbageOutputTooSmallUTxO@.
+            --   * @total_collateral@ is a floor, not an
+            --     exact amount — paying more is allowed.
+            --
+            -- So when the residual @avail − tc@ is below
+            -- @minUtxo@, we fold it into @total_collateral@
+            -- (consume the entire collateral, no return).
+            -- This mirrors @cardano-cli transaction build@.
             applyCollateralFields f b =
                 if needsCollateralFields
                     then
-                        let totalColl@(Coin tc) =
+                        let requiredTc@(Coin tc) =
                                 totalCollateralFor f
                             Coin avail = collateralLovelace
+                            tentativeReturn residualCoin =
+                                mkBasicTxOut
+                                    collReturnAddr
+                                    ( MaryValue
+                                        residualCoin
+                                        mempty
+                                    )
+                            residual = Coin (avail - tc)
+                            minReturn =
+                                getMinCoinTxOut
+                                    pp
+                                    (tentativeReturn residual)
                          in if avail < tc
                                 then
                                     Left
                                         ( CollateralShortfall
-                                            totalColl
+                                            requiredTc
                                             collateralLovelace
                                         )
                                 else
-                                    let returnOut =
-                                            mkBasicTxOut
-                                                collReturnAddr
-                                                ( MaryValue
-                                                    (Coin (avail - tc))
-                                                    mempty
-                                                )
-                                     in Right $
-                                            b
-                                                & totalCollateralTxBodyL
-                                                    .~ SJust totalColl
-                                                & collateralReturnTxBodyL
-                                                    .~ SJust returnOut
+                                    if residual == Coin 0
+                                        || residual < minReturn
+                                        then
+                                            -- Cannot emit a
+                                            -- min-UTxO-valid
+                                            -- collateral_return:
+                                            -- consume the
+                                            -- entire collateral
+                                            -- input set as
+                                            -- total_collateral.
+                                            Right $
+                                                b
+                                                    & totalCollateralTxBodyL
+                                                        .~ SJust collateralLovelace
+                                                    & collateralReturnTxBodyL
+                                                        .~ SNothing
+                                        else
+                                            Right $
+                                                b
+                                                    & totalCollateralTxBodyL
+                                                        .~ SJust requiredTc
+                                                    & collateralReturnTxBodyL
+                                                        .~ SJust
+                                                            (tentativeReturn residual)
                     else Right b
             -- Build a candidate tx for a given fee.
             -- Change is clamped to 0 so fee estimation
@@ -373,7 +428,10 @@ balanceTxWith
                         Left err -> Left err
                         Right finalBody ->
                             Right (tx & bodyTxL .~ finalBody)
-            -- Iterate until the fee stabilises.
+            -- Iterate until the fee stabilises. Returns
+            -- the converged fee and the final candidate
+            -- so the post-loop block reuses it instead
+            -- of calling 'buildTx' once more.
             go !n currentFee
                 | n > (10 :: Int) =
                     Left FeeNotConverged
@@ -389,12 +447,14 @@ balanceTxWith
                                         0 -- Byron witnesses
                                         refScriptBytes
                              in if newFee <= currentFee
-                                    then Right currentFee
+                                    then
+                                        Right
+                                            (currentFee, candidate)
                                     else go (n + 1) newFee
             initFee = Coin 0
          in case go 0 initFee of
                 Left err -> Left err
-                Right fee ->
+                Right (fee, result) ->
                     let Coin available = inputCoin
                         Coin required = fee
                         changeAmount =
@@ -406,16 +466,12 @@ balanceTxWith
                                         fee
                                         inputCoin
                                     )
-                            else case buildTx fee of
-                                Left err -> Left err
-                                Right result ->
-                                    let chIdx =
-                                            length origOutputs
-                                     in Right
-                                            ( BalanceResult
-                                                result
-                                                chIdx
-                                            )
+                            else
+                                Right
+                                    ( BalanceResult
+                                        result
+                                        (length origOutputs)
+                                    )
 
 {- | Output function rejected the fee, or the
 iteration did not converge.

--- a/lib/Cardano/Node/Client/Balance.hs
+++ b/lib/Cardano/Node/Client/Balance.hs
@@ -114,6 +114,10 @@ data BalanceError
       InsufficientFee !Coin !Coin
     | -- | Fee did not converge within 10 iterations.
       FeeNotConverged
+    | -- | Collateral inputs supply less lovelace than the
+      --   protocol-required @ceil(fee × collateralPercent / 100)@.
+      --   Carries @(required, available)@.
+      CollateralShortfall !Coin !Coin
     deriving (Eq, Show)
 
 {- | Balance a transaction by adding input UTxOs

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -59,6 +59,7 @@ module Cardano.Node.Client.TxBuild (
     -- * Constraints
     validFrom,
     validTo,
+    setCollateralReturn,
     requireSignature,
     attachScript,
 
@@ -195,7 +196,7 @@ import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Node.Client.Balance (
     BalanceError,
     BalanceResult (..),
-    balanceTx,
+    balanceTxWith,
     computeScriptIntegrity,
     evalBudgetExUnits,
     refScriptsSize,
@@ -470,6 +471,23 @@ validFrom = singleton . SetValidFrom
 -- | Set the upper validity bound.
 validTo :: SlotNo -> TxBuild q e ()
 validTo = singleton . SetValidTo
+
+{- | Override the address that receives the
+collateral-return output emitted by 'build' for
+script-bearing Conway txs.
+
+Defaults to the @changeAddr@ argument of 'build'
+when the program never calls this combinator.
+Last-write-wins: calling this multiple times keeps
+only the final address, matching 'validFrom' /
+'validTo'.
+
+For non-script txs (no redeemers) this combinator
+has no effect: 'build' does not emit
+@collateral_return@ regardless. See issue #124.
+-}
+setCollateralReturn :: Addr -> TxBuild q e ()
+setCollateralReturn = singleton . SetCollReturn
 
 -- | Require a key signature.
 requireSignature ::
@@ -891,7 +909,7 @@ the Tx body stabilizes:
 will be added here without breaking 'build', whose
 default behaviour is preserved by 'defaultBuildOptions'.
 -}
-newtype BuildOptions = BuildOptions
+data BuildOptions = BuildOptions
     { boExUnitsMargin :: ExUnits -> ExUnits
     -- ^ Transform each redeemer's evaluated 'ExUnits'
     -- before the integrity hash is recomputed and the
@@ -906,11 +924,30 @@ newtype BuildOptions = BuildOptions
     -- newer side, and that delta lands as
     -- 'PlutusFailure' at submit time even though the
     -- shape of the tx is correct.
+    , boCollateralUtxos :: [(TxIn, TxOut ConwayEra)]
+    -- ^ Resolution map for the body's collateral
+    -- inputs (issue #124). Used to compute the
+    -- @total_collateral@ / @collateral_return@
+    -- arithmetic during balancing. These UTxOs are
+    -- NOT added to the body's @inputs@ — they only
+    -- contribute lovelace to the collateral fields.
+    --
+    -- Pass @[]@ (the default) when the program uses
+    -- the same UTxO for both a regular @spend@ and a
+    -- @collateral@ instruction, since 'inputUtxos'
+    -- already covers both lookups in that case.
+    -- Pass the collateral-only UTxOs here when the
+    -- collateral inputs are different from the
+    -- regular spend inputs.
     }
 
 -- | All defaults preserve pre-'buildWith' behaviour.
 defaultBuildOptions :: BuildOptions
-defaultBuildOptions = BuildOptions{boExUnitsMargin = id}
+defaultBuildOptions =
+    BuildOptions
+        { boExUnitsMargin = id
+        , boCollateralUtxos = []
+        }
 
 build ::
     PParams ConwayEra ->
@@ -1019,12 +1056,23 @@ buildWith opts pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
             Map.toList evalResult
         ]
 
-    balanceWithEval tx evalResult =
-        balanceTx
+    -- \| Resolve the collateral-return override
+    -- address from interpreter state. Threaded into
+    -- 'balanceTxWith' so the Conway @collateral_return@
+    -- output's address respects 'setCollateralReturn'
+    -- when the caller used it.
+    collReturnFor st = case tsCollReturnAddr st of
+        SJust a -> Just a
+        SNothing -> Nothing
+
+    balanceWithEval st tx evalResult =
+        balanceTxWith
             pp
             inputUtxos
+            (boCollateralUtxos opts)
             refUtxos
             changeAddr
+            (collReturnFor st)
             (patchExUnits tx evalResult)
 
     -- \| One iteration: interpret, assemble, eval,
@@ -1090,11 +1138,13 @@ buildWith opts pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
                                         patchExUnits
                                             tx
                                             prevEUs
-                                case balanceTx
+                                case balanceTxWith
                                     pp
                                     inputUtxos
+                                    (boCollateralUtxos opts)
                                     refUtxos
                                     changeAddr
+                                    (collReturnFor st)
                                     patchedTx of
                                     Left err ->
                                         pure $
@@ -1143,7 +1193,7 @@ buildWith opts pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
                 --    pre-balance evaluation, then
                 --    evaluate the balanced body that
                 --    validators will actually see.
-                case balanceWithEval tx evalResult of
+                case balanceWithEval st tx evalResult of
                     Left err ->
                         pure $
                             Left $
@@ -1217,7 +1267,7 @@ buildWith opts pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
             -- again so fee and change account for
             -- those final costs without appending a
             -- second change output.
-            case balanceWithEval tx balancedEvalResult of
+            case balanceWithEval st tx balancedEvalResult of
                 Left err ->
                     pure $
                         Left $
@@ -1345,11 +1395,13 @@ buildWith opts pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
                                 & bodyTxL . feeTxBodyL
                                     .~ mid
                     -- Balance to get change output
-                    case balanceTx
+                    case balanceTxWith
                         pp
                         inputUtxos
+                        (boCollateralUtxos opts)
                         refUtxos
                         changeAddr
+                        (collReturnFor st')
                         tx' of
                         Left _ ->
                             -- Can't balance at mid
@@ -1420,11 +1472,13 @@ buildWith opts pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
                     & bodyTxL . feeTxBodyL .~ fee
             patched =
                 patchExUnits tx' evalResult
-        case balanceTx
+        case balanceTxWith
             pp
             inputUtxos
+            (boCollateralUtxos opts)
             refUtxos
             changeAddr
+            (collReturnFor st')
             patched of
             Left err ->
                 pure $ Left $ BalanceFailed err

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -161,6 +161,7 @@ import Cardano.Ledger.Api.Tx.Wits (
  )
 import Cardano.Ledger.BaseTypes (
     StrictMaybe (SJust, SNothing),
+    strictMaybeToMaybe,
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
@@ -196,6 +197,7 @@ import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Node.Client.Balance (
     BalanceError,
     BalanceResult (..),
+    CollateralUtxos (..),
     balanceTxWith,
     computeScriptIntegrity,
     evalBudgetExUnits,
@@ -924,7 +926,7 @@ data BuildOptions = BuildOptions
     -- newer side, and that delta lands as
     -- 'PlutusFailure' at submit time even though the
     -- shape of the tx is correct.
-    , boCollateralUtxos :: [(TxIn, TxOut ConwayEra)]
+    , boCollateralUtxos :: CollateralUtxos
     -- ^ Resolution map for the body's collateral
     -- inputs (issue #124). Used to compute the
     -- @total_collateral@ / @collateral_return@
@@ -932,13 +934,17 @@ data BuildOptions = BuildOptions
     -- NOT added to the body's @inputs@ — they only
     -- contribute lovelace to the collateral fields.
     --
-    -- Pass @[]@ (the default) when the program uses
-    -- the same UTxO for both a regular @spend@ and a
-    -- @collateral@ instruction, since 'inputUtxos'
-    -- already covers both lookups in that case.
-    -- Pass the collateral-only UTxOs here when the
-    -- collateral inputs are different from the
-    -- regular spend inputs.
+    -- Pass @CollateralUtxos []@ (the default) when
+    -- the program uses the same UTxO for both a
+    -- regular @spend@ and a @collateral@ instruction,
+    -- since 'inputUtxos' already covers both lookups
+    -- in that case. Pass the collateral-only UTxOs
+    -- here when the collateral inputs are different
+    -- from the regular spend inputs.
+    --
+    -- This field is input data rather than a tunable
+    -- knob; it lives here for backwards compatibility
+    -- with the @build@ / @buildWith@ signatures.
     }
 
 -- | All defaults preserve pre-'buildWith' behaviour.
@@ -946,7 +952,7 @@ defaultBuildOptions :: BuildOptions
 defaultBuildOptions =
     BuildOptions
         { boExUnitsMargin = id
-        , boCollateralUtxos = []
+        , boCollateralUtxos = CollateralUtxos []
         }
 
 build ::
@@ -1056,15 +1062,6 @@ buildWith opts pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
             Map.toList evalResult
         ]
 
-    -- \| Resolve the collateral-return override
-    -- address from interpreter state. Threaded into
-    -- 'balanceTxWith' so the Conway @collateral_return@
-    -- output's address respects 'setCollateralReturn'
-    -- when the caller used it.
-    collReturnFor st = case tsCollReturnAddr st of
-        SJust a -> Just a
-        SNothing -> Nothing
-
     balanceWithEval st tx evalResult =
         balanceTxWith
             pp
@@ -1072,7 +1069,7 @@ buildWith opts pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
             (boCollateralUtxos opts)
             refUtxos
             changeAddr
-            (collReturnFor st)
+            (strictMaybeToMaybe (tsCollReturnAddr st))
             (patchExUnits tx evalResult)
 
     -- \| One iteration: interpret, assemble, eval,
@@ -1144,7 +1141,7 @@ buildWith opts pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
                                     (boCollateralUtxos opts)
                                     refUtxos
                                     changeAddr
-                                    (collReturnFor st)
+                                    (strictMaybeToMaybe (tsCollReturnAddr st))
                                     patchedTx of
                                     Left err ->
                                         pure $
@@ -1401,7 +1398,7 @@ buildWith opts pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
                         (boCollateralUtxos opts)
                         refUtxos
                         changeAddr
-                        (collReturnFor st')
+                        (strictMaybeToMaybe (tsCollReturnAddr st'))
                         tx' of
                         Left _ ->
                             -- Can't balance at mid
@@ -1478,7 +1475,7 @@ buildWith opts pp interpret evaluateTx inputUtxos refUtxos changeAddr prog =
             (boCollateralUtxos opts)
             refUtxos
             changeAddr
-            (collReturnFor st')
+            (strictMaybeToMaybe (tsCollReturnAddr st'))
             patched of
             Left err ->
                 pure $ Left $ BalanceFailed err

--- a/lib/Cardano/Node/Client/TxBuild.hs
+++ b/lib/Cardano/Node/Client/TxBuild.hs
@@ -313,6 +313,9 @@ data TxInstr q e a where
     SetValidFrom :: SlotNo -> TxInstr q e ()
     -- | Set the upper validity bound.
     SetValidTo :: SlotNo -> TxInstr q e ()
+    -- | Override the address that receives the
+    --     collateral-return output. Last-write-wins.
+    SetCollReturn :: Addr -> TxInstr q e ()
     -- | Peek at the final Tx (fixpoint).
     Peek ::
         (ConwayTx -> Convergence a) ->
@@ -556,6 +559,7 @@ data TxState e = TxState
         Map ScriptHash (Script ConwayEra)
     , tsValidFrom :: StrictMaybe SlotNo
     , tsValidTo :: StrictMaybe SlotNo
+    , tsCollReturnAddr :: StrictMaybe Addr
     , tsChecks :: [ConwayTx -> Check e]
     }
 
@@ -573,6 +577,7 @@ emptyState =
         , tsScripts = Map.empty
         , tsValidFrom = SNothing
         , tsValidTo = SNothing
+        , tsCollReturnAddr = SNothing
         , tsChecks = []
         }
 
@@ -693,6 +698,13 @@ interpretWithM runCtx currentTx = go emptyState True
             go
                 st
                     { tsValidTo = SJust slot
+                    }
+                conv
+                (k ())
+        SetCollReturn addr :>>= k ->
+            go
+                st
+                    { tsCollReturnAddr = SJust addr
                     }
                 conv
                 (k ())

--- a/specs/040-txbuild-conway-collateral/checklists/requirements.md
+++ b/specs/040-txbuild-conway-collateral/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: TxBuild Conway collateral fields
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec is technical-by-domain (Conway CBOR keys, ledger types) but those are surface-level vocabulary — none of the FRs prescribe a Haskell module layout, lens names, or call sites. The plan phase will translate these into concrete code touchpoints (`TxInstr`, `TxState`, `assembleTxWith`, `Balance.hs`).
+- `setCollateralReturn :: Addr -> TxBuild q e ()` is mentioned because it's a contract surface, not an implementation detail — it's the only caller-visible API addition and must be agreed before implementation.

--- a/specs/040-txbuild-conway-collateral/contracts/txbuild-api.md
+++ b/specs/040-txbuild-conway-collateral/contracts/txbuild-api.md
@@ -1,0 +1,99 @@
+# Contract: TxBuild caller-facing API
+
+**Feature**: [spec.md](../spec.md). Issue: [#124](https://github.com/lambdasistemi/cardano-node-clients/issues/124).
+
+## New public symbols
+
+```haskell
+module Cardano.Node.Client.TxBuild where
+
+-- | Set the address that receives the collateral-return output.
+--
+--   Only meaningful for Conway txs that have script witnesses
+--   and at least one collateral input. Ignored otherwise (a
+--   non-script tx never emits @collateral_return@ regardless).
+--
+--   If never called, defaults to the @changeAddr@ argument of
+--   'build' / 'buildWith'.
+--
+--   Last-write-wins: calling this multiple times keeps only the
+--   final address, matching 'setValidFrom' / 'setValidTo'.
+setCollateralReturn :: Addr -> TxBuild q e ()
+```
+
+## New error case
+
+```haskell
+module Cardano.Node.Client.Balance where
+
+data BalanceError
+  = ...
+  | -- | The collateral inputs supply less lovelace than the
+    --   protocol-required @ceil(fee × collateralPercent / 100)@.
+    --   Carries (required, available).
+    CollateralShortfall !Coin !Coin
+  ...
+```
+
+This propagates through `BuildError` via the existing `BalanceFailed` constructor; no new `BuildError` constructor is needed.
+
+## Unchanged signatures
+
+`build` and `buildWith` keep their existing signatures verbatim:
+
+```haskell
+build ::
+    PParams ConwayEra ->
+    InterpretIO q ->
+    (ConwayTx -> IO (Map (ConwayPlutusPurpose AsIx ConwayEra) (Either String ExUnits))) ->
+    [(TxIn, TxOut ConwayEra)] ->
+    [(TxIn, TxOut ConwayEra)] ->
+    Addr ->
+    TxBuild q e a ->
+    IO (Either (BuildError e) ConwayTx)
+
+buildWith ::
+    BuildOptions ->
+    PParams ConwayEra ->
+    InterpretIO q ->
+    (ConwayTx -> IO (Map (ConwayPlutusPurpose AsIx ConwayEra) (Either String ExUnits))) ->
+    [(TxIn, TxOut ConwayEra)] ->
+    [(TxIn, TxOut ConwayEra)] ->
+    Addr ->
+    TxBuild q e a ->
+    IO (Either (BuildError e) ConwayTx)
+```
+
+The semantic change is post-balancing the body now contains `total_collateral` / `collateral_return` whenever the program has redeemers + at least one `collateral txIn`.
+
+## Internal-only signature change (acceptable)
+
+`Cardano.Node.Client.Balance.balanceTx` gains one parameter:
+
+```haskell
+balanceTx ::
+    PParams ConwayEra ->
+    [(TxIn, TxOut ConwayEra)] ->
+    [(TxIn, TxOut ConwayEra)] ->
+    Addr ->
+    Maybe Addr ->                  -- NEW: optional collateral-return address override
+    ConwayTx ->
+    Either BalanceError BalanceResult
+```
+
+`balanceTx` is exported (`Cardano.Node.Client.Balance` re-exports it), but no external caller currently invokes it directly — `buildWith` is the only consumer. To avoid an unnecessary breaking change for any out-of-tree consumer, we will:
+
+1. Rename the new function to `balanceTxWithCollateral` (or add the override parameter as a record-shaped `BalanceCollateral` config).
+2. Keep `balanceTx :: ... -> Either BalanceError BalanceResult` (5-arg) as a thin wrapper that passes `Nothing`.
+
+Final shape will be confirmed in `tasks.md` (Phase 2) once the implementation order is fixed.
+
+## Backwards compatibility
+
+| Surface | Change | Compatibility |
+|---------|--------|---------------|
+| `setCollateralReturn` | Added | New — no compat impact |
+| `BalanceError` | New constructor | Source-compatible; non-exhaustive pattern matches will warn |
+| `build`/`buildWith` | Same signatures | Wire-compatible; behaviour now produces different body bytes for **script-bearing txs only** |
+| `balanceTx` | Optional new param via wrapper | Source-compatible (5-arg form preserved) |
+| Non-script tx output | Unchanged | Byte-identical (SC-005) |

--- a/specs/040-txbuild-conway-collateral/data-model.md
+++ b/specs/040-txbuild-conway-collateral/data-model.md
@@ -1,0 +1,98 @@
+# Data Model: TxBuild Conway collateral fields
+
+**Feature**: [spec.md](./spec.md). Implementation plan: [plan.md](./plan.md).
+
+## Changed types
+
+### `TxInstr q e a` (in `lib/Cardano/Node/Client/TxBuild.hs`)
+
+Add one constructor:
+
+```haskell
+-- | Override the address for the collateral-return output.
+SetCollReturn :: Addr -> TxInstr q e ()
+```
+
+Existing constructors are unchanged.
+
+### `TxState e` (in `lib/Cardano/Node/Client/TxBuild.hs`)
+
+Add one field:
+
+```haskell
+data TxState e = TxState
+  { ...
+  , tsCollReturnAddr :: StrictMaybe Addr   -- NEW; default: SNothing
+  , ...
+  }
+```
+
+`emptyState` initialises it to `SNothing`. `interpretWithM`'s `SetCollReturn addr :>>= k` branch sets it to `SJust addr` (last-write-wins, matching the existing `SetValidFrom` / `SetValidTo` pattern).
+
+### `BalanceError` (in `lib/Cardano/Node/Client/Balance.hs`)
+
+Add one constructor:
+
+```haskell
+data BalanceError
+  = ...
+  | CollateralShortfall !Coin !Coin
+  --   ^ required total_collateral ^ available sum(collateral_input.lovelace)
+  ...
+```
+
+Existing constructors and the `Eq`/`Show` derivations are unchanged.
+
+## Unchanged but referenced
+
+These types are part of the contract but receive no field-level changes:
+
+- `BalanceResult { balancedTx, changeIndex }` — same shape; the balanced tx now carries the new body fields when applicable.
+- `BuildError e` — `BalanceFailed BalanceError` automatically covers the new `CollateralShortfall` case.
+- `BuildOptions` — no new knobs.
+- `Cardano.Node.Client.Ledger.ConwayTx` — same era; the new fields live on the body via the existing ledger lenses (`totalCollateralTxBodyL`, `collateralReturnTxBodyL`).
+
+## Validation rules
+
+| Rule | Source | Enforcement point |
+|------|--------|-------------------|
+| If body has no redeemers → both new fields absent | FR-008 | `balanceTx` post-`buildTx` step |
+| If body has redeemers AND collateral inputs → both new fields present | FR-001, FR-003 | `balanceTx` post-`buildTx` step |
+| `total_collateral = ceil(fee × collateralPercent / 100)` | FR-002 | `balanceTx` per-iteration recompute |
+| `collateral_return.value = sum(collateral_input.lovelace) − total_collateral` (lovelace only) | FR-004 | `balanceTx` per-iteration recompute |
+| Address = `tsCollReturnAddr` if set, else `changeAddr` | FR-005 | `buildWith` resolves and passes to `balanceTx` |
+| `sum(coll input lovelace) ≥ total_collateral` | FR-009 | `balanceTx` aborts with `CollateralShortfall` otherwise |
+| Last `setCollateralReturn` wins | FR-010 | Interpreter assigns `SJust addr` unconditionally |
+
+## Helpers (private)
+
+Two small private helpers in `Balance.hs`:
+
+```haskell
+-- | Compute total_collateral and the lovelace-balanced collateral_return.
+--   Returns Nothing when the body has no redeemers (no fields to emit).
+deriveCollateralFields ::
+  PParams ConwayEra ->
+  [(TxIn, TxOut ConwayEra)] ->   -- inputUtxos
+  Addr ->                         -- effective return addr
+  Coin ->                         -- balanced fee
+  ConwayTx ->
+  Either BalanceError (Maybe (Coin, TxOut ConwayEra))
+```
+
+```haskell
+-- | Sum the lovelace coins of UTxOs whose TxIn is in the given set.
+lookupCollateralLovelace ::
+  Set TxIn ->
+  [(TxIn, TxOut ConwayEra)] ->
+  Coin
+```
+
+These are private to `Balance.hs` (not exported) — they exist only to keep the per-iteration loop body legible.
+
+## Migration / compatibility
+
+- **Wire format**: Conway tx body grows two optional fields when applicable. Bodies for non-script txs are byte-identical to today's output.
+- **API**: One additive function (`setCollateralReturn`). One additive constructor on `BalanceError`. No removed or renamed symbols.
+- **Persistence**: None — the library does not persist tx state.
+- **Downstream consumers**: A consumer that pattern-matches on `BalanceError` exhaustively will get a non-exhaustive-pattern warning until they handle `CollateralShortfall`. This is desired (consumers currently treat the absence of this error as silent success).

--- a/specs/040-txbuild-conway-collateral/plan.md
+++ b/specs/040-txbuild-conway-collateral/plan.md
@@ -1,0 +1,157 @@
+# Implementation Plan: TxBuild Conway collateral fields
+
+**Branch**: `040-txbuild-conway-collateral` | **Date**: 2026-05-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from [spec.md](./spec.md). Source issue: [#124](https://github.com/lambdasistemi/cardano-node-clients/issues/124).
+
+## Summary
+
+Wire `total_collateral` and `collateral_return` into the body produced by `Cardano.Node.Client.TxBuild.build`. The values are mandatory for any Conway tx that has script witnesses + collateral inputs and the chain rejects bodies that omit them. `total_collateral = ceil(fee × collateralPercent / 100)` and `collateral_return.value.coin = sum(collateral_input.lovelace) − total_collateral` are fully derived during balancing; only the return *address* is caller-overridable through a new `setCollateralReturn :: Addr -> TxBuild q e ()` combinator (default: the existing change address).
+
+The work touches three layers:
+1. `TxBuild` DSL: one new `TxInstr`, one new smart constructor, one new `TxState` field.
+2. `Balance.balanceTx`: extend the fee fixpoint to re-derive both fields per iteration so `estimateMinFeeTx` accounts for their CBOR bytes (currently 76 missing bytes ≈ 3344 lovelace shortfall).
+3. Tests: extend the existing `TxBuildSpec` (unit) and `E2E/TxBuildSpec` / `MultiAssetChangeSpec` (e2e) coverage to assert the body shape and chain acceptance.
+
+## Technical Context
+
+**Language/Version**: Haskell, GHC 9.12.2 (matches existing flake-pinned toolchain).
+**Primary Dependencies**: `cardano-ledger-conway` (1.21), `cardano-ledger-babbage` (1.13, supplies `totalCollateralTxBodyL` / `collateralReturnTxBodyL`), `cardano-ledger-alonzo` (supplies `ppCollateralPercentageL`), `cardano-ledger-api` (`estimateMinFeeTx`). All are already in the closure.
+**Storage**: N/A — pure tx assembly; no persistence change.
+**Testing**: HSpec (unit + e2e). E2E tests run against a local Conway devnet (`Cardano.Node.Client.Devnet.withCardanoNode`).
+**Target Platform**: Linux dev/CI (NixOS / `nix develop`). No platform-specific code.
+**Project Type**: Library (`cardano-node-clients`) — single project layout under `lib/` + `test/`.
+**Performance Goals**: The fee fixpoint already converges in 2–3 rounds and caps at 10. Adding two fields whose sizes are bounded by ~10 bytes each must not change this convergence.
+**Constraints**: No new caller-facing breaking changes beyond the additive `setCollateralReturn`. Existing non-script flows (golden vectors, `TxBuildGoldenSpec`) must produce byte-identical output (covered by SC-005).
+**Scale/Scope**: Library-internal change. Affects every downstream consumer that builds script-bearing Conway txs (currently: `amaru-treasury-tx`, internal Plutus flows).
+
+## Constitution Check
+
+Constitution principles ([memory/constitution.md](../../.specify/memory/constitution.md)):
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Channel-Driven N2C Clients | ✅ N/A | This feature touches the pure tx-assembly layer, not the channel layer. |
+| II. Devnet E2E Testing | ✅ | New e2e coverage runs against `withCardanoNode` like every other E2E test. No mocking. |
+| III. Minimal Dependencies | ✅ | Only adds one extra import (`ppCollateralPercentageL` from `cardano-ledger-alonzo`, already in the closure). No new packages. |
+| IV. Test Utilities Are First-Class | ✅ | Any test helper introduced (e.g. a shared "build a script-bearing tx" fixture) lives under the test library so other consumers can reuse it. |
+
+Quality gates (`just ci` passes, e2e runs against real devnet, no mocks): all enforceable, no exceptions requested.
+
+**Result**: PASS. No constitutional violations. Complexity Tracking section omitted.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/040-txbuild-conway-collateral/
+├── plan.md                # This file
+├── spec.md                # Feature spec
+├── research.md            # Phase 0 output
+├── data-model.md          # Phase 1 output
+├── quickstart.md          # Phase 1 output
+├── contracts/
+│   └── txbuild-api.md     # The single new caller-facing contract: setCollateralReturn
+├── checklists/
+│   └── requirements.md    # Spec-quality validation
+└── tasks.md               # Created later by /speckit.tasks
+```
+
+### Source Code (repository root)
+
+```text
+lib/
+└── Cardano/
+    └── Node/
+        └── Client/
+            ├── TxBuild.hs       # ← modify: TxInstr, smart constructor, TxState, buildWith wiring
+            └── Balance.hs       # ← modify: extend balanceTx fee fixpoint with collateral derivation
+
+test/
+└── Cardano/
+    └── Node/
+        └── Client/
+            ├── TxBuildSpec.hs              # ← extend: assert body shape for new code paths
+            ├── TxBuildGoldenSpec.hs        # ← may need new vectors for script-bearing txs
+            └── E2E/
+                ├── TxBuildSpec.hs          # ← extend: end-to-end script tx that previously failed
+                └── MultiAssetChangeSpec.hs # ← already exercises collateral; assert new fields appear
+```
+
+**Structure Decision**: Single-project library layout (the existing one). All changes confined to `lib/Cardano/Node/Client/{TxBuild,Balance}.hs` and the corresponding test modules. No new modules.
+
+## Phase 0: Outline & Research
+
+See [research.md](./research.md) for the full record. Open questions resolved:
+
+1. **Where does the lovelace sum of collateral inputs come from?** — Resolved. The `inputUtxos` argument already passed into `buildWith` and `balanceTx` is the resolved `[(TxIn, TxOut)]` map for *all* inputs the tx may reference (regular spends + collateral). Existing tests (`MultiAssetChangeSpec`) confirm the convention: `collateral seedIn` and `spend seedIn` reference the same UTxO, and the caller passes that single resolved UTxO once via `inputUtxos`. Lookup at balancing time: filter `inputUtxos` by `body ^. collateralInputsTxBodyL`, sum `coinTxOutL`.
+
+2. **Should collateral arithmetic live inside `balanceTx` or in `buildWith`?** — Resolved. Inside `balanceTx`. The fields' sizes interact with the fee fixpoint, and putting them outside the loop would require a redundant second pass. `balanceTx` already takes `pp` (for `collateralPercent`) and `inputUtxos` (for the lovelace sum); it just needs a way to know the desired return address.
+
+3. **How does `balanceTx` learn the collateral-return address?** — Resolved. Add a single new `Maybe Addr` parameter (`mCollReturnOverride`) to `balanceTx`. When `Nothing`, fall back to the `changeAddr` already passed in. `buildWith` derives this from `tsCollReturnAddr`.
+
+4. **Convergence safety**: extending the fixpoint to also re-derive `total_collateral` and `collateral_return.value` per iteration. — Resolved. The CBOR sizes of both fields are bounded (≤ 10 bytes each across the entire range of fees and collateral sums on mainnet). Each fee delta `Δf` propagates a bounded `Δsize`, which in turn changes the next-iteration fee by `≪ Δf`. Existing 10-iteration cap stays sufficient.
+
+5. **What if the body has scripts but collateral inputs are missing?** — Resolved. The existing chain rejection path is preserved; this feature does not synthesise inputs (FR scope already excludes this).
+
+## Phase 1: Design & Contracts
+
+### Data model changes ([data-model.md](./data-model.md))
+
+- `TxInstr q e a` — add a constructor `SetCollReturn :: Addr -> TxInstr q e ()`.
+- `TxState e` — add field `tsCollReturnAddr :: StrictMaybe Addr` (last-write-wins, like `tsValidFrom`/`tsValidTo`). Default: `SNothing`.
+- `BalanceError` — add `CollateralShortfall !Coin !Coin` (required total-collateral, available collateral-input sum) for the FR-009 case.
+- No changes to `BalanceResult`, `BuildError`, `BuildOptions`.
+
+### Caller-facing contract ([contracts/txbuild-api.md](./contracts/txbuild-api.md))
+
+The single new public symbol:
+
+```haskell
+-- | Set the address that receives the collateral-return output.
+--   If never called, defaults to the change address passed to 'build'.
+--   Last-write-wins: calling this multiple times keeps only the final address.
+setCollateralReturn :: Addr -> TxBuild q e ()
+```
+
+No other public-API change. `build` and `buildWith` keep their existing signatures.
+
+### Algorithm sketch (no code, semantics only)
+
+Inside the existing `balanceTx` fee fixpoint loop, after each `buildTx fee`:
+
+```text
+if body has at least one redeemer AND at least one collateral input:
+  totalCollateralCoin = ceil(fee * collateralPercent / 100)
+  collIns       = body.collateralInputs        -- Set TxIn
+  collInLovelace = sum [coinTxOutL of inputUtxos[i] for i in collIns]
+  if collInLovelace < totalCollateralCoin:
+    abort with CollateralShortfall(required = totalCollateralCoin,
+                                   available = collInLovelace)
+  returnAddr = mCollReturnOverride `orElse` changeAddr
+  returnVal  = MaryValue (collInLovelace - totalCollateralCoin) mempty
+  body.totalCollateral  = SJust totalCollateralCoin
+  body.collateralReturn = SJust (mkBasicTxOut returnAddr returnVal)
+else:
+  -- preserve existing behaviour; do not emit either field
+  body.totalCollateral  = SNothing
+  body.collateralReturn = SNothing
+```
+
+The existing `estimateMinFeeTx` then sees the populated body and returns a fee that already covers the new bytes. Convergence check (`newFee <= currentFee`) is unchanged.
+
+### Quickstart ([quickstart.md](./quickstart.md))
+
+A 30-line script using the public DSL that produces a script-bearing tx with the new fields populated. Useful as a smoke test and as documentation for downstream callers. Will be runnable from `cabal repl test:cardano-node-clients-test` against the existing Plutus fixtures.
+
+### Agent context update
+
+`CLAUDE.md` already lists the relevant tech (`cardano-ledger-conway`, GHC 9.6+). No new technologies introduced — the agent context update is a no-op for this feature; running `update-agent-context.sh` will record the spec ID under "Recent Changes".
+
+## Re-evaluated Constitution Check (post-Phase-1)
+
+No new violations surfaced during design. The `Maybe Addr` addition to `balanceTx` is internal (the function is exported but the change is a single optional argument; rather than break callers, we can keep the existing 5-arg `balanceTx` as a wrapper around a new 6-arg primitive — to be confirmed in Phase 2 tasks). Constitution check: PASS.
+
+## Complexity Tracking
+
+No violations to track.

--- a/specs/040-txbuild-conway-collateral/quickstart.md
+++ b/specs/040-txbuild-conway-collateral/quickstart.md
@@ -1,0 +1,90 @@
+# Quickstart: Building a script-bearing Conway tx
+
+**Feature**: [spec.md](./spec.md). Issue: [#124](https://github.com/lambdasistemi/cardano-node-clients/issues/124).
+
+## What changes for callers
+
+Before this feature, `build` produced a body that the chain rejected for any Plutus-driven tx (missing `total_collateral` / `collateral_return`). After this feature, the same program produces a submittable body.
+
+## Default usage (no API change)
+
+```haskell
+import Cardano.Node.Client.TxBuild
+import Cardano.Node.Client.Balance ()
+
+let prog :: TxBuild NoQ Void ()
+    prog = do
+      _ <- spend scriptIn               -- Plutus-locked UTxO
+      collateral feeIn                  -- Collateral input
+      attachScript myValidator
+      _ <- payTo recipientAddr (inject (Coin 3_000_000))
+      pure ()
+
+result <- build pp interpret evaluator
+                [feeUtxo, scriptUtxo]   -- inputUtxos: covers BOTH spend + collateral
+                []                       -- refUtxos
+                changeAddr
+                prog
+```
+
+That's it. The resulting `ConwayTx` now carries `total_collateral` and `collateral_return` (return target = `changeAddr`).
+
+## Override the collateral-return address
+
+```haskell
+let prog = do
+      _ <- spend scriptIn
+      collateral feeIn
+      attachScript myValidator
+      setCollateralReturn collateralWalletAddr   -- ← new
+      _ <- payTo recipientAddr (inject (Coin 3_000_000))
+      pure ()
+```
+
+Now the leftover from the collateral input lands at `collateralWalletAddr`, while the change from the regular spend stays at `changeAddr`.
+
+## What you get back
+
+For a script-bearing tx (at least one redeemer + at least one collateral input):
+
+| Body field | Value |
+|------------|-------|
+| `inputs` | as before |
+| `outputs` | as before + change output appended |
+| `collateral_inputs` | as before |
+| `collateral_return` | NEW: `(returnAddr, sum(collateral_input.lovelace) − total_collateral)` |
+| `total_collateral` | NEW: `ceil(fee × collateralPercent / 100)` |
+| `fee` | now correctly accounts for the bytes of the two new fields |
+
+For a non-script tx (no redeemers): output is byte-identical to today.
+
+## What can go wrong
+
+```haskell
+case result of
+  Right tx -> submit tx
+  Left (BalanceFailed (CollateralShortfall required available)) ->
+    -- caller's collateral inputs cover only `available`,
+    -- but the protocol needs at least `required`.
+    -- Fix: provide a larger collateral input.
+    ...
+  Left otherErr -> ...
+```
+
+This error is new in this feature. All other `BuildError` cases are unchanged.
+
+## Verification (smoke test)
+
+```haskell
+case result of
+  Right tx -> do
+    let body = tx ^. bodyTxL
+    body ^. totalCollateralTxBodyL `shouldBe` SJust expectedTotal
+    case body ^. collateralReturnTxBodyL of
+      SJust o -> do
+        o ^. addrTxOutL  `shouldBe` returnAddr
+        o ^. coinTxOutL  `shouldBe` collateralIn `subtractCoin` expectedTotal
+      SNothing -> expectationFailure "collateral_return missing"
+```
+
+This is the shape used in the unit tests added under `test/Cardano/Node/Client/TxBuildSpec.hs`.

--- a/specs/040-txbuild-conway-collateral/research.md
+++ b/specs/040-txbuild-conway-collateral/research.md
@@ -1,0 +1,70 @@
+# Research: TxBuild Conway collateral fields
+
+**Feature**: [spec.md](./spec.md) — Issue [#124](https://github.com/lambdasistemi/cardano-node-clients/issues/124).
+
+## Decisions
+
+### Decision 1 — Resolution map for collateral input lovelace sum
+
+**Decision**: Reuse the existing `inputUtxos :: [(TxIn, TxOut ConwayEra)]` argument that `buildWith`/`balanceTx` already accept. At balancing time, compute `sum(collateral lovelace)` by intersecting `body ^. bodyTxL . collateralInputsTxBodyL` with `inputUtxos`.
+
+**Rationale**: The convention that exists today (verified in `test/Cardano/Node/Client/E2E/MultiAssetChangeSpec.hs`, line 167–177) is that callers pass every UTxO that any instruction in the program references — the same `seedIn` is both `spend`'d and used as `collateral`, and `inputUtxos = [seed]` covers both. Adding a new `collateralUtxos` parameter would break that convention and force every caller to thread the same UTxO through twice.
+
+**Alternatives considered**:
+- New `collateralUtxos :: [(TxIn, TxOut)]` parameter on `buildWith`/`balanceTx`. Rejected: breaking change for every existing caller, no semantic benefit. The body already carries the `Set TxIn` of collateral inputs, and the resolution map already exists.
+- Have `TxBuild` instructions carry the resolved `TxOut` inline (`Collateral :: TxIn -> TxOut -> TxInstr ...`). Rejected: forces callers to pre-resolve at program-construction time, which is awkward for callers that read UTxO state after the program is written.
+
+### Decision 2 — Where collateral arithmetic lives in the build pipeline
+
+**Decision**: Inside `Cardano.Node.Client.Balance.balanceTx`'s fee fixpoint loop.
+
+**Rationale**: The two new fields' CBOR bytes are part of the body's signed size; the fee depends on them; their values depend on the fee. Putting the derivation inside the loop turns this circular dependency into a single converging fixpoint, identical in shape to the existing fee/output fixpoint. Putting it outside (e.g. as a post-balance pass in `buildWith`) would require an additional iteration over `balanceTx` to absorb the size delta.
+
+**Alternatives considered**:
+- Pre-set worst-case placeholder values before `balanceTx`, run the existing loop, then fix up. Rejected: the worst-case placeholder must over-estimate the size (otherwise `estimateMinFeeTx` under-shoots). Over-estimating wastes a few lovelace per tx and adds a special-case post-pass — same convergence cost as just doing it inside the loop, but messier.
+- Put the derivation inside `buildWith` and pass through `balanceTx` unchanged. Rejected: the existing `BalanceResult { changeIndex }` and the `bumpFee` retry path already entangle balance state with fee state; the derivation needs to live next to the fee loop to remain coherent.
+
+### Decision 3 — Caller signal for the override return address
+
+**Decision**: Add a `Maybe Addr` parameter to `balanceTx` (`mCollReturnOverride`). `buildWith` reads `tsCollReturnAddr` from the interpreter state and passes it through.
+
+**Rationale**: `balanceTx` already takes `changeAddr :: Addr` for the change output. Adding a sibling optional parameter is symmetric and self-documenting. Threading the address via a new field on `BalanceResult` would be backwards (the address is an input, not an output).
+
+**Alternatives considered**:
+- Encode the override into the body before calling `balanceTx` (e.g. set `collateral_return.address` to the override and leave `value = 0`, then have `balanceTx` only update the value). Rejected: requires `balanceTx` to recognise a magic "value=0 means update me" sentinel, which is fragile and obscures the contract.
+- A dedicated configuration record threaded into both `buildWith` and `balanceTx`. Rejected: premature — current callers do not need a knob bag.
+
+### Decision 4 — Public-API surface for the override
+
+**Decision**: One new combinator `setCollateralReturn :: Addr -> TxBuild q e ()`. No combinator for `total_collateral` coin or `collateral_return` value.
+
+**Rationale**: Both derived values are mandated by ledger arithmetic. A caller-supplied override would only produce an invalid tx that the chain rejects. `cardano-cli transaction build` exposes `--tx-out-return-collateral <addr>` (address only) and never an absolute coin override; matching that behaviour is the principle of least surprise.
+
+**Alternatives considered**:
+- Expose `setTotalCollateral :: Coin -> TxBuild q e ()` "for power users". Rejected: the user explicitly chose option 1 (no setter) when the API was reviewed mid-issue. `total_collateral` is a protocol-driven field; an override is footgun-only.
+- Expose a single `setCollateral :: CollateralConfig -> TxBuild q e ()` knob bag. Rejected: only one knob exists today; a record-shaped API is over-engineering for a single field.
+
+### Decision 5 — Convergence safety of the extended fee loop
+
+**Decision**: Existing 10-iteration cap stays. No change to convergence logic.
+
+**Rationale**: The CBOR sizes of `total_collateral` (a varint `Coin`) and `collateral_return` (a `TxOut` with a fixed-shape lovelace-only value) are both bounded by ~10 bytes each across the realistic fee range. A fee delta `Δf` produces at most a few bytes of size delta, which in turn changes the next-iteration fee by `~txFeePerByte × Δsize ≈ 44 × few = O(100 lovelace)` — well under any plausible `Δf` (typically thousands of lovelace). The loop converges in 2–3 rounds, same as today. The 10-iteration cap is a defensive ceiling, not a tight bound.
+
+**Alternatives considered**:
+- Bump the iteration cap to 20 "to be safe". Rejected: no evidence of need; would mask real divergence bugs if introduced later.
+
+### Decision 6 — What to do when the body has scripts but no collateral inputs (or vice versa)
+
+**Decision**:
+- Body has redeemers but **no** collateral inputs: out of scope for this feature. Pass through to `balanceTx` unchanged (do not emit `total_collateral`/`collateral_return`). The chain will reject the resulting tx; that error path is unchanged from today.
+- Body has collateral inputs but **no** redeemers: do not emit either field (FR-008). Matches `cardano-cli`'s behaviour for non-script txs.
+- Body has redeemers AND collateral inputs but `sum(collateral input lovelace) < total_collateral_required`: surface a new `BalanceError` (`CollateralShortfall`). FR-009.
+
+**Rationale**: Each of these edge cases is already part of the spec. The library should fail fast and visibly when the program is internally inconsistent; it should not paper over caller mistakes by synthesising inputs or emitting mathematically nonsensical fields.
+
+## Open issues / not resolved here
+
+None blocking implementation. Two follow-ups deferred:
+
+- **Reference-script-only collateral**: a tx may reference a script via `referenceInputsTxBodyL` rather than `attachScript`. The "has redeemers" predicate (`null . unRedeemers . view rdmrsTxWitsL`) covers both cases (every Plutus invocation needs a redeemer regardless of how the script bytes are sourced), so no special handling is needed. Re-confirm during implementation.
+- **Future eras after Conway**: this feature targets Conway-only because that is all `build` produces. If a successor era arrives with a different collateral model, this code will need a per-era branch — but until that era is real, there is nothing to plan.

--- a/specs/040-txbuild-conway-collateral/spec.md
+++ b/specs/040-txbuild-conway-collateral/spec.md
@@ -1,0 +1,111 @@
+# Feature Specification: TxBuild Conway collateral fields
+
+**Feature Branch**: `040-txbuild-conway-collateral`
+**Created**: 2026-05-05
+**Status**: Draft
+**Input**: Issue [#124](https://github.com/lambdasistemi/cardano-node-clients/issues/124) — TxBuild does not populate the Conway body fields `total_collateral` (CBOR key 17) and `collateral_return` (CBOR key 16). Discovered while reproducing a real treasury swap tx in [amaru-treasury-tx#18](https://github.com/lambdasistemi/amaru-treasury-tx/pull/18).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Script-bearing tx is mempool-acceptable out of the box (Priority: P1)
+
+A caller writes a `TxBuild` program that spends a Plutus-locked UTxO and adds at least one collateral input. They call `build` and submit the resulting tx. The chain accepts it.
+
+**Why this priority**: Without this story the library cannot produce any submittable script-bearing tx. The chain rejects script-bearing Conway txs that omit `total_collateral` or `collateral_return`. Every Plutus-driven flow built on `TxBuild` is currently broken at the mempool.
+
+**Independent Test**: Build a minimal tx that spends a Plutus-locked UTxO, attaches a single collateral input, and lands change at the caller's address. Submit to a Conway-era node. The body must contain both fields, `total_collateral` must equal `ceil(fee × collateralPercent / 100)`, and the lovelace balance `sum(collateral_inputs) = total_collateral + collateral_return.value` must hold exactly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `TxBuild` program with one Plutus spend and one collateral input, **When** the caller runs `build` and inspects the result, **Then** the body has 12 map entries (not 10), with `total_collateral` and `collateral_return` populated and the collateral arithmetic balanced to the lovelace.
+2. **Given** the same program submitted to a real Conway node, **When** the node validates it, **Then** the tx clears the `BabbageEraTxOut` collateral arithmetic predicate without "missing total_collateral" rejections.
+3. **Given** a `TxBuild` program with neither scripts nor collateral inputs, **When** the caller runs `build`, **Then** the body contains neither `total_collateral` nor `collateral_return` (these fields stay absent for non-script txs, matching pre-feature behaviour).
+
+---
+
+### User Story 2 - Fee converges with collateral fields counted (Priority: P1)
+
+A caller runs `build` on a script-bearing tx with collateral inputs. The reported fee already accounts for the bytes that `total_collateral` and `collateral_return` will occupy in the final body — the tx is not rejected at submission for `FeeTooSmallUTxO`, and the fee does not need a manual top-up.
+
+**Why this priority**: Without this story, the fee estimator under-counts by ~76 bytes (~3344 lovelace at base `txFeePerByte = 44`), producing txs that look correct but are immediately rejected by the mempool. This is the second half of making `build` actually usable for script-bearing flows.
+
+**Independent Test**: Run `build` on the swap-probe shape from [amaru-treasury-tx#18](https://github.com/lambdasistemi/amaru-treasury-tx/pull/18) and compare its body byte length to `cardano-cli transaction build`'s output for the same inputs. The two byte counts must match.
+
+**Acceptance Scenarios**:
+
+1. **Given** a script-bearing tx with collateral inputs, **When** `build` returns, **Then** the fee field already reflects the bytes consumed by `total_collateral` and `collateral_return` (no shortfall vs. `cardano-cli`).
+2. **Given** the same inputs, **When** the resulting CBOR body is submitted, **Then** the node does not reject with `FeeTooSmallUTxO`.
+
+---
+
+### User Story 3 - Caller redirects collateral return to a chosen address (Priority: P2)
+
+A caller has separate "operational" and "collateral" wallets. They call `setCollateralReturn collateralRefundAddr` so the leftover from collateral inputs lands in the collateral wallet, not in the change wallet that receives the tx outputs' change.
+
+**Why this priority**: This is the only legitimate caller-facing override exposed by this feature. P2 (not P1) because the default — return to change address — already produces a valid, submittable tx; this story is only needed for callers who actively want a different return target.
+
+**Independent Test**: Build a script-bearing tx with `setCollateralReturn customAddr`, then verify the tx body's `collateral_return` output's address equals `customAddr` (not the change address) and the lovelace amount equals `sum(collateral_inputs) − total_collateral`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `TxBuild` program that calls `setCollateralReturn collateralAddr`, **When** `build` runs, **Then** `collateral_return.address = collateralAddr` and the collateral arithmetic still balances exactly.
+2. **Given** a program that does not call `setCollateralReturn`, **When** `build` runs, **Then** `collateral_return.address` equals the change address passed to `build`.
+
+---
+
+### Edge Cases
+
+- A program declares collateral inputs but no scripts (no redeemers): the chain does not require `total_collateral`/`collateral_return` for non-script txs. The library MUST NOT add the fields in this case (adding them on a no-script tx is a spec violation).
+- A program declares scripts but no collateral inputs: this is an invalid program for any era that requires collateral on script-bearing txs. Behaviour stays as today — the chain rejects the tx for the missing collateral input set; this feature does not synthesise collateral inputs.
+- The sum of collateral inputs is less than `ceil(fee × collateralPercent / 100)`: the resulting `collateral_return` value would be negative. `build` MUST surface this as a `BuildError` (existing balance/insufficient-funds error category) rather than producing a malformed body.
+- The sum of collateral inputs equals `total_collateral` exactly: `collateral_return.value` is zero. The library MUST still emit a `collateral_return` output (with zero lovelace) so the body byte count remains stable across iterations of the fee fixpoint and the mempool predicate's arithmetic check has both endpoints to compare.
+- The protocol parameter `collateralPercent` is zero (theoretical): `total_collateral = 0`. The fields are still emitted; the collateral inputs are returned in full.
+- The chosen collateral-return address has a value below the protocol-parameter `minUTxOValue`: the resulting output would be ledger-rejected. This is a caller mistake (they picked a return address with insufficient leftover) and surfaces as a normal balance failure during the fee/balance fixpoint.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `build` MUST populate `total_collateral` on the resulting tx body whenever the body has at least one redeemer (i.e. a script witness) AND at least one collateral input.
+- **FR-002**: `build` MUST set `total_collateral = ceil(fee × collateralPercent / 100)`, where `fee` is the converged fee from balancing and `collateralPercent` is read from the protocol parameters supplied to `build`.
+- **FR-003**: `build` MUST populate `collateral_return` on the resulting tx body under the same condition as FR-001.
+- **FR-004**: `build` MUST set `collateral_return.value.coin = sum(collateral_inputs.value.coin) − total_collateral` and `collateral_return.value.assets = ∅` (lovelace-only return).
+- **FR-005**: `build` MUST set `collateral_return.address` to the value passed to `setCollateralReturn` if the program called it; otherwise to the `changeAddr` argument of `build`/`buildWith`.
+- **FR-006**: The fee estimator inside `buildWith` MUST account for the CBOR bytes of `total_collateral` and `collateral_return` before the fee converges, so the returned fee covers the final body without a post-balance shortfall.
+- **FR-007**: `TxBuild` MUST expose a smart constructor `setCollateralReturn :: Addr -> TxBuild q e ()` that records the override address. The library MUST NOT expose any setter for the `total_collateral` lovelace amount or for the `collateral_return` lovelace amount — these are fully derived.
+- **FR-008**: When the body has no redeemers, `build` MUST NOT add `total_collateral` or `collateral_return`, regardless of whether collateral inputs are present (preserves pre-feature behaviour for non-script flows).
+- **FR-009**: When `sum(collateral_inputs.value.coin) < ceil(fee × collateralPercent / 100)`, `build` MUST surface a `BuildError` rather than emit a body with a negative-valued `collateral_return`.
+- **FR-010**: A program that calls `setCollateralReturn` more than once MUST behave as if only the last call happened (last-write-wins, matching the existing semantics of `SetValidFrom` / `SetValidTo`).
+
+### Key Entities
+
+- **TxBuild program**: a sequence of instructions describing intent (spends, mints, withdrawals, …). Augmented in this feature with one new instruction (`SetCollReturn`) and one new optional state field (collateral-return address).
+- **TxState**: the interpreter's accumulated state. Gains a single optional field for the explicit collateral-return address override.
+- **Conway tx body**: the output artifact. Gains two CBOR fields when the body has scripts + collateral inputs: `total_collateral` (key 17, `Coin`) and `collateral_return` (key 16, `TxOut`).
+- **Protocol parameters**: read-only input to `build`. The `collateralPercent` field drives `total_collateral`'s value.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A script-bearing tx built with `build` and submitted to a Conway node receives no "missing `total_collateral`" or "missing `collateral_return`" rejection (failure rate goes from 100% to 0% for the swap-probe shape).
+- **SC-002**: For the swap-probe inputs from [amaru-treasury-tx#18](https://github.com/lambdasistemi/amaru-treasury-tx/pull/18), the body byte length produced by `build` matches `cardano-cli transaction build`'s output exactly (delta ≤ 0 bytes; today the gap is 76 bytes).
+- **SC-003**: The fee returned by `build` is within the slack accepted by the chain — i.e. the body never fails submission with `FeeTooSmallUTxO` due to under-counted collateral-field bytes (today's residual ~3344 lovelace shortfall is eliminated).
+- **SC-004**: The lovelace-balance invariant `sum(collateral_inputs.value.coin) = total_collateral + collateral_return.value.coin` holds exactly in every output of `build` (verifiable by reading the body).
+- **SC-005**: For non-script txs (no redeemers), the body emitted by `build` is byte-identical to the pre-feature output (no regression on the `TxBuildGoldenSpec` golden vectors that exercise non-script flows).
+
+## Assumptions
+
+- Callers supply a `PParams ConwayEra` to `build`; `collateralPercent` is read from this value (not from a separately-passed argument). This matches the existing API shape.
+- The collateral-return output is always lovelace-only. Returning multi-assets in `collateral_return` is not in scope — `cardano-cli` does not do it either, and no current caller has asked for it.
+- The library does not synthesise collateral inputs. If a script-bearing program forgets to call `collateral`, the existing failure path (chain rejection at submission) is unchanged.
+- The fee fixpoint already implemented in `Cardano.Node.Client.Balance.balanceTx` can be extended to also re-derive `total_collateral` / `collateral_return` per iteration without changing its convergence guarantees (both fields' CBOR sizes are bounded by a few bytes).
+- No on-disk format or wire format outside the tx body changes. This is purely a body-construction fix; downstream consumers (submit clients, golden vectors for script-bearing txs) get a richer body and the chain accepts it.
+
+## Out of Scope
+
+- Caller-supplied absolute `total_collateral` value: `collateralPercent` is a protocol parameter and the formula is mandatory; an override would only produce invalid txs.
+- Caller-supplied `collateral_return` lovelace amount: derived from inputs and `total_collateral`; an override breaks the lovelace-conservation invariant.
+- Multi-asset collateral returns.
+- Synthesising collateral inputs when the program omits them.
+- Pre-Babbage eras (Conway only — that's all `build` produces today).

--- a/specs/040-txbuild-conway-collateral/tasks.md
+++ b/specs/040-txbuild-conway-collateral/tasks.md
@@ -1,0 +1,169 @@
+---
+
+description: "Task list for 040-txbuild-conway-collateral"
+---
+
+# Tasks: TxBuild Conway collateral fields
+
+**Input**: Design documents in [`specs/040-txbuild-conway-collateral/`](./).
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/txbuild-api.md](./contracts/txbuild-api.md), [quickstart.md](./quickstart.md).
+**Tests**: TDD requested by user — failing tests precede implementation.
+**Source issue**: [lambdasistemi/cardano-node-clients#124](https://github.com/lambdasistemi/cardano-node-clients/issues/124).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]** = parallel-safe (different file, no incomplete deps).
+- **[Story]** = `[US1]`, `[US2]`, `[US3]` for user-story phases; omitted for shared phases.
+
+## Path Conventions
+
+Single-library Haskell layout:
+- `lib/Cardano/Node/Client/{TxBuild,Balance}.hs` — feature implementation.
+- `test/Cardano/Node/Client/{TxBuildSpec,TxBuildGoldenSpec}.hs` — unit tests.
+- `test/Cardano/Node/Client/E2E/{TxBuildSpec,MultiAssetChangeSpec}.hs` — devnet E2E.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Branch + working tree are already in place. Confirm baseline.
+
+- [ ] T001 Confirm `nix develop --quiet -c just ci` passes on the freshly-created `040-txbuild-conway-collateral` branch (baseline must be green so any later red is attributable to the feature work).
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Type-level scaffolding that every user story depends on. Per [data-model.md](./data-model.md).
+
+**⚠️ CRITICAL**: No user-story work can compile until this phase lands.
+
+- [ ] T002 Add new constructor `SetCollReturn :: Addr -> TxInstr q e ()` to `TxInstr` in `lib/Cardano/Node/Client/TxBuild.hs` (next to `SetValidFrom` / `SetValidTo` for visual symmetry).
+- [ ] T003 Add field `tsCollReturnAddr :: StrictMaybe Addr` to `TxState` and initialise it to `SNothing` in `emptyState` in `lib/Cardano/Node/Client/TxBuild.hs`.
+- [ ] T004 Handle the `SetCollReturn addr :>>= k` branch in `interpretWithM` in `lib/Cardano/Node/Client/TxBuild.hs` — last-write-wins (`tsCollReturnAddr = SJust addr`).
+- [ ] T005 Add new constructor `CollateralShortfall !Coin !Coin` to `BalanceError` in `lib/Cardano/Node/Client/Balance.hs`. Update `Eq`/`Show` derivations as needed (they're auto-derived; verify no manual instance).
+- [ ] T006 Confirm `nix develop --quiet -c cabal build all -O0` still compiles after T002–T005 (the new constructor adds a non-exhaustive-pattern warning; that's expected and resolved by the user-story tasks).
+
+**Checkpoint**: Types are in place; the project still builds; no behavioural change yet.
+
+---
+
+## Phase 3: User Story 1 — Script-bearing tx is mempool-acceptable (Priority: P1) 🎯 MVP
+
+**Goal**: A `TxBuild` program that spends a Plutus-locked UTxO and adds a collateral input now produces a body with `total_collateral` and `collateral_return` populated. Submission to a Conway node clears the collateral arithmetic predicate.
+
+**Independent Test**: Build a minimal Plutus-spend-with-collateral tx via `build` and verify `total_collateral = ceil(fee × collateralPercent / 100)` and `sum(collateral_inputs.lovelace) = total_collateral + collateral_return.value.coin` exactly. Submit to devnet and confirm acceptance. (See [quickstart.md](./quickstart.md) for the canonical shape.)
+
+### Tests for User Story 1 (FIRST — TDD)
+
+- [ ] T007 [US1] Add a unit-test case to `test/Cardano/Node/Client/TxBuildSpec.hs` that runs `build` on a script-bearing program (one Plutus spend + one collateral input) against synthetic pparams and asserts: (a) `body ^. totalCollateralTxBodyL == SJust (ceil (fee × cp / 100))`, (b) the body's `collateral_return` exists and pays `collInLovelace − total_collateral` to the change address, (c) `length (toList (body ^. outputsTxBodyL)) == n + 1` (existing change behaviour preserved). The test must fail on `main`'s code path before T010–T013 land.
+- [ ] T008 [US1] [P] Add an E2E test to `test/Cardano/Node/Client/E2E/TxBuildSpec.hs` (or extend `MultiAssetChangeSpec`) that submits a script-bearing tx via the local devnet and asserts the node accepts it (no `MissingCollateralInputs`/collateral-arithmetic error). The test must fail on `main`'s code path because the chain currently rejects the body.
+- [ ] T009 [US1] Add an `Eq`/`Show` regression for `BalanceError` to `test/Cardano/Node/Client/E2E/BalanceSpec.hs` (or unit equivalent) covering the new `CollateralShortfall` constructor — to lock in FR-009 behaviour.
+
+### Implementation for User Story 1
+
+- [ ] T010 [US1] Implement private helper `lookupCollateralLovelace :: Set TxIn -> [(TxIn, TxOut ConwayEra)] -> Coin` in `lib/Cardano/Node/Client/Balance.hs` (folds `inputUtxos` filtered by the collateral input set, sums `coinTxOutL`).
+- [ ] T011 [US1] Implement private helper `deriveCollateralFields :: PParams ConwayEra -> [(TxIn, TxOut ConwayEra)] -> Addr -> Coin -> ConwayTx -> Either BalanceError (Maybe (Coin, TxOut ConwayEra))` in `lib/Cardano/Node/Client/Balance.hs` per the algorithm in [plan.md § Algorithm sketch](./plan.md). Returns `Right Nothing` when the body has no redeemers; `Left CollateralShortfall` when the collateral input sum is insufficient; `Right (Just (totalColl, returnOut))` otherwise.
+- [ ] T012 [US1] Refactor `balanceTx` in `lib/Cardano/Node/Client/Balance.hs` to take an additional `Maybe Addr` parameter (collateral-return override) under a renamed primitive (e.g. `balanceTxWith`); keep the existing 5-arg `balanceTx` as a wrapper that passes `Nothing`. Inside the fee fixpoint's `buildTx fee` step, call `deriveCollateralFields`, wire `body & totalCollateralTxBodyL .~ ... & collateralReturnTxBodyL .~ ...` when the result is `Right (Just _)`. Surface `Left CollateralShortfall` as the loop's terminal `Left`.
+- [ ] T013 [US1] Update `buildWith` in `lib/Cardano/Node/Client/TxBuild.hs` to compute the effective return address (`fromSMaybe changeAddr (tsCollReturnAddr st)`) and thread it through every `balanceTx`/`balanceTxWith` call site (4 sites: lines ~1011, ~1083, ~1336, ~1411 — confirm during implementation). The interpreted state's `tsCollReturnAddr` must reach the balancer; do not introduce a new top-level argument to `buildWith`.
+
+### Verification for User Story 1
+
+- [ ] T014 [US1] Run `nix develop --quiet -c just ci` and confirm: T007 passes, T008 passes (E2E green against devnet), T009 passes, no other `TxBuildSpec` golden vector regressed (SC-005). Commit.
+
+**Checkpoint**: User Story 1 complete. Library produces submittable script-bearing Conway txs. MVP shippable from this commit.
+
+---
+
+## Phase 4: User Story 2 — Fee converges with collateral fields counted (Priority: P1)
+
+**Goal**: The fee returned by `build` already accounts for the new fields' bytes — no `FeeTooSmallUTxO` rejection at submission, no shortfall vs. `cardano-cli`.
+
+**Independent Test**: Build the swap-probe shape from [amaru-treasury-tx#18](https://github.com/lambdasistemi/amaru-treasury-tx/pull/18) and compare body byte length to `cardano-cli transaction build`'s output.
+
+US2 implementation overlap with US1 is high (both are settled by extending the fee fixpoint). The remaining tasks are byte-level assertions and a guard against future regressions.
+
+### Tests for User Story 2
+
+- [ ] T015 [US2] Add a unit assertion to `test/Cardano/Node/Client/TxBuildSpec.hs`: for a script-bearing tx, the fee returned by `build` is at least `estimateMinFeeTx pp finalBody 1 0 refScriptBytes` (i.e. no shortfall). Use the same fixture as T007.
+- [ ] T016 [US2] [P] Add a golden vector to `test/Cardano/Node/Client/TxBuildGoldenSpec.hs` for a deterministic script-bearing tx (fixed inputs, fixed pparams) so the body bytes are byte-locked across future changes.
+
+### Implementation for User Story 2
+
+No new code — US1's T010–T013 already place the fields inside the fee fixpoint. If T015 fails, treat as a US1 implementation bug and fix in `Balance.hs`.
+
+### Verification for User Story 2
+
+- [ ] T017 [US2] Run `nix develop --quiet -c just ci` and confirm both new assertions pass; commit if green.
+
+**Checkpoint**: Fee accounting is complete. The library is production-ready for script-bearing Conway txs.
+
+---
+
+## Phase 5: User Story 3 — Caller redirects collateral return (Priority: P2)
+
+**Goal**: A program calling `setCollateralReturn customAddr` sees the collateral leftover land at `customAddr`, not at the change address.
+
+**Independent Test**: Build a script-bearing tx with `setCollateralReturn customAddr`; verify `body.collateral_return.address == customAddr` and the lovelace sum still balances.
+
+### Tests for User Story 3
+
+- [ ] T018 [US3] Add a unit test to `test/Cardano/Node/Client/TxBuildSpec.hs` that calls `setCollateralReturn customAddr` and asserts (a) the resulting body's `collateral_return` address matches `customAddr` (not `changeAddr`), (b) the lovelace value is unchanged from the default-address case (sum invariant still holds), (c) calling `setCollateralReturn` twice yields the second address (FR-010 last-write-wins).
+- [ ] T019 [US3] [P] Extend the E2E `MultiAssetChangeSpec` (or `E2E/TxBuildSpec`) to exercise `setCollateralReturn` against a devnet node and assert the on-chain output address matches.
+
+### Implementation for User Story 3
+
+- [ ] T020 [US3] Add the smart constructor `setCollateralReturn :: Addr -> TxBuild q e ()` to `lib/Cardano/Node/Client/TxBuild.hs` (next to `setValidFrom`/`setValidTo`, with Haddock per the contract in [contracts/txbuild-api.md](./contracts/txbuild-api.md)). Export it from the module's export list.
+- [ ] T021 [US3] Verify the new symbol is included in any haddock/quickstart doc snippets and resolves at the public-API surface.
+
+### Verification for User Story 3
+
+- [ ] T022 [US3] Run `nix develop --quiet -c just ci`; confirm T018 + T019 pass; commit.
+
+**Checkpoint**: Override path complete. All three user stories shipped.
+
+---
+
+## Phase 6: Polish & cross-cutting
+
+- [ ] T023 [P] Update CHANGELOG.md with a one-liner under "Unreleased" (e.g. `feat(tx-build): emit Conway total_collateral / collateral_return for script-bearing txs (#124)`).
+- [ ] T024 [P] Sweep Haddock: ensure `setCollateralReturn`, `CollateralShortfall`, and the new field on `TxState` carry exported docstrings consistent with the rest of the module.
+- [ ] T025 Run `nix develop --quiet -c just ci` one final time on the rebased branch; push the branch; open a PR linked to [#124](https://github.com/lambdasistemi/cardano-node-clients/issues/124) with a description that walks the reviewer through `Balance.hs`, the new `TxInstr` constructor, and the test additions.
+
+---
+
+## Dependency graph
+
+```text
+T001 (baseline)
+  └── T002 ── T003 ── T004 ── T005 ── T006 (foundational types)
+                                       ├── US1: T007, T008, T009 (failing tests)
+                                       │     └── T010 ── T011 ── T012 ── T013 ── T014 (impl + verify)
+                                       ├── US2: T015, T016 (assertions)
+                                       │     └── T017 (verify; relies on US1 impl)
+                                       └── US3: T018, T019 (failing tests)
+                                             └── T020 ── T021 ── T022 (impl + verify)
+                                                                   └── T023, T024, T025 (polish)
+```
+
+Edges to remember:
+- T012 must happen before T013 (the `Maybe Addr` parameter must exist before `buildWith` threads it).
+- T015's assertion can only pass after T012/T013 land — order it inside US1's verification window or run it post-T014.
+- T020 (`setCollateralReturn`) is required for US3 tests to even compile; do NOT mark T018 as failing-on-`main`-without-T020 — the failure mode is a compile error, not a wrong body. Pair them in the same commit if working sequentially.
+
+## Parallel opportunities
+
+Limited — single library, two source files, two test files. The genuinely parallel pairs are:
+
+- **T007 & T008**: unit and E2E tests for US1 touch different files and can be drafted concurrently before any impl work.
+- **T015 & T016**: byte-assertion and golden vector for US2 — different files.
+- **T018 & T019**: unit + E2E for US3 — different files.
+- **T023 & T024**: CHANGELOG and Haddock sweep — different files.
+
+Everything else is strictly sequential by file.
+
+## Implementation strategy
+
+- **MVP target**: complete through T014 (US1). At that point the library produces submittable script-bearing Conway txs and the chain accepts them — the headline outcome of the issue.
+- **Incremental commits**: one commit per task ID for T002–T013 (vertical commits, bisect-safe per repo convention). T014, T017, T022 are verification-only — squash into the preceding impl commit if it stays green from the start.
+- **Don't pre-merge**: per the user's "surge before merge" preference, push the branch, request review, only merge once the reviewer has had eyes on it.

--- a/test/Cardano/Node/Client/BalanceSpec.hs
+++ b/test/Cardano/Node/Client/BalanceSpec.hs
@@ -365,6 +365,9 @@ balanceTxSpec =
                 Left FeeNotConverged ->
                     expectationFailure
                         "expected InsufficientFee"
+                Left (CollateralShortfall _ _) ->
+                    expectationFailure
+                        "expected InsufficientFee"
                 Right _ ->
                     expectationFailure
                         "expected InsufficientFee"

--- a/test/Cardano/Node/Client/TxBuildGoldenSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildGoldenSpec.hs
@@ -102,11 +102,13 @@ import Cardano.Ledger.TxIn (
  )
 import Cardano.Node.Client.Ledger (ConwayTx)
 import Cardano.Node.Client.TxBuild (
+    BuildOptions (..),
     InterpretIO (..),
     TxBuild,
     attachScript,
-    build,
+    buildWith,
     collateral,
+    defaultBuildOptions,
     draft,
     mint,
     output,
@@ -429,7 +431,8 @@ mkTxInFromText txHashText indexText = do
 
 buildGoldenTx :: ConwayTx -> [(TxIn, Coin)] -> IO ConwayTx
 buildGoldenTx expected inputCoins =
-    build
+    buildWith
+        goldenBuildOptions
         goldenBuildPParams
         noCtxInterpretIO
         (\_ -> pure (expectedExUnits expected))
@@ -444,12 +447,38 @@ buildGoldenTx expected inputCoins =
             Right tx ->
                 pure tx
   where
-    expectedOutputs = toList (expected ^. bodyTxL . outputsTxBodyL)
+    expectedBody = expected ^. bodyTxL
+    expectedOutputs = toList (expectedBody ^. outputsTxBodyL)
     changeAddr = selectChangeAddr expectedOutputs
+    -- Synthesise a generous lovelace value for each
+    -- collateral input so the collateral arithmetic
+    -- in 'balanceTxWith' has enough budget to balance
+    -- @total_collateral@ + @collateral_return@. The
+    -- exact value does not affect the assertions in
+    -- 'assertBalancedStructurallyEquivalent' (which
+    -- ignore @total_collateral@ and
+    -- @collateral_return@); what matters is that the
+    -- balancer can complete without
+    -- 'CollateralShortfall'. 100 ADA is large enough
+    -- for any realistic fee × 1.5 (issue #124).
+    collateralIns = Set.toAscList (expectedBody ^. collateralInputsTxBodyL)
+    perCollateralUtxoLovelace = Coin 100_000_000
+    syntheticCollateralUtxos =
+        [ ( txIn
+          , mkBasicTxOut
+                changeAddr
+                (inject perCollateralUtxoLovelace)
+          )
+        | txIn <- collateralIns
+        ]
     inputUtxos =
         [ (txIn, mkBasicTxOut changeAddr (inject coin))
         | (txIn, coin) <- inputCoins
         ]
+    goldenBuildOptions =
+        defaultBuildOptions
+            { boCollateralUtxos = syntheticCollateralUtxos
+            }
 
 selectChangeAddr ::
     [TxOut ConwayEra] ->

--- a/test/Cardano/Node/Client/TxBuildGoldenSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildGoldenSpec.hs
@@ -100,6 +100,7 @@ import Cardano.Ledger.TxIn (
     TxId (..),
     TxIn (..),
  )
+import Cardano.Node.Client.Balance (CollateralUtxos (..))
 import Cardano.Node.Client.Ledger (ConwayTx)
 import Cardano.Node.Client.TxBuild (
     BuildOptions (..),
@@ -477,7 +478,8 @@ buildGoldenTx expected inputCoins =
         ]
     goldenBuildOptions =
         defaultBuildOptions
-            { boCollateralUtxos = syntheticCollateralUtxos
+            { boCollateralUtxos =
+                CollateralUtxos syntheticCollateralUtxos
             }
 
 selectChangeAddr ::

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -43,6 +43,7 @@ import Cardano.Ledger.Api.PParams (
  )
 import Cardano.Ledger.Api.Tx (
     auxDataTxL,
+    estimateMinFeeTx,
     witsTxL,
  )
 import Cardano.Ledger.Api.Tx.Body (
@@ -114,6 +115,7 @@ import Cardano.Ledger.TxIn (
     TxIn (..),
  )
 import Cardano.Node.Client.Balance (
+    BalanceError (..),
     BalanceResult (..),
     balanceTx,
  )
@@ -1570,20 +1572,27 @@ collateralFieldsSpec =
                         expectationFailure $ show err
                     Right tx -> do
                         -- The fee returned by build must
-                        -- be at least estimateMinFeeTx of
-                        -- the final body; otherwise the
-                        -- chain would reject for
-                        -- FeeTooSmallUTxO. We don't have
-                        -- estimateMinFeeTx in scope here,
-                        -- but a positive fee that
-                        -- balances the body is enough to
-                        -- prove the loop converged with
-                        -- the new fields counted.
-                        let Coin fee =
+                        -- be at least estimateMinFeeTx
+                        -- of the final body — otherwise
+                        -- the chain rejects with
+                        -- FeeTooSmallUTxO. This pins
+                        -- down that the fee fixpoint
+                        -- accounts for the bytes of
+                        -- total_collateral and
+                        -- collateral_return.
+                        let fee =
                                 tx
                                     ^. bodyTxL
                                         . feeTxBodyL
-                        fee `shouldSatisfy` (> 0)
+                            estimated =
+                                estimateMinFeeTx
+                                    pp
+                                    tx
+                                    1 -- key witnesses
+                                    0 -- Byron witnesses
+                                    0 -- ref-script bytes
+                        fee
+                            `shouldSatisfy` (>= estimated)
 
         it
             "omits both fields for a tx with no script \
@@ -1674,6 +1683,51 @@ collateralFieldsSpec =
                                 expectationFailure
                                     "expected collateral_return \
                                     \to be set"
+
+        it
+            "surfaces CollateralShortfall when the \
+            \collateral input lovelace is below the \
+            \protocol-required total_collateral"
+            $ do
+                -- Tiny collateral input: covers minUtxo
+                -- for emptyPParams (which has zero
+                -- per-byte cost so any coin clears
+                -- 'getMinCoinTxOut') but is well below
+                -- ceil(fee × 150 / 100).
+                let tinyCollUtxo =
+                        ( mkTxIn 9
+                        , mkBasicTxOut
+                            (mkAddr 1)
+                            (inject (Coin 1_000))
+                        )
+                    mockEval =
+                        outputCountingEval 200_000
+                result <-
+                    build
+                        pp
+                        noCtxInterpretIO
+                        mockEval
+                        [tinyCollUtxo, scriptUtxo]
+                        []
+                        (mkAddr 1)
+                        scriptProg
+                case result of
+                    Left
+                        ( BalanceFailed
+                                ( CollateralShortfall
+                                        required
+                                        available
+                                    )
+                            ) -> do
+                            required `shouldSatisfy` (> available)
+                            available `shouldBe` Coin 1_000
+                    Left err ->
+                        expectationFailure $
+                            "expected CollateralShortfall, got "
+                                <> show err
+                    Right _ ->
+                        expectationFailure
+                            "expected CollateralShortfall"
 
 isSpend ::
     ConwayPlutusPurpose AsIx ConwayEra -> Bool

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -28,6 +28,9 @@ import Cardano.Ledger.Address (
     Withdrawals (..),
  )
 import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
+import Cardano.Ledger.Alonzo.PParams (
+    ppCollateralPercentageL,
+ )
 import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
 import Cardano.Ledger.Api.PParams (
@@ -45,17 +48,20 @@ import Cardano.Ledger.Api.Tx (
 import Cardano.Ledger.Api.Tx.Body (
     auxDataHashTxBodyL,
     collateralInputsTxBodyL,
+    collateralReturnTxBodyL,
     feeTxBodyL,
     inputsTxBodyL,
     mintTxBodyL,
     outputsTxBodyL,
     referenceInputsTxBodyL,
     reqSignerHashesTxBodyL,
+    totalCollateralTxBodyL,
     vldtTxBodyL,
     withdrawalsTxBodyL,
  )
 import Cardano.Ledger.Api.Tx.Out (
     TxOut,
+    addrTxOutL,
     coinTxOutL,
     mkBasicTxOut,
  )
@@ -63,7 +69,7 @@ import Cardano.Ledger.Api.Tx.Wits (rdmrsTxWitsL)
 import Cardano.Ledger.BaseTypes (
     Inject (..),
     Network (..),
-    StrictMaybe (SJust),
+    StrictMaybe (SJust, SNothing),
     TxIx (..),
  )
 import Cardano.Ledger.Coin (
@@ -208,6 +214,7 @@ spec = describe "TxBuild" $ do
     validSpec
     referenceValiditySpec
     buildSpec
+    collateralFieldsSpec
 
 data TestQ a where
     GetValue :: TestQ Int
@@ -1460,6 +1467,213 @@ buildSpec =
                         `shouldBe` [ Coin 3_000_000
                                    , Coin 6_999_700
                                    ]
+
+collateralFieldsSpec :: Spec
+collateralFieldsSpec =
+    describe "build (Conway collateral fields, #124)" $ do
+        let pp =
+                emptyPParams @ConwayEra
+                    & ppTxFeePerByteL
+                        .~ CoinPerByte
+                            (compactCoinOrError (Coin 44))
+                    & ppTxFeeFixedL .~ Coin 155381
+                    & ppMaxTxSizeL .~ 100_000
+                    -- emptyPParams already sets collateralPercent
+                    -- to 150; spell it out so the test stays
+                    -- correct if that default ever drifts.
+                    & ppCollateralPercentageL .~ 150
+            collateralCoin = Coin 5_000_000
+            scriptUtxo =
+                ( mkTxIn 2
+                , mkBasicTxOut
+                    (mkAddr 3)
+                    (inject (Coin 5_000_000))
+                )
+            collUtxo =
+                ( mkTxIn 9
+                , mkBasicTxOut (mkAddr 1) (inject collateralCoin)
+                )
+            scriptProg :: TxBuild TestQ TestErr ()
+            scriptProg = do
+                _ <- spendScript (mkTxIn 2) (42 :: Integer)
+                _ <-
+                    payTo
+                        (mkAddr 4)
+                        (inject (Coin 3_000_000))
+                collateral (mkTxIn 9)
+
+            ceilDiv :: Integer -> Integer -> Integer
+            ceilDiv a b = (a + b - 1) `div` b
+
+        it
+            "emits total_collateral and collateral_return \
+            \for a script-bearing tx with collateral inputs"
+            $ do
+                let mockEval =
+                        outputCountingEval 200_000
+                result <-
+                    build
+                        pp
+                        noCtxInterpretIO
+                        mockEval
+                        [collUtxo, scriptUtxo]
+                        []
+                        (mkAddr 1)
+                        scriptProg
+                case result of
+                    Left err ->
+                        expectationFailure $ show err
+                    Right tx -> do
+                        let body = tx ^. bodyTxL
+                            Coin fee = body ^. feeTxBodyL
+                            cp =
+                                fromIntegral
+                                    ( pp ^. ppCollateralPercentageL
+                                    )
+                            expectedTotalColl =
+                                Coin (ceilDiv (fee * cp) 100)
+                            Coin available =
+                                collateralCoin
+                            Coin expectedTotal =
+                                expectedTotalColl
+                            expectedReturnCoin =
+                                Coin (available - expectedTotal)
+                        body ^. totalCollateralTxBodyL
+                            `shouldBe` SJust expectedTotalColl
+                        case body
+                            ^. collateralReturnTxBodyL of
+                            SJust o -> do
+                                o ^. coinTxOutL
+                                    `shouldBe` expectedReturnCoin
+                            SNothing ->
+                                expectationFailure
+                                    "expected collateral_return \
+                                    \to be set"
+
+        it
+            "fee accounts for the bytes of total_collateral \
+            \and collateral_return"
+            $ do
+                let mockEval =
+                        outputCountingEval 200_000
+                result <-
+                    build
+                        pp
+                        noCtxInterpretIO
+                        mockEval
+                        [collUtxo, scriptUtxo]
+                        []
+                        (mkAddr 1)
+                        scriptProg
+                case result of
+                    Left err ->
+                        expectationFailure $ show err
+                    Right tx -> do
+                        -- The fee returned by build must
+                        -- be at least estimateMinFeeTx of
+                        -- the final body; otherwise the
+                        -- chain would reject for
+                        -- FeeTooSmallUTxO. We don't have
+                        -- estimateMinFeeTx in scope here,
+                        -- but a positive fee that
+                        -- balances the body is enough to
+                        -- prove the loop converged with
+                        -- the new fields counted.
+                        let Coin fee =
+                                tx
+                                    ^. bodyTxL
+                                        . feeTxBodyL
+                        fee `shouldSatisfy` (> 0)
+
+        it
+            "omits both fields for a tx with no script \
+            \witnesses"
+            $ do
+                let nonScriptProg :: TxBuild TestQ TestErr ()
+                    nonScriptProg = do
+                        _ <- spend (mkTxIn 2)
+                        _ <-
+                            payTo
+                                (mkAddr 4)
+                                (inject (Coin 3_000_000))
+                        -- Even with a collateral input
+                        -- declared, a tx with no
+                        -- redeemers must NOT carry
+                        -- total_collateral /
+                        -- collateral_return.
+                        collateral (mkTxIn 9)
+                    spendUtxo =
+                        ( mkTxIn 2
+                        , mkBasicTxOut
+                            (mkAddr 1)
+                            (inject (Coin 5_000_000))
+                        )
+                    mockEval _ = pure Map.empty
+                result <-
+                    build
+                        pp
+                        noCtxInterpretIO
+                        mockEval
+                        [collUtxo, spendUtxo]
+                        []
+                        (mkAddr 1)
+                        nonScriptProg
+                case result of
+                    Left err ->
+                        expectationFailure $ show err
+                    Right tx -> do
+                        tx
+                            ^. bodyTxL
+                                . totalCollateralTxBodyL
+                            `shouldBe` SNothing
+                        tx
+                            ^. bodyTxL
+                                . collateralReturnTxBodyL
+                            `shouldBe` SNothing
+
+        it
+            "setCollateralReturn redirects the return \
+            \output to the chosen address"
+            $ do
+                let customAddr = mkAddr 7
+                    progWithOverride ::
+                        TxBuild TestQ TestErr ()
+                    progWithOverride = do
+                        _ <-
+                            spendScript
+                                (mkTxIn 2)
+                                (42 :: Integer)
+                        _ <-
+                            payTo
+                                (mkAddr 4)
+                                (inject (Coin 3_000_000))
+                        collateral (mkTxIn 9)
+                        setCollateralReturn customAddr
+                    mockEval =
+                        outputCountingEval 200_000
+                result <-
+                    build
+                        pp
+                        noCtxInterpretIO
+                        mockEval
+                        [collUtxo, scriptUtxo]
+                        []
+                        (mkAddr 1)
+                        progWithOverride
+                case result of
+                    Left err ->
+                        expectationFailure $ show err
+                    Right tx ->
+                        case tx
+                            ^. bodyTxL
+                                . collateralReturnTxBodyL of
+                            SJust o ->
+                                o ^. addrTxOutL
+                                    `shouldBe` customAddr
+                            SNothing ->
+                                expectationFailure
+                                    "expected collateral_return \
+                                    \to be set"
 
 isSpend ::
     ConwayPlutusPurpose AsIx ConwayEra -> Bool


### PR DESCRIPTION
Closes #124.

## Summary

`Cardano.Node.Client.TxBuild.build` now populates the Conway body fields `total_collateral` (CBOR key 17) and `collateral_return` (CBOR key 16) whenever the tx has script witnesses + at least one collateral input. Without these fields the chain rejects script-bearing Conway txs, and the fee estimator under-counts by ~76 bytes (~3344 lovelace at base `txFeePerByte=44`) — the headline bug discovered in [amaru-treasury-tx#18](https://github.com/lambdasistemi/amaru-treasury-tx/pull/18).

The values are fully derived from protocol params + the balanced fee:
- `total_collateral = ceil(fee × collateralPercent / 100)`
- `collateral_return.value.coin = sum(collateral_inputs.lovelace) − total_collateral` (lovelace-only)
- `collateral_return.address` defaults to the change address; overridable via the new `setCollateralReturn` combinator (the only caller-facing knob).

## Tour of changes

### `lib/Cardano/Node/Client/Balance.hs`
- New `balanceTxWith` extends the fee fixpoint to derive `total_collateral` / `collateral_return` per iteration. `estimateMinFeeTx` therefore counts the new bytes in the same loop — no separate post-balance pass.
- New `BalanceError.CollateralShortfall !Coin !Coin` for when the collateral inputs supply less lovelace than the protocol requires (FR-009).
- `balanceTx` is now a thin wrapper around `balanceTxWith` (5-arg signature preserved).

### `lib/Cardano/Node/Client/TxBuild.hs`
- New `TxInstr.SetCollReturn :: Addr -> TxInstr q e ()` and smart constructor `setCollateralReturn :: Addr -> TxBuild q e ()`. Last-write-wins semantics matching `setValidFrom` / `setValidTo`.
- `TxState.tsCollReturnAddr :: StrictMaybe Addr` threaded through `interpretWithM`. `buildWith` resolves it (or falls back to `changeAddr`) and passes it to every `balanceTxWith` call site.
- New knob `BuildOptions.boCollateralUtxos :: [(TxIn, TxOut ConwayEra)]` for the collateral resolution map. Existing callers (and the in-tree convention where the same UTxO is both spend + collateral) keep `defaultBuildOptions`. Callers with separate spend / collateral UTxOs (mainnet golden vectors) populate it.

### Tests
- `test/Cardano/Node/Client/TxBuildSpec.hs`: four new assertions in a `collateralFieldsSpec` block — script-bearing tx emits the fields, fee accounts for them, non-script tx omits them, `setCollateralReturn` redirects the return address.
- `test/Cardano/Node/Client/TxBuildGoldenSpec.hs`: switches to `buildWith` with `boCollateralUtxos` so the ten mainnet golden vectors stay green. The synthetic UTxOs use a generous 100 ADA per collateral input — the structural-equivalence assertions don't compare `total_collateral` / `collateral_return`, so the value only needs to clear the floor.
- `test/Cardano/Node/Client/BalanceSpec.hs`: one extra exhaustive-pattern arm for the new `CollateralShortfall` constructor.

## What stays unchanged

- Non-script tx output is byte-identical to today (SC-005 in the spec). All pre-existing golden vectors and unit tests that exercise non-script flows pass without modification.
- `build`'s public signature is unchanged.
- The fee fixpoint's 10-iteration cap stays — `total_collateral` and `collateral_return` add at most a few CBOR bytes per iteration, well within the existing convergence budget.

## Out of scope (per the issue)

- No `setTotalCollateral` setter — `collateralPercent` is a protocol parameter and the formula is mandatory; an override would only produce invalid txs.
- No multi-asset collateral returns. `cardano-cli` doesn't do it either.
- No synthesis of collateral inputs when the program omits them. Existing chain-rejection path is preserved.

## Testing

- `nix develop --quiet -c just unit` → 221 examples, 0 failures.
- `nix develop --quiet -c just e2e` → 24 examples, 0 failures (~4 min).
- Format / hlint / cabal-fmt all green.

## Spec artifacts

The full speckit cycle lives under [`specs/040-txbuild-conway-collateral/`](https://github.com/lambdasistemi/cardano-node-clients/tree/040-txbuild-conway-collateral/specs/040-txbuild-conway-collateral): [spec.md](https://github.com/lambdasistemi/cardano-node-clients/blob/040-txbuild-conway-collateral/specs/040-txbuild-conway-collateral/spec.md), [plan.md](https://github.com/lambdasistemi/cardano-node-clients/blob/040-txbuild-conway-collateral/specs/040-txbuild-conway-collateral/plan.md), [research.md](https://github.com/lambdasistemi/cardano-node-clients/blob/040-txbuild-conway-collateral/specs/040-txbuild-conway-collateral/research.md), [data-model.md](https://github.com/lambdasistemi/cardano-node-clients/blob/040-txbuild-conway-collateral/specs/040-txbuild-conway-collateral/data-model.md), [contracts/txbuild-api.md](https://github.com/lambdasistemi/cardano-node-clients/blob/040-txbuild-conway-collateral/specs/040-txbuild-conway-collateral/contracts/txbuild-api.md), [quickstart.md](https://github.com/lambdasistemi/cardano-node-clients/blob/040-txbuild-conway-collateral/specs/040-txbuild-conway-collateral/quickstart.md), [tasks.md](https://github.com/lambdasistemi/cardano-node-clients/blob/040-txbuild-conway-collateral/specs/040-txbuild-conway-collateral/tasks.md).