### PR TITLE
chore: bump GHC to 9.12.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,23 +117,6 @@
         "type": "github"
       }
     },
-    "cabal-32_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
     "cabal-34": {
       "flake": false,
       "locked": {
@@ -446,11 +429,11 @@
     "hackage-for-stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1762302430,
-        "narHash": "sha256-thtGuIGrodKEfZPh+Sv22m1BR2zxNQY8RCsGlBWroj4=",
+        "lastModified": 1777941947,
+        "narHash": "sha256-lv/D6tAU+kOARnDutmRqBKeES+YtngYnfRwuEciqGlw=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "c5dc9e01d45948892915b5394f23986277fb0ccb",
+        "rev": "c790aeedf8b119a2cce4c085a4274ab570942bfd",
         "type": "github"
       },
       "original": {
@@ -527,17 +510,17 @@
     "hackageNix_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1776252609,
-        "narHash": "sha256-oUeHwNUXIAG89EihLIoUKSKolFOPwT+q4pPd8IogkJE=",
+        "lastModified": 1777942856,
+        "narHash": "sha256-uNleQgyctFm13GstMF0HiO4trN/4lQWroPYlfQJO7kM=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "55ba0ca4bcc9690f2ea45335cb2b9e95d8219a04",
+        "rev": "b6b4aa4bd699f743238da45c7f43da5a26a822f7",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "55ba0ca4bcc9690f2ea45335cb2b9e95d8219a04",
+        "rev": "b6b4aa4bd699f743238da45c7f43da5a26a822f7",
         "type": "github"
       }
     },
@@ -600,7 +583,6 @@
     "haskellNix_2": {
       "inputs": {
         "HTTP": "HTTP_2",
-        "cabal-32": "cabal-32_2",
         "cabal-34": "cabal-34_2",
         "cabal-36": "cabal-36_2",
         "cardano-shell": "cardano-shell_2",
@@ -615,6 +597,7 @@
         "hls-2.0": "hls-2.0_2",
         "hls-2.10": "hls-2.10_2",
         "hls-2.11": "hls-2.11_2",
+        "hls-2.12": "hls-2.12",
         "hls-2.2": "hls-2.2_2",
         "hls-2.3": "hls-2.3_2",
         "hls-2.4": "hls-2.4_2",
@@ -634,22 +617,23 @@
         "nixpkgs-2405": "nixpkgs-2405_2",
         "nixpkgs-2411": "nixpkgs-2411_2",
         "nixpkgs-2505": "nixpkgs-2505_2",
+        "nixpkgs-2511": "nixpkgs-2511",
         "nixpkgs-unstable": "nixpkgs-unstable_2",
         "old-ghc-nix": "old-ghc-nix_2",
         "stackage": "stackage_2"
       },
       "locked": {
-        "lastModified": 1762315551,
-        "narHash": "sha256-7uaB/UpiFn/+gf7s5NMpSTTUv5Ws30DjsmmqZry+1cY=",
+        "lastModified": 1777977445,
+        "narHash": "sha256-2MvOtjkuTdhqZnZI0g8HuvACrZKpGq0/4EESqsWt9ag=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "ef52c36b9835c77a255befe2a20075ba71e3bfab",
+        "rev": "8b447d7f57d62fab9249f79bb916bc891e29b9d0",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "ef52c36b9835c77a255befe2a20075ba71e3bfab",
+        "rev": "8b447d7f57d62fab9249f79bb916bc891e29b9d0",
         "type": "github"
       }
     },
@@ -801,6 +785,23 @@
       "original": {
         "owner": "haskell",
         "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758709460,
+        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.12.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -1211,17 +1212,33 @@
     "iserv-proxy_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1755243078,
-        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
+        "lastModified": 1775620557,
+        "narHash": "sha256-10x8/G0x3eR/++XRHPx4MBuqlnc6+N+ajIxXyLkG+nU=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
+        "rev": "3f7b2815307c20a0dfd816bdf4a39ab86af3e0d4",
         "type": "github"
       },
       "original": {
         "owner": "stable-haskell",
         "ref": "iserv-syms",
         "repo": "iserv-proxy",
+        "type": "github"
+      }
+    },
+    "lintNixpkgs": {
+      "locked": {
+        "lastModified": 1759070547,
+        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
         "type": "github"
       }
     },
@@ -1391,11 +1408,11 @@
     },
     "nixpkgs-2411_2": {
       "locked": {
-        "lastModified": 1748037224,
-        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "lastModified": 1751290243,
+        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
         "type": "github"
       },
       "original": {
@@ -1423,16 +1440,32 @@
     },
     "nixpkgs-2505_2": {
       "locked": {
-        "lastModified": 1757716134,
-        "narHash": "sha256-OYoZLWvmCnCTCJQwaQlpK1IO5nkLnLLoUW8wwmPmrfU=",
+        "lastModified": 1764560356,
+        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e85b5aa112a98805a016bbf6291e726debbc448a",
+        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2511": {
+      "locked": {
+        "lastModified": 1775749320,
+        "narHash": "sha256-msT6frWJSQ2WR+0cpk+KPcZdLTLagUIsJwQwIX9JNSo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "74b87959b2d16f59f54d8559cf3cf26b9d907949",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1485,11 +1518,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1759070547,
-        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {
@@ -1541,6 +1574,7 @@
         "hackageNix": "hackageNix_3",
         "haskellNix": "haskellNix_2",
         "iohkNix": "iohkNix_2",
+        "lintNixpkgs": "lintNixpkgs",
         "mkdocs": "mkdocs",
         "nixpkgs": [
           "haskellNix",
@@ -1635,11 +1669,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1762301584,
-        "narHash": "sha256-yLihKEbngbLV1EhuLJSencMCtrDM2sYGsVZkX8xlSK8=",
+        "lastModified": 1777941049,
+        "narHash": "sha256-QyXmYtr1Sqzezfot7ARd5OL/0sMot/cybcZJh7EmYE0=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "ce12bd44df0b5488bdbbe8762d79379e2bc76d62",
+        "rev": "aeb46c4a0af96a116fb0c9dc54cfae2fd6e01a39",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,14 +9,16 @@
   inputs = {
     haskellNix = {
       url =
-        "github:input-output-hk/haskell.nix/ef52c36b9835c77a255befe2a20075ba71e3bfab";
+        "github:input-output-hk/haskell.nix/8b447d7f57d62fab9249f79bb916bc891e29b9d0";
       inputs.hackage.follows = "hackageNix";
     };
     hackageNix = {
-      url = "github:input-output-hk/hackage.nix/55ba0ca4bcc9690f2ea45335cb2b9e95d8219a04";
+      url = "github:input-output-hk/hackage.nix/b6b4aa4bd699f743238da45c7f43da5a26a822f7";
       flake = false;
     };
     nixpkgs.follows = "haskellNix/nixpkgs-unstable";
+    lintNixpkgs.url =
+      "github:NixOS/nixpkgs/647e5c14cbd5067f44ac86b74f014962df460840";
     flake-parts.url = "github:hercules-ci/flake-parts";
     iohkNix = {
       url =
@@ -34,8 +36,8 @@
     };
   };
 
-  outputs = inputs@{ self, nixpkgs, flake-parts, haskellNix, hackageNix
-    , iohkNix, CHaP, mkdocs, cardano-node, ... }:
+  outputs = inputs@{ self, nixpkgs, lintNixpkgs, flake-parts, haskellNix
+    , hackageNix, iohkNix, CHaP, mkdocs, cardano-node, ... }:
     let
       imageTag =
         self.dirtyShortRev or self.shortRev or "unknown";
@@ -56,6 +58,7 @@
             ];
             inherit system;
           };
+          lintPkgs = import lintNixpkgs { inherit system; };
           indexState = "2026-02-17T10:15:41Z";
           indexTool = { index-state = indexState; };
           fix-libs = { lib, pkgs, ... }: {
@@ -80,16 +83,16 @@
           project = pkgs.haskell-nix.cabalProject' {
             name = "cardano-node-clients";
             src = ./.;
-            compiler-nix-name = "ghc9122";
+            compiler-nix-name = "ghc9123";
             shell = {
-              withHoogle = false;
+              withHoogle = true;
               tools = {
                 cabal = indexTool;
               };
               buildInputs = [
-                pkgs.haskellPackages.cabal-fmt
-                pkgs.haskellPackages.fourmolu
-                pkgs.haskellPackages.hlint
+                lintPkgs.haskellPackages.cabal-fmt
+                lintPkgs.haskellPackages.fourmolu
+                lintPkgs.haskellPackages.hlint
                 pkgs.just
                 pkgs.mkdocs
                 pkgs.curl
@@ -110,7 +113,7 @@
           };
           components = project.hsPkgs.cardano-node-clients.components;
           checks = import ./nix/checks.nix {
-            inherit pkgs components;
+            inherit pkgs components lintPkgs;
             cardanoNode = cardano-node.packages.${system}.cardano-node;
             src = ./.;
           };

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,4 +1,4 @@
-{ pkgs, src, components, cardanoNode }:
+{ pkgs, src, components, cardanoNode, lintPkgs ? pkgs }:
 let
   build = pkgs.writeShellApplication {
     name = "build";
@@ -32,7 +32,7 @@ let
 
   lint = pkgs.writeShellApplication {
     name = "lint";
-    runtimeInputs = with pkgs.haskellPackages; [
+    runtimeInputs = with lintPkgs.haskellPackages; [
       cabal-fmt
       fourmolu
       hlint


### PR DESCRIPTION
## Summary
- bump the haskell.nix/hackage.nix pins so the flake exposes GHC 9.12.3
- switch the project compiler from ghc9122 to ghc9123
- re-enable Hoogle in the development shell
- keep lint tools pinned to the previous nixpkgs revision so this PR does not become a repo-wide formatter migration

## Verification
- `nix develop --quiet -c ghc --numeric-version` -> `9.12.3`
- `nix develop --quiet -c hoogle --version` -> `Hoogle 5.0.19.0`
- `nix develop --quiet -c hoogle 'balanceTx' --count=5`\n- `nix develop --quiet -c bash -lc 'fourmolu --version && hlint --version && ghc --numeric-version && hoogle --version'` -> Fourmolu 0.15.0.0, HLint 3.8, GHC 9.12.3, Hoogle 5.0.19.0\n- `nix run --quiet .#lint` -> No hints\n- `nix develop --quiet -c just build`\n- `nix develop --quiet -c just unit` -> 222 examples, 0 failures\n\nE2E suite not run locally.