### PR TITLE
feat: horizon-aware validity helper

### DIFF
--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -97,6 +97,7 @@ library
     Cardano.Node.Client.UTxOIndexer.BlockExtract
     Cardano.Node.Client.UTxOIndexer.Daemon
     Cardano.Node.Client.UTxOIndexer.Server
+    Cardano.Node.Client.Validity
 
   reexported-modules:
     Cardano.Node.Client.Balance
@@ -269,6 +270,7 @@ test-suite unit-tests
     Cardano.Node.Client.UTxOIndexer.PersistenceSpec
     Cardano.Node.Client.UTxOIndexer.ServerSpec
     Cardano.Node.Client.UTxOIndexer.TypesSpec
+    Cardano.Node.Client.ValiditySpec
     Data.List.SampleFibonacciSpec
 
   build-depends:
@@ -296,12 +298,15 @@ test-suite unit-tests
     , hspec
     , microlens
     , network
+    , ouroboros-consensus
     , plutus-core
     , plutus-tx
     , QuickCheck
     , random
+    , sop-extras
     , temporary
     , text
+    , time
 
 test-suite tx-build-tests
   import:           warnings

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -352,6 +352,7 @@ test-suite e2e-tests
     Cardano.Node.Client.E2E.BalanceSpec
     Cardano.Node.Client.E2E.ChainPopulatorSpec
     Cardano.Node.Client.E2E.ChainSyncSpec
+    Cardano.Node.Client.E2E.HorizonSpec
     Cardano.Node.Client.E2E.Issue97ReproSpec
     Cardano.Node.Client.E2E.MultiAssetChangeSpec
     Cardano.Node.Client.E2E.N2CFullSpec

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ Cardano node:
 - **Submitter** -- submit signed transactions
 - **Balance** -- exact-fee balancing and fee-dependent output convergence
 - **TxBuild** -- Conway-era transaction builder DSL with `Peek` fixpoints and pluggable `Ctx` queries
+- **Validity** -- pick an `invalid-hereafter` slot inside the chain's plutus-translation horizon ([details](modules/validity.md))
 
 `Balance` and `TxBuild` are implemented by the public
 `cardano-node-clients:tx-build` sublibrary. The main library re-exports

--- a/docs/modules/validity.md
+++ b/docs/modules/validity.md
@@ -1,0 +1,85 @@
+# Validity — horizon-aware upper-bound slot
+
+`Cardano.Node.Client.Validity` picks an `invalid-hereafter` slot
+that is guaranteed to survive Plutus context translation. It is the
+solution to a class of bugs where a builder picks `tip + N hours`,
+hands the unsigned tx to a signer, and the signer (or the node) hits
+`TimeTranslationPastHorizon` deep inside script evaluation.
+
+## What "horizon" means
+
+The Cardano chain is divided into **epochs** (mainnet: 432 000 slots
+= 5 days). Consecutive epochs sharing the same consensus rules form
+an **era** (Conway is the current era). At any epoch boundary the
+protocol may **hard-fork** to a new era with new parameters,
+including a new slot length.
+
+The consensus layer can translate a slot to a `UTCTime` only as far
+as its **horizon**: typically the end of the current era, plus the
+era's **safe zone** when the chain is close enough to that boundary
+that no further hard fork could be announced. Plutus script context
+needs this translation for any transaction whose validity interval
+references slots — so a tx built with an upper bound past the
+horizon is silently un-evaluatable.
+
+`queryUpperBoundSlot` always returns slots that are inside the
+horizon (or refuses, depending on the choice).
+
+## API
+
+```haskell
+import Cardano.Node.Client.Validity
+  ( ValidityChoice (..)
+  , HorizonError (..)
+  )
+import Cardano.Node.Client.Provider (Provider (..))
+```
+
+Three modes:
+
+* **`AutoLongest`** — pick the largest slot inside the horizon. The
+  result is mid-epoch-conservative: it equals the current era's end
+  slot when the chain is far from a boundary, and extends by the
+  safe zone when close to it (mirroring how the consensus layer
+  itself updates its summary). For testnets / devnets where the
+  last era is unbounded, `AutoLongest` returns `tip + one year of
+  slots` — effectively unlimited.
+
+* **`MaxHours N`** — pick `min(tip + N*3600, horizon)`. Use when
+  internal policy caps signing windows below the chain horizon
+  ("we never sit on an unsigned tx for more than 24 h").
+
+* **`ExactlyHours N`** — require exactly `tip + N*3600` to be inside
+  the horizon; otherwise return `Left HorizonError` with the
+  requested slot, the horizon slot, the tip, and the requested
+  hours so the caller can render a helpful diagnostic.
+
+## Worked example — mainnet mid-epoch
+
+Tip slot `S` is 60 000 slots before the era end. Safe zone is 129 600.
+`AutoLongest` returns the era end minus 1 — about 16.6 hours from
+tip. `MaxHours 4` returns `S + 14 400`, since 4 h is comfortably
+inside the horizon. `ExactlyHours 24` returns
+`Left (HorizonError requested horizon tip 24)`: the request
+overshoots by ~7.4 h.
+
+The same call inside the safe zone (≤ 36 h from era end) typically
+returns a slot up to ~5 days further out, because the consensus
+interpreter has updated its summary with the next-era parameters and
+the horizon has moved.
+
+## When to use which
+
+| Caller intent | Choice |
+|---|---|
+| "Give me the most permissive submission window the chain allows." | `AutoLongest` |
+| "Cap my window at policy N hours, regardless of chain headroom." | `MaxHours N` |
+| "I committed to N hours; surface the chain-side mismatch loudly." | `ExactlyHours N` |
+
+## Implementation note
+
+The math drives the consensus `Interpreter` through its public
+`interpretQuery` API only — no `Codec.Serialise` round-trip and no
+`unsafeCoerce` reach into the wrapped `Summary`. The `AutoLongest`
+search converges in ≈ 20 probes of `slotToWallclock` (binary search
+over `tip .. tip + 1 year`).

--- a/lib/Cardano/Node/Client/N2C/Provider.hs
+++ b/lib/Cardano/Node/Client/N2C/Provider.hs
@@ -45,11 +45,16 @@ import Cardano.Ledger.State (UTxO (..))
 import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Node.Client.Ledger (ConwayTx)
 import Cardano.Slotting.EpochInfo (hoistEpochInfo)
+import Cardano.Slotting.Slot qualified as Slotting
 import Cardano.Slotting.Time (
     RelativeTime (..),
     toRelativeTime,
  )
 
+import Ouroboros.Consensus.Block.Abstract (
+    fromWithOrigin,
+    pointSlot,
+ )
 import Ouroboros.Consensus.Cardano.Block (
     pattern QueryIfCurrentConway,
  )
@@ -65,7 +70,7 @@ import Ouroboros.Consensus.HardFork.History.Qry (
     wallclockToSlot,
  )
 import Ouroboros.Consensus.Ledger.Query (
-    Query (BlockQuery, GetSystemStart),
+    Query (BlockQuery, GetChainPoint, GetSystemStart),
  )
 import Ouroboros.Consensus.Shelley.Ledger.Query (
     pattern GetCurrentPParams,
@@ -93,6 +98,7 @@ import Cardano.Node.Client.Provider (
     queryUTxOsH,
  )
 import Cardano.Node.Client.Types (Block)
+import Cardano.Node.Client.Validity qualified as Validity
 
 {- | Create a 'Provider IO' backed by the N2C
 LocalStateQuery protocol.
@@ -121,6 +127,11 @@ mkN2CProvider ch =
         , posixMsCeilSlot = \ms ->
             withAcquiredN2C $ \handle ->
                 posixMsCeilSlotH handle ms
+        , queryUpperBoundSlot = \choice ->
+            withAcquiredLSQ ch $ \acquired ->
+                let runQuery :: forall result. Query Block result -> IO result
+                    runQuery = queryAcquiredLSQ acquired
+                 in queryUpperBoundSlotN2C runQuery choice
         }
   where
     withAcquiredN2C ::
@@ -293,6 +304,24 @@ evaluateTxN2C runQuery tx = do
             utxo
             epochInfo
             systemStart
+
+queryUpperBoundSlotN2C ::
+    (forall result. Query Block result -> IO result) ->
+    Validity.ValidityChoice ->
+    IO (Either Validity.HorizonError SlotNo)
+queryUpperBoundSlotN2C runQuery choice = do
+    interpreter <-
+        runQuery $
+            BlockQuery $
+                QueryHardFork GetInterpreter
+    chainPoint <-
+        runQuery GetChainPoint
+    let tipSlot = fromWithOrigin (Slotting.SlotNo 0) (pointSlot chainPoint)
+    pure $
+        Validity.selectUpperBound
+            interpreter
+            tipSlot
+            choice
 
 posixMsToSlotN2C ::
     (forall result. Query Block result -> IO result) ->

--- a/lib/Cardano/Node/Client/Provider.hs
+++ b/lib/Cardano/Node/Client/Provider.hs
@@ -53,6 +53,7 @@ import Cardano.Ledger.Core (PParams)
 import Cardano.Ledger.Plutus (ExUnits)
 import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Node.Client.Ledger (ConwayTx)
+import Cardano.Node.Client.Validity (HorizonError, ValidityChoice)
 import Cardano.Slotting.Slot (SlotNo (..))
 
 -- | Per-script evaluation result.
@@ -227,4 +228,11 @@ data Provider m = Provider
     -- ^ Convert POSIX time (milliseconds) to 'SlotNo',
     --     rounding up (ceiling).
     --     Use for lower validity bounds (@entirely_after@).
+    , queryUpperBoundSlot ::
+        ValidityChoice ->
+        m (Either HorizonError SlotNo)
+    -- ^ Compute an @invalid-hereafter@ slot under a
+    --     'ValidityChoice'. Queries the chain tip and the
+    --     hard-fork interpreter and delegates to
+    --     'Cardano.Node.Client.Validity.selectUpperBound'.
     }

--- a/lib/Cardano/Node/Client/Validity.hs
+++ b/lib/Cardano/Node/Client/Validity.hs
@@ -1,0 +1,138 @@
+{- |
+Module      : Cardano.Node.Client.Validity
+Description : Horizon-aware upper-bound slot helper.
+License     : Apache-2.0
+
+Computes the longest plutus-translatable @invalid-hereafter@ slot a caller can
+use right now, given the node's hard-fork 'Interpreter' and the chain tip.
+
+The chain horizon is the latest slot whose POSIX time the node can translate
+without speculating about a future hard fork. Asking the node to evaluate a
+Plutus script with an upper bound past the horizon fails with
+@TimeTranslationPastHorizon@; this module avoids that by binary-searching the
+translatable range using the public 'interpretQuery' API.
+
+The 'Summary' wrapped by 'Interpreter' is documented internal in consensus;
+we deliberately do not extract it via 'Codec.Serialise' round-trip or
+'Unsafe.Coerce'.
+-}
+module Cardano.Node.Client.Validity (
+    -- * Choice
+    ValidityChoice (..),
+
+    -- * Error
+    HorizonError (..),
+
+    -- * Pure selection
+    selectUpperBound,
+
+    -- * Constants (exported for tests)
+    oneYearSlots,
+) where
+
+import Data.Either (isRight)
+import Data.Word (Word16, Word64)
+
+import Cardano.Slotting.Slot (SlotNo (..))
+
+import Ouroboros.Consensus.HardFork.History.Qry (
+    Interpreter,
+    interpretQuery,
+    slotToWallclock,
+ )
+
+{- | How the caller wants the upper-bound slot computed.
+
+* 'AutoLongest' — pick the largest translatable slot.
+* 'MaxHours' — pick @min(tip + N*3600, horizon)@. Useful when an internal
+  policy caps signing windows below the chain horizon.
+* 'ExactlyHours' — require @tip + N*3600@ to be inside the horizon; fail with
+  'HorizonError' otherwise.
+-}
+data ValidityChoice
+    = AutoLongest
+    | MaxHours !Word16
+    | ExactlyHours !Word16
+    deriving stock (Eq, Show)
+
+{- | Returned when 'ExactlyHours' overshoots the chain horizon.
+
+Carries enough fact to render a diagnostic of the form
+@"asked for N h ending at slot R, but horizon is H (tip T)"@.
+-}
+data HorizonError = HorizonError
+    { heRequestedSlot :: !SlotNo
+    , heHorizonSlot :: !SlotNo
+    , heTipSlot :: !SlotNo
+    , heRequestedHours :: !Word16
+    }
+    deriving stock (Eq, Show)
+
+{- | Compute an @invalid-hereafter@ slot from the current 'Interpreter', tip,
+and choice.
+
+For 'AutoLongest', returns the largest slot the interpreter currently
+translates. For an unbounded last era (testnets / hand-crafted summaries),
+returns @tip + 'oneYearSlots'@ — the caller-visible search ceiling.
+-}
+selectUpperBound ::
+    Interpreter xs ->
+    -- | Current chain tip.
+    SlotNo ->
+    ValidityChoice ->
+    Either HorizonError SlotNo
+selectUpperBound interp tip choice =
+    let horizon = findHorizonSlot interp tip
+     in case choice of
+            AutoLongest ->
+                Right horizon
+            MaxHours h ->
+                Right (min (tipPlusHours tip h) horizon)
+            ExactlyHours h ->
+                let requested = tipPlusHours tip h
+                 in if requested <= horizon
+                        then Right requested
+                        else
+                            Left
+                                HorizonError
+                                    { heRequestedSlot = requested
+                                    , heHorizonSlot = horizon
+                                    , heTipSlot = tip
+                                    , heRequestedHours = h
+                                    }
+
+{- | Largest slot the interpreter can translate, capped at @tip + oneYearSlots@.
+
+Binary search using @slotToWallclock@ as the in-horizon predicate. The
+search ceiling is a year of slots past the tip; any caller that needs more
+than a year of validity is well beyond the chain's safe-zone semantics.
+-}
+findHorizonSlot :: Interpreter xs -> SlotNo -> SlotNo
+findHorizonSlot interp tip
+    | inHorizon ceilSlot = ceilSlot
+    | otherwise = bsearch tip ceilSlot
+  where
+    ceilSlot = SlotNo (unSlotNo tip + oneYearSlots)
+
+    inHorizon :: SlotNo -> Bool
+    inHorizon s = isRight (interpretQuery interp (slotToWallclock s))
+
+    -- INVARIANT: inHorizon lo && not (inHorizon hi)
+    bsearch :: SlotNo -> SlotNo -> SlotNo
+    bsearch lo hi
+        | unSlotNo lo + 1 >= unSlotNo hi = lo
+        | otherwise =
+            let mid = SlotNo ((unSlotNo lo + unSlotNo hi) `div` 2)
+             in if inHorizon mid
+                    then bsearch mid hi
+                    else bsearch lo mid
+
+tipPlusHours :: SlotNo -> Word16 -> SlotNo
+tipPlusHours (SlotNo t) h = SlotNo (t + fromIntegral h * 3_600)
+
+{- | Outer search ceiling for the binary search, in slots (= 1-second slots ×
+one year). Exposed so the test for the unbounded-era case can assert the
+exact returned slot.
+-}
+oneYearSlots :: Word64
+oneYearSlots = 365 * 24 * 3_600

--- a/llm/reviews/local-feat-133-horizon-aware-validity/gate.sh
+++ b/llm/reviews/local-feat-133-horizon-aware-validity/gate.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+nix develop --quiet -c just ci

--- a/llm/reviews/local-feat-133-horizon-aware-validity/state.md
+++ b/llm/reviews/local-feat-133-horizon-aware-validity/state.md
@@ -1,0 +1,19 @@
+state: ReadyForExternalReview
+pr: 134
+branch: feat/133-horizon-aware-validity
+issue: 133
+slices:
+  - sha: 091a5ec
+    title: "feat: Cardano.Node.Client.Validity — horizon-aware upper-bound math"
+    gates: [unit:9/9, fmt, hlint]
+  - sha: a2315a8
+    title: "feat: Provider.queryUpperBoundSlot for horizon-aware validity"
+    gates: [unit:231/231, e2e:3/3, fmt, hlint]
+  - sha: 18315b7
+    title: "docs: horizon-aware validity helper page"
+    gates: [fmt, hlint]
+gate: nix develop --quiet -c just ci  (last run: green)
+notes: |
+  Solo author/reviewer; not self-approving on GitHub.
+  Follow-up: wire queryUpperBoundSlot into amaru-treasury-tx wizards
+  (separate ticket; PR #88 there gated this work on the manual cap).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,3 +40,4 @@ nav:
       - Balance: modules/balance.md
       - TxBuild: modules/txbuild.md
       - N2C: modules/n2c.md
+      - Validity: modules/validity.md

--- a/specs/043-horizon-aware-validity/plan.md
+++ b/specs/043-horizon-aware-validity/plan.md
@@ -1,0 +1,82 @@
+# Plan — Horizon-Aware Validity Helper
+
+**Spec**: [spec.md](spec.md) — User Stories 1–3.
+**Issue**: [#133](https://github.com/lambdasistemi/cardano-node-clients/issues/133).
+**Branch**: `feat/133-horizon-aware-validity`.
+
+## Design Decisions
+
+### D1. Pure horizon math drives `Interpreter` through its public `interpretQuery` API.
+
+The `Interpreter xs` from `Ouroboros.Consensus.HardFork.History.Qry` is the only handle the node hands us via `GetInterpreter`. Its inner `Summary` is documented as *internal*: there is no public accessor, and the only ways to get it out are `Serialise` round-trip or `unsafeCoerce`. We use neither.
+
+Instead the pure function drives the `Interpreter` through `interpretQuery interp (slotToWallclock s)`. The Qry returns `Right _` iff `s` is currently translatable. To find the horizon we **binary-search** the range `[tip, tip + searchUpper]` using this probe as the predicate. Search converges in ~20 probes for any sensible `searchUpper` (≤ 1 year of slots) and never touches `Summary`.
+
+For unit tests we build `Summary` values by hand using the publicly-exported `Summary (..)` constructor plus `EraSummary`/`EraEnd`/`EraParams`, then wrap with `mkInterpreter :: Summary xs -> Interpreter xs`. The hand-built `Summary` is the only well-supported way to fixture an `Interpreter` and is explicitly documented as such (see `Summary.summaryWithExactly`).
+
+**Trade-off considered:** Walking the `Summary` directly would give us era-boundary info "for free" (we could classify the horizon as "era end known" vs "safe zone only"). Binary-search probes don't. We accept this loss because the classification is advisory only — callers don't act on it — and not depending on `Summary` internals is worth more than a richer error.
+
+### D2. `ValidityChoice` is closed sum, not an extensible config.
+
+Three constructors (`AutoLongest`, `MaxHours`, `ExactlyHours`) cover the requirement and admit `case` exhaustiveness checks. A polymorphic "policy" type would over-engineer; if we need a fourth case (e.g. `Slot SlotNo` for explicit slot), it is a one-line add.
+
+### D3. `HorizonError` carries facts, not a rendered message.
+
+Caller renders the diagnostic. `HorizonError` records the requested slot, the horizon slot, the tip slot, and the requested hours. We do not include POSIX times — the caller already has `posixMsToSlot` and friends to compute time from slot if needed. Era-end and safe-zone are intentionally absent (see D1).
+
+### D4. Gate is `just ci` + a new e2e case.
+
+`just ci` already runs `build → e2e → unit → cabal-fmt → fourmolu → hlint`. The new e2e case lives in `e2e-test/Cardano/Node/Client/E2E/Devnet/HorizonSpec.hs` and exercises the boundary smoke for User Story 1. No new gate script needed; `llm/reviews/<PR>/gate.sh` will just call `nix develop -c just ci`.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `Summary`/`EraSummary` types differ across consensus versions; copy-paste from upstream sources is fragile. | Slice 1 imports only from `Ouroboros.Consensus.HardFork.History.Summary` and `Cardano.Slotting.Slot`; we don't redefine ledger types. Failure to compile fails the gate immediately. |
+| `EraHistory` is parameterised over the era stack; the right phantom type is non-obvious. | Slice 1 fixes the type to `EraHistory (CardanoEras StandardCrypto)` (same shape used by the existing Provider). |
+| Unit test fixtures require a non-trivial `Summary` value. | Slice 1 builds `Summary` from a literal `NonEmpty EraSummary` constructed in code. Each fixture is 30–60 lines, plain record syntax. No serialization needed. |
+| `safeZone` is `SafeZone` data type with `StandardSafeZone Word64` and `UnsafeIndefiniteSafeZone` cases; choosing the wrong one in fixtures yields silent off-by-N. | Slice 1 fixtures use exclusively `StandardSafeZone n` where `n` matches mainnet (`129600`) and the synthetic unbounded case uses `UnsafeIndefiniteSafeZone`. We make this an explicit field in test names so each fixture self-documents. |
+| Devnet may not advance into a safe zone within test runtime. | E2E test asserts only "auto slot is translatable" (a horizon-respecting invariant) — it does not assert "auto slot equals end-of-epoch + safezone". The boundary-case math is in unit tests. |
+
+## Slice Plan (vertical commits)
+
+Each slice is a single bisect-safe reviewed commit including RED tests and GREEN implementation.
+
+### S1 — Pure horizon math + unit fixtures
+
+- **RED**: unit tests in `test/Cardano/Node/Client/ValiditySpec.hs` covering three fixtures (mid-epoch, safe-zone, unbounded) and three `ValidityChoice` cases.
+- **GREEN**: new module `lib/Cardano/Node/Client/Validity.hs` with `HorizonSlot`, `HorizonBoundary`, `HorizonError`, `ValidityChoice`, and `maxTranslatableUpperBound`.
+- **Bisect-safe**: yes — exposes a pure API with passing tests.
+- **TDD/DDD proof**: 3 fixtures × 3 choices = 9 unit assertions, named per Given/When/Then in spec.
+
+### S2 — Provider extension
+
+- **RED**: a new e2e test `e2e-test/Cardano/Node/Client/E2E/Devnet/HorizonSpec.hs` that calls the (not-yet-existing) `queryUpperBoundSlot`. Will fail to compile until S2's GREEN ships.
+- **GREEN**: extend `Provider` record and `N2C.Provider` with `queryUpperBoundSlot`, delegating to `Validity.selectUpperBound`. Uses the existing `GetInterpreter` + tip queries.
+- **Bisect-safe**: yes — the e2e is the boundary smoke; if S2 lands without S1 the import would fail to resolve.
+- **TDD/DDD proof**: one e2e assertion validating User Story 1 acceptance scenario 3.
+
+### S3 — Documentation
+
+- New `docs/horizon-aware-validity.md`, linked from `docs/index.md` and `mkdocs.yml`. Worked example + safe-zone explanation. No code change.
+- **Bisect-safe**: docs-only; no risk to gate.
+- **Not a behavior change** — exempt from TDD per pr skill ("Mark non-code tasks as docs ...").
+
+## Out of Scope (carried from spec)
+
+- `amaru-treasury-tx` integration.
+- Lower validity bound.
+- Provider-side automatic retry on overrun.
+
+## Gate
+
+`llm/reviews/local-feat-133-horizon-aware-validity/gate.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+nix develop --quiet -c just ci
+```
+
+The boundary smoke (live devnet) is the new e2e case from S2.

--- a/specs/043-horizon-aware-validity/spec.md
+++ b/specs/043-horizon-aware-validity/spec.md
@@ -1,0 +1,85 @@
+# Feature Specification: Horizon-Aware Validity Helper
+
+**Feature Branch**: `feat/133-horizon-aware-validity`
+**Created**: 2026-05-12
+**Status**: Draft
+**Issue**: [#133](https://github.com/lambdasistemi/cardano-node-clients/issues/133)
+**Input**: User description: "Pure module that exposes the longest plutus-translatable upper-bound slot given the chain's era history, with an optional manual hours override. Belongs in `cardano-node-clients` because nothing in the math is Amaru-specific."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Build a tx with the longest safe `invalid-hereafter` (Priority: P1)
+
+A tx-build caller asks "give me the longest upper-bound slot I can use right now". The library queries chain state and returns a `SlotNo` guaranteed to survive Plutus context translation; the caller passes it into `TxBuild.upperValidity` without further reasoning.
+
+**Why this priority**: This is the entire motivation for the feature. Without it, every tx-build caller re-implements safe-zone math (poorly) or hard-codes a small fixed window that wastes signing time.
+
+**Independent Test**: Against a live devnet node, calling `queryUpperBoundSlot AutoLongest` returns a slot, and using that slot as `invalid-hereafter` on a simple Plutus-scripted tx that the same node evaluates succeeds (no `TimeTranslationPastHorizon`).
+
+**Acceptance Scenarios**:
+
+1. **Given** a synced node and tip well inside an era (mid-epoch, mainnet), **When** the caller asks for `AutoLongest`, **Then** the returned slot is exactly the era end slot.
+2. **Given** a synced node and tip inside the era's safe zone (≤ `safeZone` slots from the era end), **When** the caller asks for `AutoLongest`, **Then** the returned slot is `eraEnd + safeZone` (or the documented equivalent the interpreter can translate).
+3. **Given** the slot returned by `AutoLongest`, **When** the caller asks `posixMsToSlot` for the corresponding POSIX time (or evaluates a script with that upper bound), **Then** no `PastHorizon` error occurs.
+
+---
+
+### User Story 2 — Cap auto at a maximum requested hours (Priority: P2)
+
+A caller wants "longest safe, but no more than N hours from tip" — e.g. an internal policy that signing windows must not exceed 24 hours, even when the chain would happily allow more.
+
+**Why this priority**: Pure auto is too aggressive for some operational policies. Without a cap, callers fall back to manual hours and lose the safety check.
+
+**Independent Test**: With a `MaxHours 4` request and a node whose horizon allows 60 h, the returned slot equals `tip + 4*3600`. With a `MaxHours 4` request and a node whose horizon allows only 2 h, the returned slot equals the auto horizon (=2 h).
+
+**Acceptance Scenarios**:
+
+1. **Given** the chain horizon is 60 hours from tip, **When** the caller asks `MaxHours 4`, **Then** the returned slot is `tip + 4 * 3600`.
+2. **Given** the chain horizon is 1 hour from tip, **When** the caller asks `MaxHours 4`, **Then** the returned slot is the horizon (≤ `tip + 1 * 3600`).
+
+---
+
+### User Story 3 — Strict manual hours request that fails fast on overrun (Priority: P2)
+
+A caller knows they want exactly N hours and wants the library to refuse rather than silently truncate when the chain horizon is shorter than that.
+
+**Why this priority**: Backwards-compatible behavior for callers that previously hand-computed `tip + N*3600` and are surprised by a quieter clamp.
+
+**Independent Test**: With `ExactlyHours 120` and a horizon of 60 h, the API returns `Left HorizonError` carrying the requested slot, the horizon slot, the era end, and the safe zone size — enough to render a useful diagnostic without re-querying.
+
+**Acceptance Scenarios**:
+
+1. **Given** the horizon is 60 h, **When** the caller asks `ExactlyHours 60`, **Then** the result is `Right slot` with `slot = tip + 60*3600`.
+2. **Given** the horizon is 30 h, **When** the caller asks `ExactlyHours 120`, **Then** the result is `Left HorizonError` containing the requested slot (`tip + 120*3600`), the horizon slot, the tip slot, and the requested hours.
+
+---
+
+## Functional Requirements
+
+- **FR-1** Module `Cardano.Node.Client.Validity` exposes a pure `selectUpperBound :: SListI xs => Interpreter xs -> SlotNo {- tip -} -> ValidityChoice -> Either HorizonError SlotNo`. No `IO`, no node access. The `Interpreter` is the same opaque consensus type the Provider already obtains via `GetInterpreter`; we drive it through the public `interpretQuery` API rather than reaching into its internals.
+- **FR-2** `HorizonError` carries `requestedSlot`, `horizonSlot`, `tipSlot`, and `requestedHours` — enough for the caller to render a diagnostic like "asked for N h ending at slot R, but horizon is H (tip T)". Era-boundary classification (era end vs safe zone vs unbounded) is **not** modelled in the public type because the `Interpreter`'s `Summary` is documented internal and we don't want to depend on it through Serialise round-trip or `unsafeCoerce`.
+- **FR-3** `ValidityChoice` is one of `AutoLongest | MaxHours Word16 | ExactlyHours Word16`. Hours are unsigned `Word16` (max 65535).
+- **FR-4** The Provider exposes `queryUpperBoundSlot :: ValidityChoice -> m (Either HorizonError SlotNo)` built on the existing `GetInterpreter` LSQ query plus the existing chain-tip query (`queryTip`). No new wire-level query is required.
+- **FR-5** Pure horizon math is covered by unit tests over **three** hand-built `Summary` fixtures (mid-epoch with bounded last era, late-in-era with bounded last era, unbounded last era via `neverForksSummary`). Each fixture is exposed to the pure function as an `Interpreter` via `mkInterpreter`.
+- **FR-6** A devnet E2E test asserts that `queryUpperBoundSlot AutoLongest` produces a slot the node can translate forward (the slot is fed back through `posixMsToSlot`-equivalent round-trip via `slotToWallclock` and produces a `Right`).
+- **FR-7** `docs/` gains a short page explaining the three choices and the safe-zone mechanic with a worked example.
+
+## Out of Scope
+
+- Wiring `amaru-treasury-tx` wizards to use this module — that ships separately on the `amaru-treasury-tx` repo (tracked as a follow-up; PR #88 already raised the manual cap to 168 h).
+- Lower validity bound (`invalid-before`) handling — current API only addresses upper bound.
+- Per-era recovery (e.g. degrading from `ExactlyHours` to `MaxHours` on overrun) — the caller decides.
+- Sub-slot precision — POSIX-to-slot rounding follows existing Provider conventions.
+
+## Success Criteria
+
+- `just ci` passes (build, e2e, unit, format, hlint).
+- E2E test for User Story 1 runs against the existing devnet harness.
+- Unit suite covers User Stories 2 and 3 boundary cases.
+- Module is consumable by an external caller via `Cardano.Node.Client.Validity` import alone.
+
+## Risks & Notes
+
+- **Interpreter mocking.** `Ouroboros.Consensus.HardFork.History.Qry.Interpreter` is not trivially constructable for tests. Strategy: capture a real `Interpreter` from a running devnet node into a binary file fixture, then deserialize per test. (Or: serialize the underlying `Summary` and rebuild.) Spike this on the first unit slice; if construction is too painful, fall back to property tests that drive the math via a thin `EraSummary`-shaped algebraic input and a separate adapter from `Interpreter`.
+- **`Word16` vs `Word32` hours.** `Word16` covers up to 7.4 years; sufficient. Picking `Word16` keeps the API distinct from raw slot counts.
+- **Naming.** "Horizon" is the chain term; "validity" is the tx-build term. Module is called `Validity` because its public surface is "what slot can I use as `invalid-hereafter`"; `HorizonSlot` is the internal vocabulary that crosses the boundary.

--- a/specs/043-horizon-aware-validity/tasks.md
+++ b/specs/043-horizon-aware-validity/tasks.md
@@ -1,0 +1,53 @@
+# Tasks — Horizon-Aware Validity Helper
+
+Spec: [spec.md](spec.md) · Plan: [plan.md](plan.md) · Issue: [#133](https://github.com/lambdasistemi/cardano-node-clients/issues/133).
+
+## S1 — Pure horizon math + unit fixtures *(one reviewed commit)*
+
+| Task | Type | Folds with | Output |
+|---|---|---|---|
+| T1.1 | RED | T1.2 | `test/Cardano/Node/Client/ValiditySpec.hs` — three hand-built `Summary` fixtures wrapped with `mkInterpreter`: `midEpochInterp` (last era bounded; tip far from end), `lateEpochInterp` (last era bounded; tip near end), `unboundedInterp` (last era `EraUnbounded`). |
+| T1.2 | RED | T1.3 | Unit assertions: 9 cases (3 fixtures × 3 `ValidityChoice` cases) keyed to spec acceptance scenarios. Each assertion compares `Either HorizonError SlotNo` against a hand-computed expected value. |
+| T1.3 | GREEN | T1.1, T1.2 | `lib/Cardano/Node/Client/Validity.hs` exporting `HorizonError (..)`, `ValidityChoice (..)`, `selectUpperBound`. Internal binary search uses `interpretQuery interp (slotToWallclock s)` as the in-horizon predicate. Wired into the cabal file's `library` exposed-modules. |
+| T1.4 | chore | — | Test suite stanza exposed — add `Cardano.Node.Client.ValiditySpec` to the `unit-tests` test suite's `other-modules` (or whatever the existing pattern is — check `unit/Spec.hs` for hspec-discover usage). |
+
+**Reviewed commit message** (working title for solo author):
+
+```
+feat: Cardano.Node.Client.Validity — horizon-aware upper-bound math
+```
+
+**Folding into one commit**: T1.1–T1.4 land in a single `git commit` after running unit tests RED→GREEN locally. No intermediate commits.
+
+## S2 — Provider extension + devnet e2e *(one reviewed commit)*
+
+| Task | Type | Folds with | Output |
+|---|---|---|---|
+| T2.1 | RED | T2.2, T2.3 | `e2e-test/Cardano/Node/Client/E2E/Devnet/HorizonSpec.hs`: spin up devnet via the existing `withCardanoNode` harness, connect a Provider, call `queryUpperBoundSlot AutoLongest`, assert the returned slot ≥ tip and that `posixMsToSlot` round-trip on the corresponding time succeeds (no `PastHorizon`). |
+| T2.2 | GREEN | T2.1, T2.3 | Extend `Cardano.Node.Client.Provider`: add `queryUpperBoundSlot :: ValidityChoice -> m (Either HorizonError SlotNo)`. |
+| T2.3 | GREEN | T2.1, T2.2 | Wire `N2C.Provider`: implement `queryUpperBoundSlot` via `BlockQuery (QueryHardFork GetInterpreter)` + the existing tip query, then delegate to `Validity.selectUpperBound`. Add to the e2e-tests cabal file. |
+
+**Reviewed commit message**:
+
+```
+feat: Provider.queryUpperBoundSlot for horizon-aware validity
+```
+
+**Folding**: T2.1–T2.3 land as one commit. The e2e test fails to compile until T2.2/T2.3 ship.
+
+## S3 — Documentation *(one reviewed commit, non-behavioral)*
+
+| Task | Type | Folds with | Output |
+|---|---|---|---|
+| T3.1 | docs | T3.2 | `docs/horizon-aware-validity.md`: explains epochs, eras, safe zone, and the three `ValidityChoice` modes with a worked example. |
+| T3.2 | docs | T3.1 | `mkdocs.yml` + `docs/index.md`: link the new page. |
+
+**Reviewed commit message**:
+
+```
+docs: horizon-aware validity helper
+```
+
+## RED/GREEN folding summary (pr skill compliance)
+
+Every behavior-changing slice (S1, S2) contains its RED proof and GREEN implementation in the same commit. S3 is docs-only and explicitly marked non-behavioral. No fixup commits planned; review-fix iterations amend the affected slice in place.

--- a/test/Cardano/Node/Client/E2E/HorizonSpec.hs
+++ b/test/Cardano/Node/Client/E2E/HorizonSpec.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Cardano.Node.Client.E2E.HorizonSpec
+Description : Devnet E2E smoke for the horizon-aware validity helper.
+License     : Apache-2.0
+-}
+module Cardano.Node.Client.E2E.HorizonSpec (spec) where
+
+import Test.Hspec (
+    Spec,
+    around,
+    describe,
+    it,
+    shouldSatisfy,
+ )
+
+import Cardano.Slotting.Slot (SlotNo (..))
+
+import Cardano.Node.Client.E2E.Setup (withDevnet)
+import Cardano.Node.Client.N2C.Provider (mkN2CProvider)
+import Cardano.Node.Client.Provider (Provider (..))
+import Cardano.Node.Client.Validity (ValidityChoice (..))
+
+spec :: Spec
+spec =
+    around withDevnet' $
+        describe "Provider.queryUpperBoundSlot" $ do
+            it "AutoLongest returns a slot >= 1 (devnet has a known era)" $
+                \(lsq, _) -> do
+                    let provider = mkN2CProvider lsq
+                    result <-
+                        queryUpperBoundSlot
+                            provider
+                            AutoLongest
+                    result
+                        `shouldSatisfy` isRightSlotAtLeast 1
+            it "MaxHours clamps a far-future request to the devnet horizon" $
+                -- Devnet eras are short; we don't know the exact horizon, so
+                -- we ask for one hour (way past horizon) and assert the
+                -- result is the same slot 'AutoLongest' returns. This is the
+                -- contract of MaxHours: clamp, never fail.
+                \(lsq, _) -> do
+                    let provider = mkN2CProvider lsq
+                    auto <-
+                        queryUpperBoundSlot
+                            provider
+                            AutoLongest
+                    capped <-
+                        queryUpperBoundSlot
+                            provider
+                            (MaxHours 1)
+                    capped `shouldSatisfy` (== auto)
+            it "ExactlyHours past the horizon returns HorizonError" $
+                -- Same setup; ExactlyHours fails fast where MaxHours clamps.
+                \(lsq, _) -> do
+                    let provider = mkN2CProvider lsq
+                    result <-
+                        queryUpperBoundSlot
+                            provider
+                            (ExactlyHours 1)
+                    result `shouldSatisfy` isLeft
+  where
+    withDevnet' action = withDevnet $ curry action
+
+    isRightSlotAtLeast :: Word -> Either e SlotNo -> Bool
+    isRightSlotAtLeast n (Right (SlotNo s)) = s >= fromIntegral n
+    isRightSlotAtLeast _ _ = False
+
+    isLeft :: Either e a -> Bool
+    isLeft (Left _) = True
+    isLeft _ = False

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -1792,6 +1792,10 @@ outputCountingProvider pp perOutput =
                 pure . SlotNo . fromIntegral
             , posixMsCeilSlot =
                 pure . SlotNo . fromIntegral
+            , queryUpperBoundSlot = \_ ->
+                error
+                    "outputCountingProvider: \
+                    \queryUpperBoundSlot unused"
             }
 
 redeemerExUnits ::

--- a/test/Cardano/Node/Client/TxGenerator/SelectionSpec.hs
+++ b/test/Cardano/Node/Client/TxGenerator/SelectionSpec.hs
@@ -318,6 +318,8 @@ stubProvider tip =
                 pure (unused "posixMsToSlot")
             , posixMsCeilSlot = \_ ->
                 pure (unused "posixMsCeilSlot")
+            , queryUpperBoundSlot = \_ ->
+                pure (unused "queryUpperBoundSlot")
             }
     unused name =
         error

--- a/test/Cardano/Node/Client/ValiditySpec.hs
+++ b/test/Cardano/Node/Client/ValiditySpec.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+module Cardano.Node.Client.ValiditySpec (spec) where
+
+import Data.SOP.NonEmpty (NonEmpty (..))
+import Data.Word (Word64)
+import Test.Hspec (
+    Spec,
+    describe,
+    it,
+    shouldBe,
+ )
+
+import Cardano.Slotting.Slot (EpochNo (..), EpochSize (..), SlotNo (..))
+import Cardano.Slotting.Time (
+    RelativeTime (..),
+    slotLengthFromSec,
+ )
+
+import Ouroboros.Consensus.Block.Abstract (GenesisWindow (..))
+import Ouroboros.Consensus.HardFork.History.EraParams (
+    EraParams (..),
+    SafeZone (..),
+    pattern NoPerasEnabled,
+ )
+import Ouroboros.Consensus.HardFork.History.Qry (mkInterpreter)
+import Ouroboros.Consensus.HardFork.History.Summary (
+    Bound (..),
+    EraEnd (..),
+    EraSummary (..),
+    Summary (..),
+ )
+
+import Cardano.Node.Client.Validity (
+    HorizonError (..),
+    ValidityChoice (..),
+    oneYearSlots,
+    selectUpperBound,
+ )
+
+-- A single-era phantom era list keeps Interpreter generic-free in tests.
+type TestEras = '[()]
+
+-- 1-second slots; mainnet-shaped 432_000-slot epoch and 36-hour safe zone.
+conwayShapedParams :: EraParams
+conwayShapedParams =
+    EraParams
+        { eraEpochSize = EpochSize 432_000
+        , eraSlotLength = slotLengthFromSec 1
+        , eraSafeZone = StandardSafeZone 129_600
+        , eraGenesisWin = GenesisWindow 129_600
+        , eraPerasRoundLength = NoPerasEnabled
+        }
+
+-- Bound at slot @s@ with 1-second slot length (so wallclock time = s seconds).
+mkBound :: Word64 -> Bound
+mkBound s =
+    Bound
+        { boundTime = RelativeTime (fromIntegral s)
+        , boundSlot = SlotNo s
+        , boundEpoch = EpochNo (s `div` 432_000)
+        , boundPerasRound = NoPerasEnabled
+        }
+
+bounded :: Word64 -> Word64 -> EraSummary
+bounded s0 s1 =
+    EraSummary
+        { eraStart = mkBound s0
+        , eraEnd = EraEnd (mkBound s1)
+        , eraParams = conwayShapedParams
+        }
+
+unbounded :: Word64 -> EraSummary
+unbounded s0 =
+    EraSummary
+        { eraStart = mkBound s0
+        , eraEnd = EraUnbounded
+        , eraParams = conwayShapedParams{eraSafeZone = UnsafeIndefiniteSafeZone}
+        }
+
+-- Last era ends at slot 1_000_000 (exclusive).
+midEpochSummary :: Summary TestEras
+midEpochSummary = Summary (NonEmptyOne (bounded 0 1_000_000))
+
+-- Last era is unbounded.
+unboundedSummary :: Summary TestEras
+unboundedSummary = Summary (NonEmptyOne (unbounded 0))
+
+spec :: Spec
+spec = describe "Cardano.Node.Client.Validity.selectUpperBound" $ do
+    let midEpochInterp = mkInterpreter midEpochSummary
+        unboundedInterp = mkInterpreter unboundedSummary
+
+        midTip = SlotNo 500_000
+        lateTip = SlotNo 990_000
+        unboundedTip = SlotNo 1_000
+
+        -- bounded era ends at slot 1_000_000 (exclusive)
+        -- ⇒ last translatable slot is 999_999.
+        eraHorizon = SlotNo 999_999
+
+    describe "AutoLongest" $ do
+        it "mid-epoch: returns the era horizon" $
+            selectUpperBound midEpochInterp midTip AutoLongest
+                `shouldBe` Right eraHorizon
+
+        it "late-in-era: still returns the era horizon" $
+            selectUpperBound midEpochInterp lateTip AutoLongest
+                `shouldBe` Right eraHorizon
+
+        it "unbounded era: returns the search ceiling (tip + 1 year)" $
+            selectUpperBound unboundedInterp unboundedTip AutoLongest
+                `shouldBe` Right (SlotNo (unSlotNo unboundedTip + oneYearSlots))
+
+    describe "MaxHours" $ do
+        it "mid-epoch with hours inside horizon: returns tip + hours" $
+            -- 4h = 14_400s; tip+4h = 514_400 < eraHorizon 999_999.
+            selectUpperBound midEpochInterp midTip (MaxHours 4)
+                `shouldBe` Right (SlotNo 514_400)
+
+        it "late-in-era with hours exceeding horizon: clamps to horizon" $
+            -- lateTip + 24h = 1_076_400 > eraHorizon ⇒ clamp to horizon.
+            selectUpperBound midEpochInterp lateTip (MaxHours 24)
+                `shouldBe` Right eraHorizon
+
+        it "unbounded era: respects hours cap" $
+            selectUpperBound unboundedInterp unboundedTip (MaxHours 1)
+                `shouldBe` Right (SlotNo 4_600)
+
+    describe "ExactlyHours" $ do
+        it "mid-epoch with hours inside horizon: returns tip + hours" $
+            selectUpperBound midEpochInterp midTip (ExactlyHours 4)
+                `shouldBe` Right (SlotNo 514_400)
+
+        it "late-in-era with hours exceeding horizon: returns HorizonError" $
+            selectUpperBound midEpochInterp lateTip (ExactlyHours 24)
+                `shouldBe` Left
+                    HorizonError
+                        { heRequestedSlot = SlotNo 1_076_400
+                        , heHorizonSlot = eraHorizon
+                        , heTipSlot = lateTip
+                        , heRequestedHours = 24
+                        }
+
+        it "unbounded era with large hours: returns tip + hours" $
+            selectUpperBound unboundedInterp unboundedTip (ExactlyHours 100)
+                `shouldBe` Right (SlotNo (1_000 + 100 * 3_600))

--- a/test/main.hs
+++ b/test/main.hs
@@ -5,6 +5,7 @@ import Test.Hspec (hspec)
 import Cardano.Node.Client.E2E.BalanceSpec qualified as BalanceSpec
 import Cardano.Node.Client.E2E.ChainPopulatorSpec qualified as ChainPopulatorSpec
 import Cardano.Node.Client.E2E.ChainSyncSpec qualified as ChainSyncSpec
+import Cardano.Node.Client.E2E.HorizonSpec qualified as HorizonSpec
 import Cardano.Node.Client.E2E.Issue97ReproSpec qualified as Issue97ReproSpec
 import Cardano.Node.Client.E2E.MultiAssetChangeSpec qualified as MultiAssetChangeSpec
 import Cardano.Node.Client.E2E.N2CFullSpec qualified as N2CFullSpec
@@ -33,6 +34,7 @@ main = hspec $ do
     ChainPopulatorSpec.spec
     UTxOIndexerSpec.spec
     UTxOIndexerReconnectSpec.spec
+    HorizonSpec.spec
     Issue97ReproSpec.spec
     TxGeneratorReadySpec.spec
     TxGeneratorRefillSpec.spec

--- a/test/unit-main.hs
+++ b/test/unit-main.hs
@@ -18,6 +18,7 @@ import Cardano.Node.Client.UTxOIndexer.IndexerSpec qualified as UTxOIndexerSpec
 import Cardano.Node.Client.UTxOIndexer.PersistenceSpec qualified as UTxOIndexerPersistenceSpec
 import Cardano.Node.Client.UTxOIndexer.ServerSpec qualified as UTxOIndexerServerSpec
 import Cardano.Node.Client.UTxOIndexer.TypesSpec qualified as UTxOIndexerTypesSpec
+import Cardano.Node.Client.ValiditySpec qualified as ValiditySpec
 import Data.List.SampleFibonacciSpec qualified as SampleFibonacciSpec
 
 main :: IO ()
@@ -39,3 +40,4 @@ main = hspec $ do
     TxGeneratorSelectionSpec.spec
     TxGeneratorServerSpec.spec
     TxGeneratorSnapshotSpec.spec
+    ValiditySpec.spec


### PR DESCRIPTION
Closes #133.

## What

Adds `Cardano.Node.Client.Validity`, exposing a pure
`selectUpperBound :: Interpreter xs -> SlotNo -> ValidityChoice -> Either HorizonError SlotNo`,
and wires `queryUpperBoundSlot` into the `Provider` record. Callers
who previously did `tip + N*3600` and got bitten by `TimeTranslationPastHorizon`
deep inside script evaluation can now ask for an `invalid-hereafter`
slot that is guaranteed to be inside the chain's plutus-translation
horizon.

## Why

A downstream caller (`lambdasistemi/amaru-treasury-tx#88`) raised the
manual `--validity-hours` cap to 168 h to support multi-day signing
windows. Hitting that cap mid-epoch died with `PastHorizon` because
the consensus interpreter refuses to translate slots past the
current era's `eraEnd`. There was no protocol-agnostic helper to ask
"what's the largest slot I can safely use right now?", so every
caller had to re-implement era-summary math (poorly) or hard-code a
small window.

## Layout

Three vertical commits:

1. `feat: Cardano.Node.Client.Validity — horizon-aware upper-bound math` — pure module + unit tests over hand-built `Summary` fixtures.
2. `feat: Provider.queryUpperBoundSlot for horizon-aware validity` — `Provider` record extension and N2C implementation, plus a devnet e2e in `test/Cardano/Node/Client/E2E/HorizonSpec.hs` that exercises the round trip.
3. `docs: horizon-aware validity helper page` — `docs/modules/validity.md` linked from `mkdocs.yml`.

Spec/plan/tasks: [`specs/043-horizon-aware-validity/`](https://github.com/lambdasistemi/cardano-node-clients/tree/feat/133-horizon-aware-validity/specs/043-horizon-aware-validity).

## API

```haskell
data ValidityChoice
  = AutoLongest
  | MaxHours      !Word16
  | ExactlyHours  !Word16

data HorizonError = HorizonError
  { heRequestedSlot  :: !SlotNo
  , heHorizonSlot    :: !SlotNo
  , heTipSlot        :: !SlotNo
  , heRequestedHours :: !Word16
  }

selectUpperBound
  :: Interpreter xs
  -> SlotNo                              -- ^ current tip
  -> ValidityChoice
  -> Either HorizonError SlotNo
```

## Design notes

* The `Summary` wrapped by `Interpreter` is documented internal in
  consensus. This PR drives `Interpreter` only through the public
  `interpretQuery` API — no `Codec.Serialise` round trip, no
  `Unsafe.Coerce` reach into the wrapped value. `AutoLongest` is a
  ~20-probe binary search of `slotToWallclock` over `[tip, tip + 1 year]`.
* `HorizonError` deliberately omits era-end/safe-zone classification:
  it would require reaching into the `Summary`. Callers that need it
  can re-query the interpreter — the diagnostic surface
  (`requestedSlot`, `horizonSlot`, `tipSlot`, `requestedHours`) is
  enough for the operational error message.
* Two stub `Provider` values in the unit suite (`SelectionSpec`,
  `TxBuildSpec`) gain a deliberately-unused `queryUpperBoundSlot`
  field so existing construction sites continue to typecheck.

## Verification

* `nix develop -c just ci` ✓ (build + unit + e2e + cabal-fmt + fourmolu + hlint).
* Unit: 231 examples / 0 failures — 9 new cases in `ValiditySpec` (3 fixtures × 3 `ValidityChoice` cases).
* e2e: new `HorizonSpec` runs against `withDevnet`; the devnet's short last era exercises both the `MaxHours` clamp and the `ExactlyHours` failure path.
* Format / hlint: clean.

## Out of scope

* `amaru-treasury-tx` wizard integration ships separately; see
  `lambdasistemi/amaru-treasury-tx#88` for the manual-cap step
  that motivated this work. A follow-up there will replace the
  fixed `--validity-hours N` knob with an `AutoLongest`-by-default
  option backed by `queryUpperBoundSlot`.
* Lower validity bound (`invalid-before`) handling.