### PR TITLE
Provider acquired query sessions

### DIFF
--- a/docs/modules/provider.md
+++ b/docs/modules/provider.md
@@ -8,9 +8,13 @@ Protocol-agnostic interface for querying the Cardano blockchain.
 
 ```haskell
 data Provider m = Provider
-    { queryUTxOs         :: Addr -> m [(TxIn, TxOut ConwayEra)]
+    { withAcquired       :: forall a. (QueryHandle m -> m a) -> m a
+    , queryUTxOs         :: Addr -> m [(TxIn, TxOut ConwayEra)]
+    , queryUTxOByTxIn    :: Set TxIn -> m (Map TxIn (TxOut ConwayEra))
     , queryProtocolParams :: m (PParams ConwayEra)
-    , evaluateTx         :: Tx ConwayEra -> m (EvaluateTxResult ConwayEra)
+    , evaluateTx         :: ConwayTx -> m (EvaluateTxResult ConwayEra)
+    , posixMsToSlot      :: Integer -> m SlotNo
+    , posixMsCeilSlot    :: Integer -> m SlotNo
     }
 ```
 
@@ -18,9 +22,48 @@ data Provider m = Provider
 
 | Field | Description |
 |-------|-------------|
+| `withAcquired` | Run several queries against one acquired ledger snapshot |
 | `queryUTxOs` | Look up UTxOs at an address |
+| `queryUTxOByTxIn` | Look up UTxOs by their transaction inputs |
 | `queryProtocolParams` | Fetch current protocol parameters |
 | `evaluateTx` | Evaluate script execution units for a transaction |
+| `posixMsToSlot` | Convert POSIX milliseconds to a floor `SlotNo` |
+| `posixMsCeilSlot` | Convert POSIX milliseconds to a ceiling `SlotNo` |
+
+## Acquired Sessions
+
+`withAcquired` gives the callback a `QueryHandle` whose query functions
+share one LocalStateQuery `Acquire`. N2C-backed handles keep the node
+protocol client in the acquired state until the callback returns, so all
+handle queries read the same ledger snapshot.
+
+```haskell
+withAcquired provider $ \handle -> do
+    pp <- queryProtocolParamsH handle
+    byAddress <- queryUTxOsAtH handle requestedAddresses
+    byInput <- queryUTxOByTxInH handle requestedInputs
+    pure (pp, byAddress, byInput)
+```
+
+Handle functions mirror the LSQ-backed provider methods:
+
+| Handle function | Description |
+|-----------------|-------------|
+| `queryUTxOsH` | Look up UTxOs at one address in the acquired snapshot |
+| `queryUTxOsAtH` | Look up UTxOs at several addresses, grouped by address |
+| `queryUTxOByTxInH` | Look up UTxOs by their transaction inputs |
+| `queryProtocolParamsH` | Fetch protocol parameters |
+| `evaluateTxH` | Evaluate script execution units |
+| `posixMsToSlotH` | Convert POSIX milliseconds to a floor `SlotNo` |
+| `posixMsCeilSlotH` | Convert POSIX milliseconds to a ceiling `SlotNo` |
+
+The standalone provider methods are unchanged for callers. For N2C they
+wrap `withAcquired` internally with one query, so existing call sites can
+keep using `queryUTxOs`, `queryUTxOByTxIn`, `queryProtocolParams`,
+`evaluateTx`, `posixMsToSlot`, and `posixMsCeilSlot`. When several
+related reads must share one snapshot, prefer one explicit `withAcquired`
+callback instead of several standalone calls; each standalone N2C call
+opens and releases its own acquired session.
 
 ### `evaluateTx`
 
@@ -49,4 +92,11 @@ let provider = mkN2CProvider lsqChannel
 utxos  <- queryUTxOs provider myAddress
 pp     <- queryProtocolParams provider
 exUnits <- evaluateTx provider mySignedTx
+
+(pp2, utxosByAddress, utxosByInput) <-
+    withAcquired provider $ \handle -> do
+        pp2 <- queryProtocolParamsH handle
+        utxosByAddress <- queryUTxOsAtH handle myAddresses
+        utxosByInput <- queryUTxOByTxInH handle myInputs
+        pure (pp2, utxosByAddress, utxosByInput)
 ```

--- a/lib/Cardano/Node/Client/N2C/LocalStateQuery.hs
+++ b/lib/Cardano/Node/Client/N2C/LocalStateQuery.hs
@@ -5,10 +5,11 @@ License     : Apache-2.0
 
 Channel-driven LocalStateQuery client. On each
 iteration: waits for a query on the 'LSQChannel',
-acquires the volatile tip, drains all queued queries
-(batching them in a single acquired session), then
-releases and loops. This avoids re-acquiring for
-rapid-fire queries.
+acquires the volatile tip, serves the request, then
+releases and loops. One-shot requests queued behind
+another one-shot request can still be served in the
+same acquired state, but explicit acquired sessions
+always begin from their own acquire.
 -}
 module Cardano.Node.Client.N2C.LocalStateQuery (
     -- * Client construction
@@ -16,11 +17,16 @@ module Cardano.Node.Client.N2C.LocalStateQuery (
 
     -- * Query helpers
     queryLSQ,
+    withAcquiredLSQ,
+    queryAcquiredLSQ,
 ) where
 
 import Cardano.Node.Client.N2C.Types (
+    AcquiredLSQ (..),
+    AcquiredLSQRequest (..),
     ConnectionLost (..),
     LSQChannel (..),
+    LSQRequest (..),
     SomeLSQQuery (..),
  )
 import Cardano.Node.Client.Types (
@@ -28,8 +34,10 @@ import Cardano.Node.Client.Types (
     BlockPoint,
  )
 import Control.Concurrent.STM (
+    TMVar,
     atomically,
     newEmptyTMVarIO,
+    newTBQueueIO,
     putTMVar,
     readTBQueue,
     takeTMVar,
@@ -39,8 +47,12 @@ import Control.Concurrent.STM (
 import Control.Exception (
     BlockedIndefinitelyOnSTM,
     handle,
+    mask,
+    onException,
     throwIO,
  )
+import Control.Monad (void)
+import Numeric.Natural (Natural)
 import Ouroboros.Consensus.Ledger.Query (Query)
 import Ouroboros.Network.Protocol.LocalStateQuery.Client (
     ClientStAcquired (..),
@@ -52,6 +64,17 @@ import Ouroboros.Network.Protocol.LocalStateQuery.Client (
 import Ouroboros.Network.Protocol.LocalStateQuery.Type (
     Target (..),
  )
+
+{- | Per-session command queue capacity.
+
+Acquired-session callbacks normally issue queries
+sequentially. The bound still allows a small amount
+of callback-local concurrency while applying
+back-pressure instead of letting leaked handles grow
+memory without limit.
+-}
+acquiredLSQQueueCapacity :: Natural
+acquiredLSQQueueCapacity = 16
 
 {- | Build a 'LocalStateQueryClient' driven by the
 given channel. The client loops: wait for a query,
@@ -85,16 +108,47 @@ waitAndAcquire ::
 waitAndAcquire ch = do
     -- Block until at least one query arrives
     req <- atomically $ readTBQueue (lsqRequests ch)
-    -- Now acquire the latest volatile tip
+    acquireAndServe ch req
+
+-- | Acquire the volatile tip for a specific request.
+acquireAndServe ::
+    LSQChannel ->
+    LSQRequest ->
+    IO
+        ( ClientStIdle
+            Block
+            BlockPoint
+            (Query Block)
+            IO
+            ()
+        )
+acquireAndServe ch req =
     pure $
         SendMsgAcquire
             VolatileTip
             ClientStAcquiring
                 { recvMsgAcquired =
-                    serveQuery ch req
+                    serveRequest ch req
                 , recvMsgFailure = \_failure ->
                     waitAndAcquire ch
                 }
+
+-- | Serve an acquired request.
+serveRequest ::
+    LSQChannel ->
+    LSQRequest ->
+    IO
+        ( ClientStAcquired
+            Block
+            BlockPoint
+            (Query Block)
+            IO
+            ()
+        )
+serveRequest ch (LSQOneShot query) =
+    serveQuery ch query
+serveRequest ch (LSQAcquire acquired acquiredVar) =
+    serveAcquired ch acquired acquiredVar
 
 -- | Serve a single query, then check for more.
 serveQuery ::
@@ -123,8 +177,12 @@ serveQuery ch (SomeLSQQuery query resultVar) =
                             tryReadTBQueue
                                 (lsqRequests ch)
                     case mNext of
-                        Just next ->
+                        Just (LSQOneShot next) ->
                             serveQuery ch next
+                        Just next ->
+                            pure $
+                                SendMsgRelease $
+                                    acquireAndServe ch next
                         Nothing ->
                             -- No more; release and
                             -- wait for next batch
@@ -132,6 +190,56 @@ serveQuery ch (SomeLSQQuery query resultVar) =
                                 SendMsgRelease $
                                     waitAndAcquire ch
                 }
+
+-- | Serve commands from an acquired-session queue.
+serveAcquired ::
+    LSQChannel ->
+    AcquiredLSQ ->
+    TMVar () ->
+    IO
+        ( ClientStAcquired
+            Block
+            BlockPoint
+            (Query Block)
+            IO
+            ()
+        )
+serveAcquired ch acquired acquiredVar = do
+    atomically $ putTMVar acquiredVar ()
+    serveAcquiredCommand ch acquired
+
+serveAcquiredCommand ::
+    LSQChannel ->
+    AcquiredLSQ ->
+    IO
+        ( ClientStAcquired
+            Block
+            BlockPoint
+            (Query Block)
+            IO
+            ()
+        )
+serveAcquiredCommand ch acquired = do
+    req <-
+        atomically $
+            readTBQueue (acquiredLSQRequests acquired)
+    case req of
+        AcquiredLSQQuery query resultVar ->
+            pure $
+                SendMsgQuery
+                    query
+                    ClientStQuerying
+                        { recvMsgResult = \result -> do
+                            atomically $
+                                putTMVar resultVar result
+                            serveAcquiredCommand ch acquired
+                        }
+        AcquiredLSQRelease releaseVar -> do
+            atomically $
+                putTMVar releaseVar ()
+            pure $
+                SendMsgRelease $
+                    waitAndAcquire ch
 
 {- | Submit a query through the channel and block
 until the result is available.
@@ -146,7 +254,64 @@ queryLSQ ch query = do
     resultVar <- newEmptyTMVarIO
     atomically $
         writeTBQueue (lsqRequests ch) $
-            SomeLSQQuery query resultVar
+            LSQOneShot $
+                SomeLSQQuery query resultVar
+    takeTMVarOrConnectionLost resultVar
+
+{- | Acquire LocalStateQuery once, run a callback, then
+release the acquired session.
+-}
+withAcquiredLSQ ::
+    LSQChannel ->
+    (AcquiredLSQ -> IO a) ->
+    IO a
+withAcquiredLSQ ch action =
+    mask $ \restore -> do
+        acquired <-
+            AcquiredLSQ
+                <$> newTBQueueIO acquiredLSQQueueCapacity
+        acquiredVar <- newEmptyTMVarIO
+        atomically $
+            writeTBQueue (lsqRequests ch) $
+                LSQAcquire acquired acquiredVar
+        takeTMVarOrConnectionLost acquiredVar
+        result <-
+            restore (action acquired)
+                `onException` releaseAcquiredLSQ acquired
+        releaseAcquiredLSQ acquired
+        pure result
+
+{- | Submit a query through an acquired session and
+block until the result is available.
+-}
+queryAcquiredLSQ ::
+    AcquiredLSQ ->
+    Query Block result ->
+    IO result
+queryAcquiredLSQ acquired query = do
+    resultVar <- newEmptyTMVarIO
+    atomically $
+        writeTBQueue
+            (acquiredLSQRequests acquired)
+            (AcquiredLSQQuery query resultVar)
+    takeTMVarOrConnectionLost resultVar
+
+releaseAcquiredLSQ ::
+    AcquiredLSQ ->
+    IO ()
+releaseAcquiredLSQ acquired = do
+    releaseVar <- newEmptyTMVarIO
+    atomically $
+        writeTBQueue
+            (acquiredLSQRequests acquired)
+            (AcquiredLSQRelease releaseVar)
+    void $
+        takeTMVarOrConnectionLost releaseVar
+
+takeTMVarOrConnectionLost ::
+    TMVar a ->
+    IO a
+takeTMVarOrConnectionLost resultVar =
     -- Catch the synchronous-deadlock detection that GHC
     -- raises when the consumer thread died with this
     -- request in flight, and re-raise 'ConnectionLost' so

--- a/lib/Cardano/Node/Client/N2C/Provider.hs
+++ b/lib/Cardano/Node/Client/N2C/Provider.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RankNTypes #-}
+
 {- |
 Module      : Cardano.Node.Client.N2C.Provider
 Description : N2C-backed Provider via LocalStateQuery
@@ -27,6 +29,7 @@ import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Control.Monad.Trans.Except (runExcept)
 import Lens.Micro ((^.))
 
+import Cardano.Ledger.Address (Addr)
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (
     evalTxExUnits,
  )
@@ -35,8 +38,12 @@ import Cardano.Ledger.Api.Tx.Body (
     inputsTxBodyL,
     referenceInputsTxBodyL,
  )
-import Cardano.Ledger.Core (bodyTxL)
+import Cardano.Ledger.Api.Tx.Out (TxOut, addrTxOutL)
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core (PParams, bodyTxL)
 import Cardano.Ledger.State (UTxO (..))
+import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Node.Client.Ledger (ConwayTx)
 import Cardano.Slotting.EpochInfo (hoistEpochInfo)
 import Cardano.Slotting.Time (
     RelativeTime (..),
@@ -67,10 +74,25 @@ import Ouroboros.Consensus.Shelley.Ledger.Query (
  )
 
 import Cardano.Node.Client.N2C.LocalStateQuery (
-    queryLSQ,
+    queryAcquiredLSQ,
+    withAcquiredLSQ,
  )
 import Cardano.Node.Client.N2C.Types (LSQChannel)
-import Cardano.Node.Client.Provider (Provider (..), SlotNo)
+import Cardano.Node.Client.Provider (
+    EvaluateTxResult,
+    Provider (..),
+    QueryHandle,
+    QueryHandleBackend (..),
+    SlotNo,
+    evaluateTxH,
+    mkQueryHandle,
+    posixMsCeilSlotH,
+    posixMsToSlotH,
+    queryProtocolParamsH,
+    queryUTxOByTxInH,
+    queryUTxOsH,
+ )
+import Cardano.Node.Client.Types (Block)
 
 {- | Create a 'Provider IO' backed by the N2C
 LocalStateQuery protocol.
@@ -81,118 +103,220 @@ mkN2CProvider ::
     Provider IO
 mkN2CProvider ch =
     Provider
-        { queryProtocolParams = do
-            result <-
-                queryLSQ ch $
-                    BlockQuery $
-                        QueryIfCurrentConway
-                            GetCurrentPParams
-            case result of
-                Right pp -> pure pp
-                Left _mismatch ->
-                    error
-                        "queryProtocolParams: era \
-                        \mismatch — node not in Conway"
-        , queryUTxOs = \addr -> do
-            result <-
-                queryLSQ ch $
-                    BlockQuery $
-                        QueryIfCurrentConway $
-                            GetUTxOByAddress
-                                (Set.singleton addr)
-            case result of
-                Right utxo ->
-                    pure $
-                        Map.toList $
-                            unUTxO utxo
-                Left _mismatch ->
-                    error
-                        "queryUTxOs: era mismatch \
-                        \— node not in Conway"
-        , queryUTxOByTxIn = \txins -> do
-            result <-
-                queryLSQ ch $
-                    BlockQuery $
-                        QueryIfCurrentConway $
-                            GetUTxOByTxIn txins
-            case result of
-                Right utxo -> pure $ unUTxO utxo
-                Left _mismatch ->
-                    error
-                        "queryUTxOByTxIn: era \
-                        \mismatch — node not in \
-                        \Conway"
-        , evaluateTx = \tx -> do
-            let body = tx ^. bodyTxL
-                allInputs =
-                    Set.unions
-                        [ body ^. inputsTxBodyL
-                        , body
-                            ^. collateralInputsTxBodyL
-                        , body
-                            ^. referenceInputsTxBodyL
-                        ]
-            -- Resolve UTxOs for all inputs
-            utxoResult <-
-                queryLSQ ch $
-                    BlockQuery $
-                        QueryIfCurrentConway $
-                            GetUTxOByTxIn allInputs
-            utxo <- case utxoResult of
-                Right u -> pure u
-                Left _mismatch ->
-                    error
-                        "evaluateTx: era mismatch \
-                        \— node not in Conway"
-            -- Protocol parameters
-            ppResult <-
-                queryLSQ ch $
-                    BlockQuery $
-                        QueryIfCurrentConway
-                            GetCurrentPParams
-            pp <- case ppResult of
-                Right p -> pure p
-                Left _mismatch ->
-                    error
-                        "evaluateTx: era mismatch \
-                        \— node not in Conway"
-            -- System start
-            systemStart <-
-                queryLSQ ch GetSystemStart
-            -- Hard-fork interpreter → EpochInfo
-            interpreter <-
-                queryLSQ ch $
-                    BlockQuery $
-                        QueryHardFork GetInterpreter
-            let epochInfo =
-                    hoistEpochInfo
-                        ( first (T.pack . show)
-                            . runExcept
-                        )
-                        $ interpreterToEpochInfo
-                            interpreter
-            pure $
-                evalTxExUnits
-                    pp
-                    tx
-                    utxo
-                    epochInfo
-                    systemStart
-        , posixMsToSlot = \ms -> do
-            (slot, _, _) <-
-                queryWallclockToSlot ch ms
-            pure slot
-        , posixMsCeilSlot = \ms -> do
-            (slot, timeInSlot, _slotLen) <-
-                queryWallclockToSlot ch ms
-            -- If the time falls exactly on a slot
-            -- boundary, floor == ceil. Otherwise
-            -- advance to the next slot.
-            pure $
-                if timeInSlot == 0
-                    then slot
-                    else slot + 1
+        { withAcquired = withAcquiredN2C
+        , queryProtocolParams =
+            withAcquiredN2C queryProtocolParamsH
+        , queryUTxOs = \addr ->
+            withAcquiredN2C $ \handle ->
+                queryUTxOsH handle addr
+        , queryUTxOByTxIn = \txins ->
+            withAcquiredN2C $ \handle ->
+                queryUTxOByTxInH handle txins
+        , evaluateTx = \tx ->
+            withAcquiredN2C $ \handle ->
+                evaluateTxH handle tx
+        , posixMsToSlot = \ms ->
+            withAcquiredN2C $ \handle ->
+                posixMsToSlotH handle ms
+        , posixMsCeilSlot = \ms ->
+            withAcquiredN2C $ \handle ->
+                posixMsCeilSlotH handle ms
         }
+  where
+    withAcquiredN2C ::
+        forall a.
+        (QueryHandle IO -> IO a) ->
+        IO a
+    withAcquiredN2C callback =
+        withAcquiredLSQ ch $ \acquired ->
+            callback $
+                mkN2CQueryHandle $
+                    queryAcquiredLSQ acquired
+
+mkN2CQueryHandle ::
+    (forall result. Query Block result -> IO result) ->
+    QueryHandle IO
+mkN2CQueryHandle runQuery =
+    mkQueryHandle
+        QueryHandleBackend
+            { backendQueryUTxOs = queryOneAddress
+            , backendQueryUTxOsAt = queryUTxOsAtN2C runQuery
+            , backendQueryUTxOByTxIn = queryUTxOByTxInN2C runQuery
+            , backendQueryProtocolParams = queryProtocolParamsN2C runQuery
+            , backendEvaluateTx = evaluateTxN2C runQuery
+            , backendPosixMsToSlot = posixMsToSlotN2C runQuery
+            , backendPosixMsCeilSlot = posixMsCeilSlotN2C runQuery
+            }
+  where
+    queryOneAddress addr =
+        Map.findWithDefault [] addr
+            <$> queryUTxOsAtN2C
+                runQuery
+                (Set.singleton addr)
+
+queryProtocolParamsN2C ::
+    (forall result. Query Block result -> IO result) ->
+    IO (PParams ConwayEra)
+queryProtocolParamsN2C runQuery = do
+    result <-
+        runQuery $
+            BlockQuery $
+                QueryIfCurrentConway
+                    GetCurrentPParams
+    case result of
+        Right pp -> pure pp
+        Left _mismatch ->
+            error
+                "queryProtocolParams: era \
+                \mismatch — node not in Conway"
+
+queryUTxOsAtN2C ::
+    (forall result. Query Block result -> IO result) ->
+    Set.Set Addr ->
+    IO (Map.Map Addr [(TxIn, TxOut ConwayEra)])
+queryUTxOsAtN2C runQuery addrs = do
+    result <-
+        runQuery $
+            BlockQuery $
+                QueryIfCurrentConway $
+                    GetUTxOByAddress addrs
+    case result of
+        Right utxo ->
+            pure $
+                groupUTxOByAddress addrs $
+                    unUTxO utxo
+        Left _mismatch ->
+            error
+                "queryUTxOsAtH: era mismatch \
+                \— node not in Conway"
+
+groupUTxOByAddress ::
+    Set.Set Addr ->
+    Map.Map TxIn (TxOut ConwayEra) ->
+    Map.Map Addr [(TxIn, TxOut ConwayEra)]
+groupUTxOByAddress addrs utxo =
+    Map.unionWith (++) grouped emptyRequested
+  where
+    emptyRequested =
+        Map.fromSet (const []) addrs
+    grouped =
+        foldl' addEntry Map.empty $
+            Map.toAscList utxo
+    addEntry acc (txIn, txOut)
+        | Set.member addr addrs =
+            Map.insertWith
+                (flip (++))
+                addr
+                [(txIn, txOut)]
+                acc
+        | otherwise =
+            acc
+      where
+        addr =
+            txOut ^. addrTxOutL
+
+queryUTxOByTxInN2C ::
+    (forall result. Query Block result -> IO result) ->
+    Set.Set TxIn ->
+    IO (Map.Map TxIn (TxOut ConwayEra))
+queryUTxOByTxInN2C runQuery txins = do
+    result <-
+        runQuery $
+            BlockQuery $
+                QueryIfCurrentConway $
+                    GetUTxOByTxIn txins
+    case result of
+        Right utxo -> pure $ unUTxO utxo
+        Left _mismatch ->
+            error
+                "queryUTxOByTxIn: era \
+                \mismatch — node not in \
+                \Conway"
+
+evaluateTxN2C ::
+    (forall result. Query Block result -> IO result) ->
+    ConwayTx ->
+    IO (EvaluateTxResult ConwayEra)
+evaluateTxN2C runQuery tx = do
+    let body = tx ^. bodyTxL
+        allInputs =
+            Set.unions
+                [ body ^. inputsTxBodyL
+                , body
+                    ^. collateralInputsTxBodyL
+                , body
+                    ^. referenceInputsTxBodyL
+                ]
+    -- Resolve UTxOs for all inputs
+    utxoResult <-
+        runQuery $
+            BlockQuery $
+                QueryIfCurrentConway $
+                    GetUTxOByTxIn allInputs
+    utxo <- case utxoResult of
+        Right u -> pure u
+        Left _mismatch ->
+            error
+                "evaluateTx: era mismatch \
+                \— node not in Conway"
+    -- Protocol parameters
+    ppResult <-
+        runQuery $
+            BlockQuery $
+                QueryIfCurrentConway
+                    GetCurrentPParams
+    pp <- case ppResult of
+        Right p -> pure p
+        Left _mismatch ->
+            error
+                "evaluateTx: era mismatch \
+                \— node not in Conway"
+    -- System start
+    systemStart <-
+        runQuery GetSystemStart
+    -- Hard-fork interpreter → EpochInfo
+    interpreter <-
+        runQuery $
+            BlockQuery $
+                QueryHardFork GetInterpreter
+    let epochInfo =
+            hoistEpochInfo
+                ( first (T.pack . show)
+                    . runExcept
+                )
+                $ interpreterToEpochInfo
+                    interpreter
+    pure $
+        evalTxExUnits
+            pp
+            tx
+            utxo
+            epochInfo
+            systemStart
+
+posixMsToSlotN2C ::
+    (forall result. Query Block result -> IO result) ->
+    Integer ->
+    IO SlotNo
+posixMsToSlotN2C runQuery ms = do
+    (slot, _, _) <-
+        queryWallclockToSlot runQuery ms
+    pure slot
+
+posixMsCeilSlotN2C ::
+    (forall result. Query Block result -> IO result) ->
+    Integer ->
+    IO SlotNo
+posixMsCeilSlotN2C runQuery ms = do
+    (slot, timeInSlot, _slotLen) <-
+        queryWallclockToSlot runQuery ms
+    -- If the time falls exactly on a slot
+    -- boundary, floor == ceil. Otherwise
+    -- advance to the next slot.
+    pure $
+        if timeInSlot == 0
+            then slot
+            else slot + 1
 
 {- | Query SystemStart and HardFork interpreter,
 then convert POSIX milliseconds to a slot via
@@ -200,14 +324,14 @@ then convert POSIX milliseconds to a slot via
 within that slot, and the slot length.
 -}
 queryWallclockToSlot ::
-    LSQChannel ->
+    (forall result. Query Block result -> IO result) ->
     Integer ->
     IO (SlotNo, NominalDiffTime, NominalDiffTime)
-queryWallclockToSlot ch ms = do
+queryWallclockToSlot runQuery ms = do
     systemStart <-
-        queryLSQ ch GetSystemStart
+        runQuery GetSystemStart
     interpreter <-
-        queryLSQ ch $
+        runQuery $
             BlockQuery $
                 QueryHardFork GetInterpreter
     let utcTime =

--- a/lib/Cardano/Node/Client/N2C/Types.hs
+++ b/lib/Cardano/Node/Client/N2C/Types.hs
@@ -13,7 +13,9 @@ protocol-parameter queries) and LocalTxSubmission
 
 Communication is channel-based: callers enqueue
 requests into a 'TBQueue' and block on a 'TMVar'
-for the result.
+for the result. Acquired sessions use a second
+queue that is served while the LocalStateQuery
+client remains in the acquired state.
 -}
 module Cardano.Node.Client.N2C.Types (
     -- * Channel types
@@ -21,6 +23,9 @@ module Cardano.Node.Client.N2C.Types (
     LTxSChannel (..),
 
     -- * Request wrappers
+    AcquiredLSQ (..),
+    AcquiredLSQRequest (..),
+    LSQRequest (..),
     SomeLSQQuery (..),
     TxSubmitRequest (..),
 
@@ -48,14 +53,48 @@ data SomeLSQQuery where
         TMVar result ->
         SomeLSQQuery
 
+{- | Commands accepted while the protocol client is
+already acquired.
+-}
+data AcquiredLSQRequest where
+    AcquiredLSQQuery ::
+        Query Block result ->
+        TMVar result ->
+        AcquiredLSQRequest
+    AcquiredLSQRelease ::
+        TMVar () ->
+        AcquiredLSQRequest
+
+-- | Internal handle for an acquired LSQ session.
+newtype AcquiredLSQ = AcquiredLSQ
+    { acquiredLSQRequests :: TBQueue AcquiredLSQRequest
+    }
+
+{- | Requests accepted by the idle LSQ client.
+
+One-shot queries acquire, query, and release. Acquired
+sessions acquire once, then serve commands from the
+session queue until release.
+-}
+data LSQRequest where
+    LSQOneShot ::
+        SomeLSQQuery ->
+        LSQRequest
+    LSQAcquire ::
+        AcquiredLSQ ->
+        TMVar () ->
+        LSQRequest
+
 {- | Channel for communicating with the
 LocalStateQuery mini-protocol client.
 
-Callers enqueue a 'SomeLSQQuery' and then block
-on the embedded 'TMVar' to receive the result.
+Callers enqueue an 'LSQRequest'. One-shot callers
+block on the embedded query 'TMVar'. Acquired-session
+callers wait for the acquire acknowledgement, then
+send commands to the acquired-session queue.
 -}
 newtype LSQChannel = LSQChannel
-    { lsqRequests :: TBQueue SomeLSQQuery
+    { lsqRequests :: TBQueue LSQRequest
     }
 
 {- | A transaction submission request bundled with

--- a/lib/Cardano/Node/Client/Provider.hs
+++ b/lib/Cardano/Node/Client/Provider.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RankNTypes #-}
+
 {- |
 Module      : Cardano.Node.Client.Provider
 Description : Protocol-agnostic query interface
@@ -10,6 +12,20 @@ constructors (e.g. 'Cardano.Node.Client.N2C.Provider.mkN2CProvider').
 module Cardano.Node.Client.Provider (
     -- * Provider interface
     Provider (..),
+    QueryHandle,
+    QueryHandleBackend (..),
+    mkQueryHandle,
+    singleShotQueryHandle,
+    singleShotWithAcquired,
+
+    -- * Acquired-session queries
+    queryUTxOsH,
+    queryUTxOsAtH,
+    queryUTxOByTxInH,
+    queryProtocolParamsH,
+    evaluateTxH,
+    posixMsToSlotH,
+    posixMsCeilSlotH,
 
     -- * Result types
     EvaluateTxResult,
@@ -19,7 +35,9 @@ module Cardano.Node.Client.Provider (
 ) where
 
 import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
 import Data.Set (Set)
+import Data.Set qualified as Set
 
 import Cardano.Ledger.Address (Addr)
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (
@@ -46,11 +64,140 @@ type EvaluateTxResult era =
             ExUnits
         )
 
+{- | Query operations bound to one acquired ledger
+snapshot.
+
+The constructor is intentionally not exported.
+Provider implementations build handles with
+'mkQueryHandle'; consumers only receive a handle
+inside 'withAcquired'.
+-}
+data QueryHandle m = QueryHandle
+    { queryUTxOsH ::
+        Addr ->
+        m [(TxIn, TxOut ConwayEra)]
+    -- ^ Look up UTxOs at one address in the
+    -- acquired snapshot.
+    , queryUTxOsAtH ::
+        Set Addr ->
+        m (Map Addr [(TxIn, TxOut ConwayEra)])
+    -- ^ Look up UTxOs at several addresses in the
+    -- acquired snapshot, grouped by address.
+    , queryUTxOByTxInH ::
+        Set TxIn ->
+        m (Map TxIn (TxOut ConwayEra))
+    -- ^ Look up UTxOs by 'TxIn' in the acquired
+    -- snapshot.
+    , queryProtocolParamsH ::
+        m (PParams ConwayEra)
+    -- ^ Fetch protocol parameters from the acquired
+    -- snapshot.
+    , evaluateTxH ::
+        ConwayTx ->
+        m (EvaluateTxResult ConwayEra)
+    -- ^ Evaluate script execution units using data
+    -- read from the acquired snapshot.
+    , posixMsToSlotH ::
+        Integer ->
+        m SlotNo
+    -- ^ Convert POSIX milliseconds to a floor slot
+    -- using the acquired snapshot's interpreter.
+    , posixMsCeilSlotH ::
+        Integer ->
+        m SlotNo
+    -- ^ Convert POSIX milliseconds to a ceiling slot
+    -- using the acquired snapshot's interpreter.
+    }
+
+{- | Named operations used by provider backends to
+construct an opaque 'QueryHandle'.
+-}
+data QueryHandleBackend m = QueryHandleBackend
+    { backendQueryUTxOs ::
+        Addr ->
+        m [(TxIn, TxOut ConwayEra)]
+    , backendQueryUTxOsAt ::
+        Set Addr ->
+        m (Map Addr [(TxIn, TxOut ConwayEra)])
+    , backendQueryUTxOByTxIn ::
+        Set TxIn ->
+        m (Map TxIn (TxOut ConwayEra))
+    , backendQueryProtocolParams ::
+        m (PParams ConwayEra)
+    , backendEvaluateTx ::
+        ConwayTx ->
+        m (EvaluateTxResult ConwayEra)
+    , backendPosixMsToSlot ::
+        Integer ->
+        m SlotNo
+    , backendPosixMsCeilSlot ::
+        Integer ->
+        m SlotNo
+    }
+
+-- | Build a 'QueryHandle' for a provider backend.
+mkQueryHandle :: QueryHandleBackend m -> QueryHandle m
+mkQueryHandle backend =
+    QueryHandle
+        { queryUTxOsH = backendQueryUTxOs backend
+        , queryUTxOsAtH = backendQueryUTxOsAt backend
+        , queryUTxOByTxInH = backendQueryUTxOByTxIn backend
+        , queryProtocolParamsH = backendQueryProtocolParams backend
+        , evaluateTxH = backendEvaluateTx backend
+        , posixMsToSlotH = backendPosixMsToSlot backend
+        , posixMsCeilSlotH = backendPosixMsCeilSlot backend
+        }
+
+{- | Build a 'QueryHandle' that delegates to a
+provider's one-shot fields.
+
+This is useful for test providers and non-LSQ
+backends where a true acquired session is not
+available.
+-}
+singleShotQueryHandle ::
+    (Applicative m) =>
+    Provider m ->
+    QueryHandle m
+singleShotQueryHandle provider =
+    mkQueryHandle
+        QueryHandleBackend
+            { backendQueryUTxOs = queryUTxOs provider
+            , backendQueryUTxOsAt = queryAddresses
+            , backendQueryUTxOByTxIn = queryUTxOByTxIn provider
+            , backendQueryProtocolParams = queryProtocolParams provider
+            , backendEvaluateTx = evaluateTx provider
+            , backendPosixMsToSlot = posixMsToSlot provider
+            , backendPosixMsCeilSlot = posixMsCeilSlot provider
+            }
+  where
+    queryAddresses addrs =
+        Map.fromList
+            <$> traverse queryAddress (Set.toList addrs)
+    queryAddress addr =
+        (,) addr
+            <$> queryUTxOs provider addr
+
+-- | Run a callback with a one-shot-backed handle.
+singleShotWithAcquired ::
+    (Applicative m) =>
+    Provider m ->
+    (QueryHandle m -> m a) ->
+    m a
+singleShotWithAcquired provider callback =
+    callback (singleShotQueryHandle provider)
+
 {- | Interface for querying the blockchain.
 All era-specific types are fixed to 'ConwayEra'.
 -}
 data Provider m = Provider
-    { queryUTxOs ::
+    { withAcquired ::
+        forall a.
+        (QueryHandle m -> m a) ->
+        m a
+    -- ^ Run several queries against one acquired
+    -- ledger snapshot when the backend supports it.
+    , queryUTxOs ::
         Addr ->
         m [(TxIn, TxOut ConwayEra)]
     -- ^ Look up UTxOs at an address

--- a/specs/041-provider-acquired-session/contracts/provider-api.md
+++ b/specs/041-provider-acquired-session/contracts/provider-api.md
@@ -1,0 +1,69 @@
+# Contract: Provider acquired-session API
+
+**Module**: `Cardano.Node.Client.Provider`
+
+## New API
+
+```haskell
+data QueryHandle m
+
+data QueryHandleBackend m
+
+mkQueryHandle
+    :: QueryHandleBackend m
+    -> QueryHandle m
+
+withAcquired
+    :: Provider m
+    -> (QueryHandle m -> m a)
+    -> m a
+
+queryUTxOsAtH
+    :: QueryHandle m
+    -> Set Addr
+    -> m (Map Addr [(TxIn, TxOut ConwayEra)])
+
+queryUTxOByTxInH
+    :: QueryHandle m
+    -> Set TxIn
+    -> m (Map TxIn (TxOut ConwayEra))
+
+queryProtocolParamsH
+    :: QueryHandle m
+    -> m (PParams ConwayEra)
+
+evaluateTxH
+    :: QueryHandle m
+    -> ConwayTx
+    -> m (EvaluateTxResult ConwayEra)
+
+posixMsToSlotH
+    :: QueryHandle m
+    -> Integer
+    -> m SlotNo
+
+posixMsCeilSlotH
+    :: QueryHandle m
+    -> Integer
+    -> m SlotNo
+```
+
+## Compatibility
+
+Existing one-shot fields remain:
+
+```haskell
+queryUTxOs :: Provider m -> Addr -> m [(TxIn, TxOut ConwayEra)]
+queryUTxOByTxIn :: Provider m -> Set TxIn -> m (Map TxIn (TxOut ConwayEra))
+queryProtocolParams :: Provider m -> m (PParams ConwayEra)
+evaluateTx :: Provider m -> ConwayTx -> m (EvaluateTxResult ConwayEra)
+posixMsToSlot :: Provider m -> Integer -> m SlotNo
+posixMsCeilSlot :: Provider m -> Integer -> m SlotNo
+```
+
+## Semantics
+
+- `withAcquired` brackets an LSQ acquire/release in N2C-backed providers.
+- `QueryHandle` methods are valid only during the callback.
+- Existing one-shot fields still perform their own bracketed acquire/release cycle.
+- Several related N2C reads should use one explicit `withAcquired` callback rather than several one-shot fields when they need one shared snapshot.

--- a/specs/041-provider-acquired-session/data-model.md
+++ b/specs/041-provider-acquired-session/data-model.md
@@ -1,0 +1,48 @@
+# Data Model: Provider acquired query session
+
+## Provider
+
+Public record containing one-shot methods plus `withAcquired`.
+
+Fields affected:
+- `withAcquired`: runs a callback with a `QueryHandle`.
+- Existing fields remain one-shot convenience methods.
+
+## QueryHandle
+
+Opaque public type passed into `withAcquired` callbacks.
+
+Operations:
+- `queryUTxOsH :: Addr -> m [(TxIn, TxOut ConwayEra)]`
+- `queryUTxOsAtH :: Set Addr -> m (Map Addr [(TxIn, TxOut ConwayEra)])`
+- `queryUTxOByTxInH :: Set TxIn -> m (Map TxIn (TxOut ConwayEra))`
+- `queryProtocolParamsH :: m (PParams ConwayEra)`
+- `evaluateTxH :: ConwayTx -> m (EvaluateTxResult ConwayEra)`
+- `posixMsToSlotH :: Integer -> m SlotNo`
+- `posixMsCeilSlotH :: Integer -> m SlotNo`
+
+Validation:
+- The handle is only valid inside the callback that received it.
+- The constructor is not exported from `Cardano.Node.Client.Provider`.
+
+## QueryHandleBackend
+
+Named record of backend operations used by provider implementations to
+construct an opaque `QueryHandle` without relying on positional
+constructor arguments.
+
+## LSQRequest
+
+Internal request sent to the LocalStateQuery protocol client.
+
+Variants:
+- one-shot query request
+- acquired-session request
+
+## AcquiredLSQ
+
+Internal lower-level session handle. Owns a queue of acquired-session commands.
+
+Commands:
+- query
+- release

--- a/specs/041-provider-acquired-session/plan.md
+++ b/specs/041-provider-acquired-session/plan.md
@@ -1,0 +1,74 @@
+# Implementation Plan: Provider acquired query session
+
+**Branch**: `feat/provider-single-acquire-multi-query-session-for-at`
+**Spec**: [spec.md](./spec.md)
+**Issue**: [#126](https://github.com/lambdasistemi/cardano-node-clients/issues/126)
+
+## Technical Context
+
+**Language/Version**: Haskell, GHC 9.12.2 through Nix
+**Primary Dependencies**: `ouroboros-network`, `ouroboros-consensus`, `cardano-ledger-api`, `stm`
+**Storage**: none
+**Testing**: Hspec E2E devnet, unit tests, `just ci`
+**Target**: Public library API in `Cardano.Node.Client.Provider`
+
+## Constitution Check
+
+- Channel-driven N2C clients: preserved; new session API is still channel-driven.
+- Devnet E2E testing: add an E2E provider test that uses a real devnet.
+- Minimal dependencies: no new package dependencies.
+- Test utilities first-class: no changes.
+
+## Design
+
+1. Add `QueryHandle m` to `Cardano.Node.Client.Provider`, exporting the type and selector functions but not the data constructor.
+2. Add `withAcquired` to `Provider m`.
+3. Add lower-level acquired-session support in `Cardano.Node.Client.N2C.LocalStateQuery`:
+   - `withAcquiredLSQ :: LSQChannel -> (AcquiredLSQ -> IO a) -> IO a`
+   - `queryAcquiredLSQ :: AcquiredLSQ -> Query Block result -> IO result`
+4. Extend `Cardano.Node.Client.N2C.Types` with queue request variants for one-shot queries and acquired sessions.
+5. Refactor `mkN2CProvider` to build a `QueryHandle` from a polymorphic query runner.
+6. Keep existing one-shot provider fields as wrappers around `withAcquired`.
+
+## Algorithm Sketch
+
+```text
+withAcquiredLSQ ch callback:
+  create an acquired-session command queue
+  enqueue "acquire this session" on the LSQ channel
+  wait until the protocol client confirms MsgAcquired
+  run callback with the acquired session
+  enqueue release on the acquired-session queue
+  wait for release acknowledgement
+
+protocol client:
+  wait for an LSQ request
+  SendMsgAcquire VolatileTip
+  if request is one-shot:
+    SendMsgQuery
+    put result
+    drain queued one-shot/session requests if present
+    otherwise SendMsgRelease
+  if request is acquired-session:
+    signal acquired
+    serve session query commands until release command
+    drain queued requests if present
+    otherwise SendMsgRelease
+```
+
+## Files
+
+- `lib/Cardano/Node/Client/Provider.hs`
+- `lib/Cardano/Node/Client/N2C/Types.hs`
+- `lib/Cardano/Node/Client/N2C/LocalStateQuery.hs`
+- `lib/Cardano/Node/Client/N2C/Provider.hs`
+- `test/Cardano/Node/Client/E2E/ProviderSpec.hs`
+- `docs/modules/provider.md`
+
+## Verification
+
+Run:
+
+```bash
+nix develop --quiet -c just ci
+```

--- a/specs/041-provider-acquired-session/quickstart.md
+++ b/specs/041-provider-acquired-session/quickstart.md
@@ -1,0 +1,31 @@
+# Quickstart: Provider acquired query session
+
+## One-shot usage remains unchanged
+
+```haskell
+let provider = mkN2CProvider lsq
+
+pp <- queryProtocolParams provider
+utxos <- queryUTxOs provider genesisAddr
+```
+
+Each standalone N2C call opens and releases its own acquired session.
+Use `withAcquired` when several related reads need one shared snapshot.
+
+## Acquired-session usage
+
+```haskell
+withAcquired provider $ \handle -> do
+    pp <- queryProtocolParamsH handle
+    byAddr <- queryUTxOsAtH handle (Set.singleton registryAddr)
+    byTxIn <- queryUTxOByTxInH handle referencedTxIns
+    pure (pp, byAddr, byTxIn)
+```
+
+All queries in the callback are served by one LocalStateQuery acquire/release cycle.
+
+## Verification
+
+```bash
+nix develop --quiet -c just ci
+```

--- a/specs/041-provider-acquired-session/research.md
+++ b/specs/041-provider-acquired-session/research.md
@@ -1,0 +1,25 @@
+# Research: Provider acquired query session
+
+## Decision: Keep the public handle high-level
+
+`QueryHandle m` exposes provider-shaped operations instead of raw consensus `Query Block result` values.
+
+**Rationale**: `Cardano.Node.Client.Provider` is protocol-agnostic today. Exposing raw consensus queries there would leak N2C internals and force downstream registry-walk code to depend on lower-level consensus APIs.
+
+**Alternatives considered**: Export a raw LSQ handle. Rejected because it would couple application code to the N2C implementation and bypass the existing provider abstraction.
+
+## Decision: Model acquired sessions as a second queue
+
+The main LSQ channel gets a new request variant that asks the protocol client to acquire and then serve commands from an acquired-session queue until a release command arrives.
+
+**Rationale**: The protocol client must remain the only thread that sends `MsgQuery` and `MsgRelease`. A session queue lets user code run normally while the protocol thread preserves LocalStateQuery state.
+
+**Alternatives considered**: Enqueue several ordinary `queryLSQ` requests. Rejected because sequential callers wait after each request, giving the protocol client a chance to release between calls.
+
+## Decision: One-shot provider fields delegate through `withAcquired`
+
+The N2C provider builds one handle implementation and uses it for both one-shot and acquired calls.
+
+**Rationale**: This avoids two divergent implementations of era mismatch handling and query conversion.
+
+**Alternatives considered**: Keep the current one-shot implementations and add separate handle implementations. Rejected because that duplicates query code and makes future provider fields easier to miss.

--- a/specs/041-provider-acquired-session/spec.md
+++ b/specs/041-provider-acquired-session/spec.md
@@ -1,0 +1,84 @@
+# Feature Specification: Provider acquired query session
+
+**Feature Branch**: `feat/provider-single-acquire-multi-query-session-for-at`
+**Created**: 2026-05-05
+**Status**: Implemented
+**Input**: Issue [#126](https://github.com/lambdasistemi/cardano-node-clients/issues/126) - expose a bracket-shaped provider API so downstream registry walks can run several ledger queries against one LocalStateQuery acquired snapshot.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Registry walk reads one consistent snapshot (Priority: P1)
+
+A downstream tool opens an acquired provider session, reads registry datums by address, then reads the referenced script UTxOs by `TxIn`. All reads come from the same chain point, so the tool can distinguish a real redeploy from chain-tip jitter.
+
+**Why this priority**: This is the issue's main value. Without it, consumers that need related UTxOs must compose multiple one-shot provider calls, each with its own acquire/release cycle.
+
+**Independent Test**: In an E2E devnet test, call the new acquired API and run at least three query methods in a single bracket. The test must use the same `QueryHandle` for protocol parameters, address UTxOs, and TxIn lookup.
+
+**Acceptance Scenarios**:
+
+1. **Given** an N2C-backed provider, **When** a caller runs `withAcquired provider`, **Then** the callback receives a handle that can perform multiple provider-style queries before the LSQ client releases.
+2. **Given** a handle from `withAcquired`, **When** the caller queries one address and then looks up a `TxIn` returned by that query, **Then** the lookup sees the same output in the same acquired session.
+3. **Given** a caller uses existing one-shot methods, **When** they call `queryUTxOs`, `queryUTxOByTxIn`, or `queryProtocolParams`, **Then** those calls still work without call-site changes.
+
+### User Story 2 - Existing provider consumers keep their API shape (Priority: P1)
+
+Existing downstream tools that only need one-shot queries continue to call the same `Provider` fields. The N2C implementation internally uses the acquired machinery for those calls, but consumers do not have to opt in.
+
+**Why this priority**: The feature is for new atomic reads. It must not force unrelated tools to rewrite basic provider usage.
+
+**Independent Test**: Run the existing unit and E2E suites unchanged, including current `Provider.N2C`, tx-build, balancer, and tx-generator tests.
+
+**Acceptance Scenarios**:
+
+1. **Given** existing code calling `queryProtocolParams provider`, **When** it is rebuilt, **Then** it compiles and behaves as before.
+2. **Given** existing code calling `queryUTxOs provider addr`, **When** it is rebuilt, **Then** it still returns the UTxOs at that address.
+3. **Given** existing code calling `evaluateTx` or POSIX-to-slot helpers, **When** it is rebuilt, **Then** those LSQ-backed helpers still return their current results.
+
+### Edge Cases
+
+- The user callback throws an exception: the acquired LSQ session must release before the exception escapes.
+- The N2C bearer dies while a caller is waiting for acquisition or query results: callers should receive the existing typed `ConnectionLost` signal rather than block indefinitely.
+- A `QueryHandle` is leaked outside its callback: this is caller misuse; the API keeps the constructor opaque to discourage it.
+- Multiple ordinary `queryLSQ` callers may still queue work concurrently; preserving the existing opportunistic batch behavior is allowed but not required for the new bracket semantics.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `Cardano.Node.Client.Provider` MUST expose an opaque `QueryHandle m` type.
+- **FR-002**: `Provider m` MUST expose `withAcquired :: (QueryHandle m -> m a) -> m a`.
+- **FR-003**: `QueryHandle m` MUST expose acquired-session forms for all existing LSQ-backed provider operations: UTxO-by-address, UTxO-by-TxIn, protocol parameters, transaction evaluation, floor POSIX-to-slot, and ceiling POSIX-to-slot.
+- **FR-004**: The acquired address query MUST support querying a set of addresses and return results grouped by address.
+- **FR-005**: The N2C implementation MUST acquire LocalStateQuery once, serve all handle queries from that callback, and release after the callback exits.
+- **FR-006**: The N2C one-shot provider fields MUST delegate through `withAcquired` so each one-shot call still performs exactly one bracketed acquire/release cycle.
+- **FR-007**: `queryLSQ` MUST remain available for existing low-level callers.
+- **FR-008**: A dead LSQ consumer while waiting for acquisition, query, or release MUST surface as `ConnectionLost`.
+- **FR-009**: Existing downstream one-shot call sites MUST remain unchanged.
+
+### Key Entities
+
+- **Provider**: Public record-of-functions for ledger queries. Gains `withAcquired` while retaining current one-shot fields.
+- **QueryHandle**: Opaque high-level handle passed only inside an acquired callback.
+- **Acquired LSQ session**: Lower-level LocalStateQuery state that owns a queue of queries served before release.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An E2E devnet test executes at least three provider queries through one `QueryHandle` and passes.
+- **SC-002**: Existing one-shot provider E2E tests continue to pass with no caller changes.
+- **SC-003**: `nix develop --quiet -c just ci` passes after the change.
+- **SC-004**: The public docs show both one-shot and acquired-session usage.
+
+## Assumptions
+
+- This feature does not change the LSQ wire codec or add a multi-query wire message.
+- `Provider` remains a record-of-functions, matching the current public API style.
+- Query consistency is scoped to one LocalStateQuery `Acquire` on the volatile tip.
+
+## Out of Scope
+
+- Cross-acquire batching.
+- Changing transaction submission or chain-sync APIs.
+- Adding application-specific registry-walk helpers.

--- a/specs/041-provider-acquired-session/tasks.md
+++ b/specs/041-provider-acquired-session/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: Provider acquired query session
+
+**Input**: Design documents in [`specs/041-provider-acquired-session/`](./).
+**Prerequisites**: [spec.md](./spec.md), [plan.md](./plan.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/provider-api.md](./contracts/provider-api.md), [quickstart.md](./quickstart.md).
+**Tests**: TDD; failing E2E compile/test before implementation.
+**Source issue**: [lambdasistemi/cardano-node-clients#126](https://github.com/lambdasistemi/cardano-node-clients/issues/126).
+
+## Phase 1: Setup
+
+- [x] T001 Confirm `nix develop --quiet -c just ci` passes on the fresh issue worktree.
+
+## Phase 2: Tests
+
+- [x] T002 [US1] Add an E2E test in `test/Cardano/Node/Client/E2E/ProviderSpec.hs` that calls `withAcquired` and runs at least three handle queries in the same callback.
+- [x] T003 [US2] Keep existing one-shot provider tests unchanged so they prove one-shot compatibility.
+
+## Phase 3: Implementation
+
+- [x] T004 Add `QueryHandle m`, handle selectors, and `withAcquired` to `lib/Cardano/Node/Client/Provider.hs`.
+- [x] T005 Extend internal LSQ request types in `lib/Cardano/Node/Client/N2C/Types.hs`.
+- [x] T006 Implement `withAcquiredLSQ` and `queryAcquiredLSQ` in `lib/Cardano/Node/Client/N2C/LocalStateQuery.hs`.
+- [x] T007 Refactor `mkN2CProvider` in `lib/Cardano/Node/Client/N2C/Provider.hs` so one-shot methods delegate through the handle implementation.
+- [x] T008 Update internal test stubs that construct `Provider` records.
+
+## Phase 4: Docs and Verification
+
+- [x] T009 Update `docs/modules/provider.md` with one-shot and acquired-session examples.
+- [x] T010 Run `nix develop --quiet -c just ci`.
+- [ ] T011 Push branch and open a PR closing issue #126.
+
+## Dependency graph
+
+```text
+T001 -> T002 -> T004 -> T005 -> T006 -> T007 -> T008 -> T009 -> T010 -> T011
+```

--- a/test/Cardano/Node/Client/E2E/ProviderSpec.hs
+++ b/test/Cardano/Node/Client/E2E/ProviderSpec.hs
@@ -8,12 +8,15 @@ License     : Apache-2.0
 -}
 module Cardano.Node.Client.E2E.ProviderSpec (spec) where
 
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Lens.Micro ((^.))
 import Test.Hspec (
     Spec,
     around,
     describe,
     it,
+    shouldBe,
     shouldSatisfy,
  )
 
@@ -26,7 +29,12 @@ import Cardano.Node.Client.E2E.Setup (
 import Cardano.Node.Client.N2C.Provider (
     mkN2CProvider,
  )
-import Cardano.Node.Client.Provider (Provider (..))
+import Cardano.Node.Client.Provider (
+    Provider (..),
+    queryProtocolParamsH,
+    queryUTxOByTxInH,
+    queryUTxOsAtH,
+ )
 
 spec :: Spec
 spec =
@@ -54,6 +62,53 @@ spec =
                                 genesisAddr
                         utxos
                             `shouldSatisfy` (not . null)
+
+                it "withAcquired serves multiple queries through one handle" $
+                    \(lsq, _) -> do
+                        let provider =
+                                mkN2CProvider lsq
+                        (maxTxSize, byAddr, byTxIn) <-
+                            withAcquired provider $ \handle -> do
+                                pp <-
+                                    queryProtocolParamsH handle
+                                utxosAt <-
+                                    queryUTxOsAtH
+                                        handle
+                                        (Set.singleton genesisAddr)
+                                let txIns =
+                                        Set.fromList $
+                                            take
+                                                1
+                                                ( fst
+                                                    <$> Map.findWithDefault
+                                                        []
+                                                        genesisAddr
+                                                        utxosAt
+                                                )
+                                utxosByTxIn <-
+                                    queryUTxOByTxInH
+                                        handle
+                                        txIns
+                                pure
+                                    ( pp ^. ppMaxTxSizeL
+                                    , utxosAt
+                                    , utxosByTxIn
+                                    )
+                        let addrUtxos =
+                                Map.findWithDefault
+                                    []
+                                    genesisAddr
+                                    byAddr
+                            txIns =
+                                Set.fromList $
+                                    take 1 $
+                                        fmap fst addrUtxos
+                        maxTxSize
+                            `shouldSatisfy` (> 0)
+                        addrUtxos
+                            `shouldSatisfy` (not . null)
+                        Map.keysSet byTxIn
+                            `shouldBe` txIns
   where
     withDevnet' action =
         withDevnet $ curry action

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -121,7 +121,10 @@ import Cardano.Node.Client.Balance (
  )
 import Cardano.Node.Client.Evaluate (evaluateAndBalance)
 import Cardano.Node.Client.Ledger (ConwayTx)
-import Cardano.Node.Client.Provider (Provider (..))
+import Cardano.Node.Client.Provider (
+    Provider (..),
+    singleShotWithAcquired,
+ )
 import Cardano.Node.Client.TxBuild
 import Cardano.Slotting.Slot (SlotNo (..))
 import Lens.Micro ((&), (.~), (^.))
@@ -1770,21 +1773,26 @@ outputCountingProvider ::
     Int ->
     Provider IO
 outputCountingProvider pp perOutput =
-    Provider
-        { queryUTxOs = const (pure [])
-        , queryUTxOByTxIn = const (pure Map.empty)
-        , queryProtocolParams = pure pp
-        , evaluateTx =
-            pure
-                . Map.singleton
-                    (ConwaySpending (AsIx 0))
-                . Right
-                . outputCountExUnits perOutput
-        , posixMsToSlot =
-            pure . SlotNo . fromIntegral
-        , posixMsCeilSlot =
-            pure . SlotNo . fromIntegral
-        }
+    provider
+  where
+    provider =
+        Provider
+            { withAcquired =
+                singleShotWithAcquired provider
+            , queryUTxOs = const (pure [])
+            , queryUTxOByTxIn = const (pure Map.empty)
+            , queryProtocolParams = pure pp
+            , evaluateTx =
+                pure
+                    . Map.singleton
+                        (ConwaySpending (AsIx 0))
+                    . Right
+                    . outputCountExUnits perOutput
+            , posixMsToSlot =
+                pure . SlotNo . fromIntegral
+            , posixMsCeilSlot =
+                pure . SlotNo . fromIntegral
+            }
 
 redeemerExUnits ::
     ConwayPlutusPurpose AsIx ConwayEra ->

--- a/test/Cardano/Node/Client/TxGenerator/SelectionSpec.hs
+++ b/test/Cardano/Node/Client/TxGenerator/SelectionSpec.hs
@@ -36,7 +36,10 @@ import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
 import Cardano.Ledger.Keys (KeyHash (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Cardano.Ledger.Val (inject)
-import Cardano.Node.Client.Provider (Provider (..))
+import Cardano.Node.Client.Provider (
+    Provider (..),
+    singleShotWithAcquired,
+ )
 import Cardano.Node.Client.TxGenerator.Selection (
     pickSourceIndex,
     verifyInputsUnspent,
@@ -299,19 +302,23 @@ touch them.
 stubProvider ::
     Map TxIn (TxOut ConwayEra) -> Provider IO
 stubProvider tip =
-    Provider
-        { queryUTxOs = const (pure [])
-        , queryUTxOByTxIn = pure . Map.restrictKeys tip
-        , queryProtocolParams =
-            pure (unused "queryProtocolParams")
-        , evaluateTx = \_ ->
-            pure (unused "evaluateTx")
-        , posixMsToSlot = \_ ->
-            pure (unused "posixMsToSlot")
-        , posixMsCeilSlot = \_ ->
-            pure (unused "posixMsCeilSlot")
-        }
+    provider
   where
+    provider =
+        Provider
+            { withAcquired =
+                singleShotWithAcquired provider
+            , queryUTxOs = const (pure [])
+            , queryUTxOByTxIn = pure . Map.restrictKeys tip
+            , queryProtocolParams =
+                pure (unused "queryProtocolParams")
+            , evaluateTx = \_ ->
+                pure (unused "evaluateTx")
+            , posixMsToSlot = \_ ->
+                pure (unused "posixMsToSlot")
+            , posixMsCeilSlot = \_ ->
+                pure (unused "posixMsCeilSlot")
+            }
     unused name =
         error
             ( "stubProvider: "


### PR DESCRIPTION
Closes #126

## Summary

- add `QueryHandle` and `withAcquired` to the public provider API, plus handle selectors for all LSQ-backed provider operations
- extend the N2C LocalStateQuery loop with explicit acquired-session requests and refactor `mkN2CProvider` so one-shot provider fields delegate through the acquired handle implementation
- add E2E coverage for three queries through one acquired handle and update provider docs/spec notes

## Verification

- `nix develop --quiet -c just ci`
- `nix build --quiet .#checks.x86_64-linux.build .#checks.x86_64-linux.e2e .#checks.x86_64-linux.unit .#checks.x86_64-linux.lint`