### PR TITLE
feat(governance): prove DevNet rewards

### DIFF
--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -46,6 +46,7 @@ library tx-build
     Cardano.Node.Client.Ledger
     Cardano.Node.Client.TxBuild
 
+  other-modules:    Cardano.Node.Client.Inputs
   build-depends:
     , base
     , bytestring

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -50,6 +50,7 @@ library tx-build
     Cardano.Node.Client.Credentials
     Cardano.Node.Client.Inputs
     Cardano.Node.Client.Scripts
+    Cardano.Node.Client.Witnesses
 
   build-depends:
     , base

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -361,6 +361,7 @@ test-suite e2e-tests
     Cardano.Node.Client.E2E.BalanceSpec
     Cardano.Node.Client.E2E.ChainPopulatorSpec
     Cardano.Node.Client.E2E.ChainSyncSpec
+    Cardano.Node.Client.E2E.GovernanceSmokeSpec
     Cardano.Node.Client.E2E.HorizonSpec
     Cardano.Node.Client.E2E.Issue97ReproSpec
     Cardano.Node.Client.E2E.MultiAssetChangeSpec

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -48,6 +48,7 @@ library tx-build
 
   other-modules:
     Cardano.Node.Client.Credentials
+    Cardano.Node.Client.Deposits
     Cardano.Node.Client.Inputs
     Cardano.Node.Client.Scripts
     Cardano.Node.Client.Witnesses

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -47,6 +47,7 @@ library tx-build
     Cardano.Node.Client.TxBuild
 
   other-modules:
+    Cardano.Node.Client.Credentials
     Cardano.Node.Client.Inputs
     Cardano.Node.Client.Scripts
 

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -46,7 +46,10 @@ library tx-build
     Cardano.Node.Client.Ledger
     Cardano.Node.Client.TxBuild
 
-  other-modules:    Cardano.Node.Client.Inputs
+  other-modules:
+    Cardano.Node.Client.Inputs
+    Cardano.Node.Client.Scripts
+
   build-depends:
     , base
     , bytestring

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -70,6 +70,7 @@ library
   hs-source-dirs:     lib
   default-language:   GHC2021
   exposed-modules:
+    Cardano.Node.Client.Address
     Cardano.Node.Client.Evaluate
     Cardano.Node.Client.N2C.ChainSync
     Cardano.Node.Client.N2C.Codecs
@@ -255,6 +256,7 @@ test-suite unit-tests
   main-is:          unit-main.hs
   default-language: GHC2021
   other-modules:
+    Cardano.Node.Client.AddressSpec
     Cardano.Node.Client.BalanceSpec
     Cardano.Node.Client.ConwayFixtures
     Cardano.Node.Client.N2C.ProbeSpec

--- a/e2e-test/Cardano/Node/Client/E2E/Setup.hs
+++ b/e2e-test/Cardano/Node/Client/E2E/Setup.hs
@@ -50,6 +50,7 @@ module Cardano.Node.Client.E2E.Setup (
 
     -- * Devnet bracket
     withDevnet,
+    withDevnetFromGenesis,
 ) where
 
 import Control.Concurrent (threadDelay)
@@ -207,6 +208,17 @@ withDevnet ::
     IO a
 withDevnet action = do
     gDir <- genesisDir
+    withDevnetFromGenesis gDir action
+
+{- | Start a cardano-node devnet from a specific
+genesis directory, connect via N2C, run an action,
+and tear down.
+-}
+withDevnetFromGenesis ::
+    FilePath ->
+    (LSQChannel -> LTxSChannel -> IO a) ->
+    IO a
+withDevnetFromGenesis gDir action =
     withCardanoNode gDir $ \sock _startMs -> do
         lsqCh <- newLSQChannel 16
         ltxsCh <- newLTxSChannel 16

--- a/lib-tx-build/Cardano/Node/Client/Balance.hs
+++ b/lib-tx-build/Cardano/Node/Client/Balance.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE LambdaCase #-}
 
 {- |
 Module      : Cardano.Node.Client.Balance
@@ -13,9 +14,9 @@ estimated iteratively via 'estimateMinFeeTx' from
 dummy VKey witnesses for correct size estimation.
 
 The change output absorbs both the residual ADA
-(@input − fee − sum(existing output ADA)@) and any
-residual multi-assets (@sum(input MA) + mint −
-sum(existing output MA)@). This lets callers mint
+(@input + refunds - fee - deposits - outputs@)
+and any residual multi-assets (@sum(input MA) +
+mint - sum(existing output MA)@). This lets callers mint
 NFTs without emitting an explicit recipient output:
 the minted asset lands in the change output along
 with the ADA leftovers, matching the convention of
@@ -47,13 +48,20 @@ module Cardano.Node.Client.Balance (
 ) where
 
 import Data.ByteString qualified as BS
+import Data.Foldable (toList)
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Sequence.Strict (StrictSeq, (|>))
 import Data.Set qualified as Set
 import Data.Word (Word32)
 import Lens.Micro ((&), (.~), (^.))
 
-import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Address (
+    AccountAddress (..),
+    AccountId (..),
+    Addr (..),
+    Withdrawals (..),
+ )
 import Cardano.Ledger.Alonzo.PParams (
     LangDepView,
     getLanguageView,
@@ -74,17 +82,24 @@ import Cardano.Ledger.Api.Tx (
     witsTxL,
  )
 import Cardano.Ledger.Api.Tx.Body (
+    TxBody,
+    certsTxBodyL,
     collateralInputsTxBodyL,
     collateralReturnTxBodyL,
     feeTxBodyL,
     inputsTxBodyL,
     mintTxBodyL,
     outputsTxBodyL,
+    proposalProceduresTxBodyL,
     referenceInputsTxBodyL,
+    reqSignerHashesTxBodyL,
     totalCollateralTxBodyL,
+    votingProceduresTxBodyL,
+    withdrawalsTxBodyL,
  )
 import Cardano.Ledger.Api.Tx.Out (
     TxOut,
+    addrTxOutL,
     coinTxOutL,
     getMinCoinTxOut,
     mkBasicTxOut,
@@ -99,8 +114,26 @@ import Cardano.Ledger.BaseTypes (
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Core (PParams)
+import Cardano.Ledger.Conway.Governance (
+    ProposalProcedure (..),
+    Voter (..),
+    VotingProcedures (..),
+ )
+import Cardano.Ledger.Conway.TxCert (
+    ConwayDelegCert (..),
+    ConwayGovCert (..),
+    ConwayTxCert (..),
+    getVKeyWitnessConwayTxCert,
+ )
+import Cardano.Ledger.Core (
+    PParams,
+    getTotalDepositsTxCerts,
+ )
+import Cardano.Ledger.Credential (
+    Credential (..),
+ )
 import Cardano.Ledger.Hashes (originalBytes)
+import Cardano.Ledger.Keys (KeyHash (..))
 import Cardano.Ledger.Mary.Value (
     MaryValue (..),
     MultiAsset (..),
@@ -256,11 +289,15 @@ balanceTxWith
                     (\s (tin, _) -> Set.insert tin s)
                     (body ^. inputsTxBodyL)
                     inputUtxos
+            keyWitnesses =
+                estimatedKeyWitnessCount body newInputs inputUtxos
             origOutputs = body ^. outputsTxBodyL
             -- Sum ADA / multi-assets already committed
             -- in existing outputs (e.g. asteria + ship
             -- outputs in a spawn-ship tx).
             (Coin origAda, origMA) = sumValues origOutputs
+            depositDelta =
+                bodyDepositDelta pp body
             bodyMint :: MultiAsset
             bodyMint = body ^. mintTxBodyL
             -- Residual multi-assets that no existing
@@ -410,7 +447,7 @@ balanceTxWith
                     change =
                         max
                             0
-                            (avail - req - origAda)
+                            (avail - req - origAda - depositDelta)
                     changeOut =
                         mkBasicTxOut
                             changeAddr
@@ -443,7 +480,7 @@ balanceTxWith
                                     estimateMinFeeTx
                                         pp
                                         candidate
-                                        1 -- key witnesses
+                                        keyWitnesses
                                         0 -- Byron witnesses
                                         refScriptBytes
                              in if newFee <= currentFee
@@ -458,7 +495,10 @@ balanceTxWith
                     let Coin available = inputCoin
                         Coin required = fee
                         changeAmount =
-                            available - required - origAda
+                            available
+                                - required
+                                - origAda
+                                - depositDelta
                      in if changeAmount < 0
                             then
                                 Left
@@ -472,6 +512,140 @@ balanceTxWith
                                         result
                                         (length origOutputs)
                                     )
+
+bodyDepositDelta ::
+    PParams ConwayEra ->
+    TxBody l ConwayEra ->
+    Integer
+bodyDepositDelta pp body =
+    coinInteger
+        ( getTotalDepositsTxCerts
+            pp
+            (const False)
+            (body ^. certsTxBodyL)
+        )
+        - sum (certRefund <$> toList (body ^. certsTxBodyL))
+        + sum
+            ( proposalDeposit
+                <$> toList (body ^. proposalProceduresTxBodyL)
+            )
+
+estimatedKeyWitnessCount ::
+    TxBody l ConwayEra ->
+    Set.Set TxIn ->
+    [(TxIn, TxOut ConwayEra)] ->
+    Int
+estimatedKeyWitnessCount body bodyInputs inputUtxos =
+    max 1 $
+        Set.size $
+            inputWitnesses
+                <> certWitnesses
+                <> requiredSignerWitnesses
+                <> votingWitnesses
+                <> withdrawalWitnesses
+  where
+    inputWitnesses =
+        Set.fromList
+            [ kh
+            | (txIn, txOut) <- inputUtxos
+            , Set.member txIn bodyInputs
+            , Just kh <- [addrPaymentKeyHashBytes (txOut ^. addrTxOutL)]
+            ]
+    certWitnesses =
+        Set.fromList
+            [ keyHashBytes kh
+            | cert <- toList (body ^. certsTxBodyL)
+            , Just kh <- [getVKeyWitnessConwayTxCert cert]
+            ]
+    requiredSignerWitnesses =
+        Set.fromList
+            [ keyHashBytes kh
+            | kh <- Set.toList (body ^. reqSignerHashesTxBodyL)
+            ]
+    votingWitnesses =
+        let VotingProcedures procedures =
+                body ^. votingProceduresTxBodyL
+         in Set.fromList
+                [ bytes
+                | voter <- Map.keys procedures
+                , Just bytes <- [voterKeyHashBytes voter]
+                ]
+    withdrawalWitnesses =
+        let Withdrawals withdrawals =
+                body ^. withdrawalsTxBodyL
+         in Set.fromList
+                [ kh
+                | account <- Map.keys withdrawals
+                , Just kh <- [accountKeyHashBytes account]
+                ]
+
+addrPaymentKeyHashBytes :: Addr -> Maybe BS.ByteString
+addrPaymentKeyHashBytes =
+    \case
+        Addr _ (KeyHashObj kh) _ ->
+            Just (keyHashBytes kh)
+        Addr _ (ScriptHashObj _) _ ->
+            Nothing
+        AddrBootstrap _ ->
+            Nothing
+
+accountKeyHashBytes :: AccountAddress -> Maybe BS.ByteString
+accountKeyHashBytes =
+    \case
+        AccountAddress _ (AccountId (KeyHashObj kh)) ->
+            Just (keyHashBytes kh)
+        AccountAddress _ (AccountId (ScriptHashObj _)) ->
+            Nothing
+
+voterKeyHashBytes :: Voter -> Maybe BS.ByteString
+voterKeyHashBytes =
+    \case
+        CommitteeVoter credential ->
+            credentialKeyHashBytes credential
+        DRepVoter credential ->
+            credentialKeyHashBytes credential
+        StakePoolVoter kh ->
+            Just (keyHashBytes kh)
+
+credentialKeyHashBytes :: Credential kd -> Maybe BS.ByteString
+credentialKeyHashBytes =
+    \case
+        KeyHashObj kh ->
+            Just (keyHashBytes kh)
+        ScriptHashObj _ ->
+            Nothing
+
+keyHashBytes :: KeyHash kd -> BS.ByteString
+keyHashBytes (KeyHash h) =
+    originalBytes h
+
+certRefund ::
+    ConwayTxCert ConwayEra ->
+    Integer
+certRefund =
+    \case
+        ConwayTxCertDeleg (ConwayUnRegCert _ refund) ->
+            strictMaybeCoin refund
+        ConwayTxCertGov (ConwayUnRegDRep _ refund) ->
+            coinInteger refund
+        _ ->
+            0
+
+proposalDeposit :: ProposalProcedure ConwayEra -> Integer
+proposalDeposit (ProposalProcedure deposit _ _ _) =
+    coinInteger deposit
+
+strictMaybeCoin :: StrictMaybe Coin -> Integer
+strictMaybeCoin =
+    \case
+        SJust coin ->
+            coinInteger coin
+        SNothing ->
+            0
+
+coinInteger :: Coin -> Integer
+coinInteger (Coin value) =
+    value
 
 {- | Output function rejected the fee, or the
 iteration did not converge.

--- a/lib-tx-build/Cardano/Node/Client/Balance.hs
+++ b/lib-tx-build/Cardano/Node/Client/Balance.hs
@@ -48,7 +48,6 @@ module Cardano.Node.Client.Balance (
 ) where
 
 import Data.Foldable (toList)
-import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Sequence.Strict (StrictSeq, (|>))
 import Data.Set qualified as Set
@@ -56,7 +55,6 @@ import Lens.Micro ((&), (.~), (^.))
 
 import Cardano.Ledger.Address (
     Addr,
-    Withdrawals (..),
  )
 import Cardano.Ledger.Alonzo.PParams (
     ppCollateralPercentageL,
@@ -80,14 +78,10 @@ import Cardano.Ledger.Api.Tx.Body (
     outputsTxBodyL,
     proposalProceduresTxBodyL,
     referenceInputsTxBodyL,
-    reqSignerHashesTxBodyL,
     totalCollateralTxBodyL,
-    votingProceduresTxBodyL,
-    withdrawalsTxBodyL,
  )
 import Cardano.Ledger.Api.Tx.Out (
     TxOut,
-    addrTxOutL,
     coinTxOutL,
     getMinCoinTxOut,
     mkBasicTxOut,
@@ -103,13 +97,11 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance (
     ProposalProcedure (..),
-    VotingProcedures (..),
  )
 import Cardano.Ledger.Conway.TxCert (
     ConwayDelegCert (..),
     ConwayGovCert (..),
     ConwayTxCert (..),
-    getVKeyWitnessConwayTxCert,
  )
 import Cardano.Ledger.Core (
     PParams,
@@ -122,12 +114,6 @@ import Cardano.Ledger.Mary.Value (
     mapMaybeMultiAsset,
  )
 import Cardano.Ledger.TxIn (TxIn)
-import Cardano.Node.Client.Credentials (
-    accountKeyHashBytes,
-    addrPaymentKeyHashBytes,
-    keyHashBytes,
-    voterKeyHashBytes,
- )
 import Cardano.Node.Client.Inputs (spendingIndex)
 import Cardano.Node.Client.Ledger (ConwayTx)
 import Cardano.Node.Client.Scripts (
@@ -136,6 +122,7 @@ import Cardano.Node.Client.Scripts (
     placeholderExUnits,
     refScriptsSize,
  )
+import Cardano.Node.Client.Witnesses (estimatedKeyWitnessCount)
 
 {- | Result of 'balanceTx'. Carries the balanced
 transaction and the index of the change output
@@ -521,55 +508,6 @@ bodyDepositDelta pp body =
             ( proposalDeposit
                 <$> toList (body ^. proposalProceduresTxBodyL)
             )
-
-estimatedKeyWitnessCount ::
-    TxBody l ConwayEra ->
-    Set.Set TxIn ->
-    [(TxIn, TxOut ConwayEra)] ->
-    Int
-estimatedKeyWitnessCount body bodyInputs inputUtxos =
-    max 1 $
-        Set.size $
-            inputWitnesses
-                <> certWitnesses
-                <> requiredSignerWitnesses
-                <> votingWitnesses
-                <> withdrawalWitnesses
-  where
-    inputWitnesses =
-        Set.fromList
-            [ kh
-            | (txIn, txOut) <- inputUtxos
-            , Set.member txIn bodyInputs
-            , Just kh <- [addrPaymentKeyHashBytes (txOut ^. addrTxOutL)]
-            ]
-    certWitnesses =
-        Set.fromList
-            [ keyHashBytes kh
-            | cert <- toList (body ^. certsTxBodyL)
-            , Just kh <- [getVKeyWitnessConwayTxCert cert]
-            ]
-    requiredSignerWitnesses =
-        Set.fromList
-            [ keyHashBytes kh
-            | kh <- Set.toList (body ^. reqSignerHashesTxBodyL)
-            ]
-    votingWitnesses =
-        let VotingProcedures procedures =
-                body ^. votingProceduresTxBodyL
-         in Set.fromList
-                [ bytes
-                | voter <- Map.keys procedures
-                , Just bytes <- [voterKeyHashBytes voter]
-                ]
-    withdrawalWitnesses =
-        let Withdrawals withdrawals =
-                body ^. withdrawalsTxBodyL
-         in Set.fromList
-                [ kh
-                | account <- Map.keys withdrawals
-                , Just kh <- [accountKeyHashBytes account]
-                ]
 
 certRefund ::
     ConwayTxCert ConwayEra ->

--- a/lib-tx-build/Cardano/Node/Client/Balance.hs
+++ b/lib-tx-build/Cardano/Node/Client/Balance.hs
@@ -47,7 +47,6 @@ module Cardano.Node.Client.Balance (
     FeeLoopError (..),
 ) where
 
-import Data.ByteString qualified as BS
 import Data.Foldable (toList)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
@@ -56,9 +55,7 @@ import Data.Set qualified as Set
 import Lens.Micro ((&), (.~), (^.))
 
 import Cardano.Ledger.Address (
-    AccountAddress (..),
-    AccountId (..),
-    Addr (..),
+    Addr,
     Withdrawals (..),
  )
 import Cardano.Ledger.Alonzo.PParams (
@@ -106,7 +103,6 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance (
     ProposalProcedure (..),
-    Voter (..),
     VotingProcedures (..),
  )
 import Cardano.Ledger.Conway.TxCert (
@@ -119,11 +115,6 @@ import Cardano.Ledger.Core (
     PParams,
     getTotalDepositsTxCerts,
  )
-import Cardano.Ledger.Credential (
-    Credential (..),
- )
-import Cardano.Ledger.Hashes (originalBytes)
-import Cardano.Ledger.Keys (KeyHash (..))
 import Cardano.Ledger.Mary.Value (
     MaryValue (..),
     MultiAsset (..),
@@ -131,6 +122,12 @@ import Cardano.Ledger.Mary.Value (
     mapMaybeMultiAsset,
  )
 import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Node.Client.Credentials (
+    accountKeyHashBytes,
+    addrPaymentKeyHashBytes,
+    keyHashBytes,
+    voterKeyHashBytes,
+ )
 import Cardano.Node.Client.Inputs (spendingIndex)
 import Cardano.Node.Client.Ledger (ConwayTx)
 import Cardano.Node.Client.Scripts (
@@ -573,46 +570,6 @@ estimatedKeyWitnessCount body bodyInputs inputUtxos =
                 | account <- Map.keys withdrawals
                 , Just kh <- [accountKeyHashBytes account]
                 ]
-
-addrPaymentKeyHashBytes :: Addr -> Maybe BS.ByteString
-addrPaymentKeyHashBytes =
-    \case
-        Addr _ (KeyHashObj kh) _ ->
-            Just (keyHashBytes kh)
-        Addr _ (ScriptHashObj _) _ ->
-            Nothing
-        AddrBootstrap _ ->
-            Nothing
-
-accountKeyHashBytes :: AccountAddress -> Maybe BS.ByteString
-accountKeyHashBytes =
-    \case
-        AccountAddress _ (AccountId (KeyHashObj kh)) ->
-            Just (keyHashBytes kh)
-        AccountAddress _ (AccountId (ScriptHashObj _)) ->
-            Nothing
-
-voterKeyHashBytes :: Voter -> Maybe BS.ByteString
-voterKeyHashBytes =
-    \case
-        CommitteeVoter credential ->
-            credentialKeyHashBytes credential
-        DRepVoter credential ->
-            credentialKeyHashBytes credential
-        StakePoolVoter kh ->
-            Just (keyHashBytes kh)
-
-credentialKeyHashBytes :: Credential kd -> Maybe BS.ByteString
-credentialKeyHashBytes =
-    \case
-        KeyHashObj kh ->
-            Just (keyHashBytes kh)
-        ScriptHashObj _ ->
-            Nothing
-
-keyHashBytes :: KeyHash kd -> BS.ByteString
-keyHashBytes (KeyHash h) =
-    originalBytes h
 
 certRefund ::
     ConwayTxCert ConwayEra ->

--- a/lib-tx-build/Cardano/Node/Client/Balance.hs
+++ b/lib-tx-build/Cardano/Node/Client/Balance.hs
@@ -53,7 +53,6 @@ import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Sequence.Strict (StrictSeq, (|>))
 import Data.Set qualified as Set
-import Data.Word (Word32)
 import Lens.Micro ((&), (.~), (^.))
 
 import Cardano.Ledger.Address (
@@ -143,6 +142,7 @@ import Cardano.Ledger.Mary.Value (
 import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
 import Cardano.Ledger.Plutus.Language (Language)
 import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Node.Client.Inputs (spendingIndex)
 import Cardano.Node.Client.Ledger (ConwayTx)
 
 {- | Result of 'balanceTx'. Carries the balanced
@@ -811,30 +811,6 @@ computeScriptIntegrity lang pp rdmrs =
                 SJust $
                     hashScriptIntegrity $
                         ScriptIntegrity rdmrs emptyDats langViews
-
-{- | Compute the spending index of a 'TxIn' within
-the sorted input set.
-
-Plutus spending redeemers reference inputs by their
-position in the sorted set of all transaction
-inputs. This function finds that position.
-
-@
-let allInputs = Set.fromList [stateIn, reqIn, feeIn]
-    stateIx = spendingIndex stateIn allInputs
-    -- redeemer: ConwaySpending (AsIx stateIx)
-@
--}
-spendingIndex :: TxIn -> Set.Set TxIn -> Word32
-spendingIndex needle inputs =
-    let sorted = Set.toAscList inputs
-     in go 0 sorted
-  where
-    go _ [] =
-        error "spendingIndex: TxIn not in set"
-    go n (x : xs)
-        | x == needle = n
-        | otherwise = go (n + 1) xs
 
 {- | Zero execution units, used as placeholder when
 building a transaction before script evaluation.

--- a/lib-tx-build/Cardano/Node/Client/Balance.hs
+++ b/lib-tx-build/Cardano/Node/Client/Balance.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE LambdaCase #-}
 
 {- |
 Module      : Cardano.Node.Client.Balance
@@ -47,7 +46,6 @@ module Cardano.Node.Client.Balance (
     FeeLoopError (..),
 ) where
 
-import Data.Foldable (toList)
 import Data.Maybe (fromMaybe)
 import Data.Sequence.Strict (StrictSeq, (|>))
 import Data.Set qualified as Set
@@ -68,15 +66,12 @@ import Cardano.Ledger.Api.Tx (
     witsTxL,
  )
 import Cardano.Ledger.Api.Tx.Body (
-    TxBody,
-    certsTxBodyL,
     collateralInputsTxBodyL,
     collateralReturnTxBodyL,
     feeTxBodyL,
     inputsTxBodyL,
     mintTxBodyL,
     outputsTxBodyL,
-    proposalProceduresTxBodyL,
     referenceInputsTxBodyL,
     totalCollateralTxBodyL,
  )
@@ -95,18 +90,7 @@ import Cardano.Ledger.BaseTypes (
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Conway.Governance (
-    ProposalProcedure (..),
- )
-import Cardano.Ledger.Conway.TxCert (
-    ConwayDelegCert (..),
-    ConwayGovCert (..),
-    ConwayTxCert (..),
- )
-import Cardano.Ledger.Core (
-    PParams,
-    getTotalDepositsTxCerts,
- )
+import Cardano.Ledger.Core (PParams)
 import Cardano.Ledger.Mary.Value (
     MaryValue (..),
     MultiAsset (..),
@@ -114,6 +98,7 @@ import Cardano.Ledger.Mary.Value (
     mapMaybeMultiAsset,
  )
 import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Node.Client.Deposits (bodyDepositDelta)
 import Cardano.Node.Client.Inputs (spendingIndex)
 import Cardano.Node.Client.Ledger (ConwayTx)
 import Cardano.Node.Client.Scripts (
@@ -491,51 +476,6 @@ balanceTxWith
                                         result
                                         (length origOutputs)
                                     )
-
-bodyDepositDelta ::
-    PParams ConwayEra ->
-    TxBody l ConwayEra ->
-    Integer
-bodyDepositDelta pp body =
-    coinInteger
-        ( getTotalDepositsTxCerts
-            pp
-            (const False)
-            (body ^. certsTxBodyL)
-        )
-        - sum (certRefund <$> toList (body ^. certsTxBodyL))
-        + sum
-            ( proposalDeposit
-                <$> toList (body ^. proposalProceduresTxBodyL)
-            )
-
-certRefund ::
-    ConwayTxCert ConwayEra ->
-    Integer
-certRefund =
-    \case
-        ConwayTxCertDeleg (ConwayUnRegCert _ refund) ->
-            strictMaybeCoin refund
-        ConwayTxCertGov (ConwayUnRegDRep _ refund) ->
-            coinInteger refund
-        _ ->
-            0
-
-proposalDeposit :: ProposalProcedure ConwayEra -> Integer
-proposalDeposit (ProposalProcedure deposit _ _ _) =
-    coinInteger deposit
-
-strictMaybeCoin :: StrictMaybe Coin -> Integer
-strictMaybeCoin =
-    \case
-        SJust coin ->
-            coinInteger coin
-        SNothing ->
-            0
-
-coinInteger :: Coin -> Integer
-coinInteger (Coin value) =
-    value
 
 {- | Output function rejected the fee, or the
 iteration did not converge.

--- a/lib-tx-build/Cardano/Node/Client/Balance.hs
+++ b/lib-tx-build/Cardano/Node/Client/Balance.hs
@@ -62,18 +62,10 @@ import Cardano.Ledger.Address (
     Withdrawals (..),
  )
 import Cardano.Ledger.Alonzo.PParams (
-    LangDepView,
-    getLanguageView,
     ppCollateralPercentageL,
- )
-import Cardano.Ledger.Alonzo.Tx (
-    ScriptIntegrity (..),
-    ScriptIntegrityHash,
-    hashScriptIntegrity,
  )
 import Cardano.Ledger.Alonzo.TxWits (
     Redeemers (..),
-    TxDats (..),
  )
 import Cardano.Ledger.Api.Tx (
     bodyTxL,
@@ -102,7 +94,6 @@ import Cardano.Ledger.Api.Tx.Out (
     coinTxOutL,
     getMinCoinTxOut,
     mkBasicTxOut,
-    referenceScriptTxOutL,
     valueTxOutL,
  )
 import Cardano.Ledger.Api.Tx.Wits (
@@ -139,11 +130,15 @@ import Cardano.Ledger.Mary.Value (
     filterMultiAsset,
     mapMaybeMultiAsset,
  )
-import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
-import Cardano.Ledger.Plutus.Language (Language)
 import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Node.Client.Inputs (spendingIndex)
 import Cardano.Node.Client.Ledger (ConwayTx)
+import Cardano.Node.Client.Scripts (
+    computeScriptIntegrity,
+    evalBudgetExUnits,
+    placeholderExUnits,
+    refScriptsSize,
+ )
 
 {- | Result of 'balanceTx'. Carries the balanced
 transaction and the index of the change output
@@ -745,96 +740,3 @@ balanceFeeLoop pp mkOutputs numWitnesses refUtxos tx =
                      in if newFee <= currentFee
                             then Right candidate
                             else go (n + 1) newFee
-
-{- | Sum the byte lengths of any reference scripts
-attached to UTxOs whose 'TxIn' is in the body's
-@referenceInputsTxBodyL@ set. Used to feed
-@estimateMinFeeTx@ so the Conway
-@minFeeRefScriptCostPerByte@ tier is correctly
-charged.
-
-Native (timelock) scripts are included in the sum;
-the Conway ledger only charges Plutus scripts, so
-including timelock bytes can over-estimate slightly,
-which is safe — over-paying fee is accepted by the
-ledger; under-paying is rejected with
-@FeeTooSmallUTxO@.
--}
-refScriptsSize ::
-    Set.Set TxIn ->
-    [(TxIn, TxOut ConwayEra)] ->
-    Int
-refScriptsSize bodyRefIns =
-    foldr
-        ( \(i, o) acc ->
-            if Set.member i bodyRefIns
-                then case o ^. referenceScriptTxOutL of
-                    SJust s -> acc + BS.length (originalBytes s)
-                    SNothing -> acc
-                else acc
-        )
-        0
-
--- -----------------------------------------------------------
--- Script helpers
--- -----------------------------------------------------------
-
-{- | Compute the 'ScriptIntegrityHash' from protocol
-parameters, a set of 'Redeemers', and the Plutus
-language used.
-
-The hash covers the language cost model, redeemers,
-and an empty datum set (inline datums only — no
-datum map needed).
-
-@
-integrity <- computeScriptIntegrity PlutusV3 pp redeemers
-body & scriptIntegrityHashTxBodyL .~ integrity
-@
--}
-computeScriptIntegrity ::
-    Language ->
-    PParams ConwayEra ->
-    Redeemers ConwayEra ->
-    StrictMaybe ScriptIntegrityHash
-computeScriptIntegrity lang pp rdmrs =
-    let langViews :: Set.Set LangDepView
-        langViews =
-            Set.singleton
-                (getLanguageView pp lang)
-        emptyDats :: TxDats ConwayEra
-        emptyDats = TxDats mempty
-        Redeemers redeemerMap = rdmrs
-     in if null redeemerMap && null langViews
-            then SNothing
-            else
-                SJust $
-                    hashScriptIntegrity $
-                        ScriptIntegrity rdmrs emptyDats langViews
-
-{- | Zero execution units, used as placeholder when
-building a transaction before script evaluation.
-After calling 'evaluateTx', patch the redeemers
-with the real values.
--}
-placeholderExUnits :: ExUnits
-placeholderExUnits = ExUnits 0 0
-
-{- | Max-budget execution units for script
-evaluation. The ledger evaluator uses redeemer
-ExUnits as the execution budget; scripts that
-exceed the budget are terminated. This value is
-injected before 'evaluateTx' so scripts get
-enough room to run, then replaced by the real
-ExUnits from the evaluation result.
-
-Sized to mainnet's Conway-era @maxTxExUnits@
-(epoch 627+: 16_500_000 mem, 10_000_000_000
-steps), so heavy scripts that already run on
-mainnet — e.g. asteria's @add_new_ship@ — fit
-under the eval budget locally too. Submission
-fails the same way as it would on mainnet if a
-script's actual usage exceeds the cluster's pp.
--}
-evalBudgetExUnits :: ExUnits
-evalBudgetExUnits = ExUnits 16_500_000 10_000_000_000

--- a/lib-tx-build/Cardano/Node/Client/Credentials.hs
+++ b/lib-tx-build/Cardano/Node/Client/Credentials.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE LambdaCase #-}
+
+{- |
+Module      : Cardano.Node.Client.Credentials
+Description : Credential key-hash extraction helpers
+License     : Apache-2.0
+
+Helpers for reducing ledger credentials, addresses,
+and governance voters to the key-hash bytes that
+identify required key witnesses.
+-}
+module Cardano.Node.Client.Credentials (
+    accountKeyHashBytes,
+    addrPaymentKeyHashBytes,
+    credentialKeyHashBytes,
+    keyHashBytes,
+    voterKeyHashBytes,
+) where
+
+import Data.ByteString qualified as BS
+
+import Cardano.Ledger.Address (
+    AccountAddress (..),
+    AccountId (..),
+    Addr (..),
+ )
+import Cardano.Ledger.Conway.Governance (Voter (..))
+import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.Hashes (originalBytes)
+import Cardano.Ledger.Keys (KeyHash (..))
+
+addrPaymentKeyHashBytes :: Addr -> Maybe BS.ByteString
+addrPaymentKeyHashBytes =
+    \case
+        Addr _ (KeyHashObj kh) _ ->
+            Just (keyHashBytes kh)
+        Addr _ (ScriptHashObj _) _ ->
+            Nothing
+        AddrBootstrap _ ->
+            Nothing
+
+accountKeyHashBytes :: AccountAddress -> Maybe BS.ByteString
+accountKeyHashBytes =
+    \case
+        AccountAddress _ (AccountId (KeyHashObj kh)) ->
+            Just (keyHashBytes kh)
+        AccountAddress _ (AccountId (ScriptHashObj _)) ->
+            Nothing
+
+voterKeyHashBytes :: Voter -> Maybe BS.ByteString
+voterKeyHashBytes =
+    \case
+        CommitteeVoter credential ->
+            credentialKeyHashBytes credential
+        DRepVoter credential ->
+            credentialKeyHashBytes credential
+        StakePoolVoter kh ->
+            Just (keyHashBytes kh)
+
+credentialKeyHashBytes :: Credential kd -> Maybe BS.ByteString
+credentialKeyHashBytes =
+    \case
+        KeyHashObj kh ->
+            Just (keyHashBytes kh)
+        ScriptHashObj _ ->
+            Nothing
+
+keyHashBytes :: KeyHash kd -> BS.ByteString
+keyHashBytes (KeyHash h) =
+    originalBytes h

--- a/lib-tx-build/Cardano/Node/Client/Deposits.hs
+++ b/lib-tx-build/Cardano/Node/Client/Deposits.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE LambdaCase #-}
+
+{- |
+Module      : Cardano.Node.Client.Deposits
+Description : Transaction deposit accounting
+License     : Apache-2.0
+
+Helpers for deriving the ADA deposit/refund delta
+introduced by transaction body fields.
+-}
+module Cardano.Node.Client.Deposits (
+    bodyDepositDelta,
+) where
+
+import Data.Foldable (toList)
+import Lens.Micro ((^.))
+
+import Cardano.Ledger.Api.Tx.Body (
+    TxBody,
+    certsTxBodyL,
+    proposalProceduresTxBodyL,
+ )
+import Cardano.Ledger.BaseTypes (
+    StrictMaybe (SJust, SNothing),
+ )
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway.Governance (
+    ProposalProcedure (..),
+ )
+import Cardano.Ledger.Conway.TxCert (
+    ConwayDelegCert (..),
+    ConwayGovCert (..),
+    ConwayTxCert (..),
+ )
+import Cardano.Ledger.Core (
+    PParams,
+    getTotalDepositsTxCerts,
+ )
+
+bodyDepositDelta ::
+    PParams ConwayEra ->
+    TxBody l ConwayEra ->
+    Integer
+bodyDepositDelta pp body =
+    coinInteger
+        ( getTotalDepositsTxCerts
+            pp
+            (const False)
+            (body ^. certsTxBodyL)
+        )
+        - sum (certRefund <$> toList (body ^. certsTxBodyL))
+        + sum
+            ( proposalDeposit
+                <$> toList (body ^. proposalProceduresTxBodyL)
+            )
+
+certRefund ::
+    ConwayTxCert ConwayEra ->
+    Integer
+certRefund =
+    \case
+        ConwayTxCertDeleg (ConwayUnRegCert _ refund) ->
+            strictMaybeCoin refund
+        ConwayTxCertGov (ConwayUnRegDRep _ refund) ->
+            coinInteger refund
+        _ ->
+            0
+
+proposalDeposit :: ProposalProcedure ConwayEra -> Integer
+proposalDeposit (ProposalProcedure deposit _ _ _) =
+    coinInteger deposit
+
+strictMaybeCoin :: StrictMaybe Coin -> Integer
+strictMaybeCoin =
+    \case
+        SJust coin ->
+            coinInteger coin
+        SNothing ->
+            0
+
+coinInteger :: Coin -> Integer
+coinInteger (Coin value) =
+    value

--- a/lib-tx-build/Cardano/Node/Client/Inputs.hs
+++ b/lib-tx-build/Cardano/Node/Client/Inputs.hs
@@ -1,0 +1,32 @@
+{- |
+Module      : Cardano.Node.Client.Inputs
+Description : Transaction input indexing helpers
+License     : Apache-2.0
+
+Helpers for concepts tied to transaction inputs.
+-}
+module Cardano.Node.Client.Inputs (
+    spendingIndex,
+) where
+
+import Data.Set qualified as Set
+import Data.Word (Word32)
+
+import Cardano.Ledger.TxIn (TxIn)
+
+{- | Compute the spending index of a 'TxIn' within
+the sorted input set.
+
+Plutus spending redeemers reference inputs by their
+position in the sorted set of all transaction
+inputs.
+-}
+spendingIndex :: TxIn -> Set.Set TxIn -> Word32
+spendingIndex needle inputs =
+    go 0 (Set.toAscList inputs)
+  where
+    go _ [] =
+        error "spendingIndex: TxIn not in set"
+    go n (x : xs)
+        | x == needle = n
+        | otherwise = go (n + 1) xs

--- a/lib-tx-build/Cardano/Node/Client/Scripts.hs
+++ b/lib-tx-build/Cardano/Node/Client/Scripts.hs
@@ -1,0 +1,129 @@
+{- |
+Module      : Cardano.Node.Client.Scripts
+Description : Script fee and integrity helpers
+License     : Apache-2.0
+
+Helpers for script-related transaction body concepts
+used by builders and balancers.
+-}
+module Cardano.Node.Client.Scripts (
+    computeScriptIntegrity,
+    evalBudgetExUnits,
+    placeholderExUnits,
+    refScriptsSize,
+) where
+
+import Data.ByteString qualified as BS
+import Data.Set qualified as Set
+import Lens.Micro ((^.))
+
+import Cardano.Ledger.Alonzo.PParams (
+    LangDepView,
+    getLanguageView,
+ )
+import Cardano.Ledger.Alonzo.Tx (
+    ScriptIntegrity (..),
+    ScriptIntegrityHash,
+    hashScriptIntegrity,
+ )
+import Cardano.Ledger.Alonzo.TxWits (
+    Redeemers (..),
+    TxDats (..),
+ )
+import Cardano.Ledger.Api.Tx.Out (
+    TxOut,
+    referenceScriptTxOutL,
+ )
+import Cardano.Ledger.BaseTypes (
+    StrictMaybe (SJust, SNothing),
+ )
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core (PParams)
+import Cardano.Ledger.Hashes (originalBytes)
+import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
+import Cardano.Ledger.Plutus.Language (Language)
+import Cardano.Ledger.TxIn (TxIn)
+
+{- | Sum the byte lengths of any reference scripts
+attached to UTxOs whose 'TxIn' is in the body's
+@referenceInputsTxBodyL@ set. Used to feed
+@estimateMinFeeTx@ so the Conway
+@minFeeRefScriptCostPerByte@ tier is correctly
+charged.
+
+Native (timelock) scripts are included in the sum;
+the Conway ledger only charges Plutus scripts, so
+including timelock bytes can over-estimate slightly,
+which is safe: over-paying fee is accepted by the
+ledger; under-paying is rejected with
+@FeeTooSmallUTxO@.
+-}
+refScriptsSize ::
+    Set.Set TxIn ->
+    [(TxIn, TxOut ConwayEra)] ->
+    Int
+refScriptsSize bodyRefIns =
+    foldr
+        ( \(i, o) acc ->
+            if Set.member i bodyRefIns
+                then case o ^. referenceScriptTxOutL of
+                    SJust s -> acc + BS.length (originalBytes s)
+                    SNothing -> acc
+                else acc
+        )
+        0
+
+{- | Compute the 'ScriptIntegrityHash' from protocol
+parameters, a set of 'Redeemers', and the Plutus
+language used.
+
+The hash covers the language cost model, redeemers,
+and an empty datum set (inline datums only, no datum
+map needed).
+-}
+computeScriptIntegrity ::
+    Language ->
+    PParams ConwayEra ->
+    Redeemers ConwayEra ->
+    StrictMaybe ScriptIntegrityHash
+computeScriptIntegrity lang pp rdmrs =
+    let langViews :: Set.Set LangDepView
+        langViews =
+            Set.singleton
+                (getLanguageView pp lang)
+        emptyDats :: TxDats ConwayEra
+        emptyDats = TxDats mempty
+        Redeemers redeemerMap = rdmrs
+     in if null redeemerMap && null langViews
+            then SNothing
+            else
+                SJust $
+                    hashScriptIntegrity $
+                        ScriptIntegrity rdmrs emptyDats langViews
+
+{- | Zero execution units, used as placeholder when
+building a transaction before script evaluation.
+After calling @evaluateTx@, patch the redeemers
+with the real values.
+-}
+placeholderExUnits :: ExUnits
+placeholderExUnits = ExUnits 0 0
+
+{- | Max-budget execution units for script
+evaluation. The ledger evaluator uses redeemer
+ExUnits as the execution budget; scripts that
+exceed the budget are terminated. This value is
+injected before @evaluateTx@ so scripts get enough
+room to run, then replaced by the real ExUnits from
+the evaluation result.
+
+Sized to mainnet's Conway-era @maxTxExUnits@
+(epoch 627+: 16_500_000 mem, 10_000_000_000
+steps), so heavy scripts that already run on
+mainnet fit under the eval budget locally too.
+Submission fails the same way as it would on
+mainnet if a script's actual usage exceeds the
+cluster's pp.
+-}
+evalBudgetExUnits :: ExUnits
+evalBudgetExUnits = ExUnits 16_500_000 10_000_000_000

--- a/lib-tx-build/Cardano/Node/Client/TxBuild.hs
+++ b/lib-tx-build/Cardano/Node/Client/TxBuild.hs
@@ -66,6 +66,9 @@ module Cardano.Node.Client.TxBuild (
     propose,
     proposeTreasuryWithdrawal,
 
+    -- * Votes
+    vote,
+
     -- * Constraints
     validFrom,
     validTo,
@@ -107,10 +110,16 @@ module Cardano.Node.Client.TxBuild (
     Delegatee (..),
     DRep (..),
     GovAction (..),
+    GovActionId (..),
+    GovActionIx (..),
     KeyRole (..),
     ProposalProcedure (..),
     ScriptHash (..),
     StrictMaybe (..),
+    Vote (..),
+    Voter (..),
+    VotingProcedure (..),
+    VotingProcedures (..),
 
     -- * Internal (for testing)
     interpretWith,
@@ -180,6 +189,7 @@ import Cardano.Ledger.Api.Tx.Body (
     referenceInputsTxBodyL,
     reqSignerHashesTxBodyL,
     vldtTxBodyL,
+    votingProceduresTxBodyL,
     withdrawalsTxBodyL,
  )
 import Cardano.Ledger.Api.Tx.Out (
@@ -202,7 +212,13 @@ import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance (
     Anchor (..),
     GovAction (..),
+    GovActionId (..),
+    GovActionIx (..),
     ProposalProcedure (..),
+    Vote (..),
+    Voter (..),
+    VotingProcedure (..),
+    VotingProcedures (..),
  )
 import Cardano.Ledger.Conway.Scripts (
     ConwayPlutusPurpose (..),
@@ -371,6 +387,12 @@ data TxInstr q e a where
     Propose ::
         ProposalProcedure ConwayEra ->
         ProposalWitness ->
+        TxInstr q e ()
+    -- | Add a Conway voting procedure.
+    VoteI ::
+        Voter ->
+        GovActionId ->
+        VotingProcedure ConwayEra ->
         TxInstr q e ()
     -- | Set transaction metadata for a label.
     SetMetadata ::
@@ -604,6 +626,20 @@ proposeTreasuryWithdrawal
                 (TreasuryWithdrawals withdrawals guardrail)
                 anchor
 
+-- | Vote on a Conway governance action.
+vote ::
+    Voter ->
+    GovActionId ->
+    Vote ->
+    StrictMaybe Anchor ->
+    TxBuild q e ()
+vote voter actionId voteChoice anchor =
+    singleton $
+        VoteI
+            voter
+            actionId
+            (VotingProcedure voteChoice anchor)
+
 -- | Set transaction metadata for a label.
 setMetadata :: Word64 -> Metadatum -> TxBuild q e ()
 setMetadata label = singleton . SetMetadata label
@@ -719,6 +755,8 @@ data TxState e = TxState
         [(ConwayTxCert ConwayEra, CertWitness)]
     , tsProposals ::
         [(ProposalProcedure ConwayEra, ProposalWitness)]
+    , tsVotes ::
+        [(Voter, GovActionId, VotingProcedure ConwayEra)]
     , tsMetadata :: Map Word64 Metadatum
     , tsSigners :: Set (KeyHash Guard)
     , tsScripts ::
@@ -740,6 +778,7 @@ emptyState =
         , tsWithdrawals = []
         , tsCerts = []
         , tsProposals = []
+        , tsVotes = []
         , tsMetadata = Map.empty
         , tsSigners = Set.empty
         , tsScripts = Map.empty
@@ -838,6 +877,15 @@ interpretWithM runCtx currentTx = go emptyState True
                 st
                     { tsProposals =
                         tsProposals st ++ [(proposal, w)]
+                    }
+                conv
+                (k ())
+        VoteI voter actionId procedure :>>= k ->
+            go
+                st
+                    { tsVotes =
+                        tsVotes st
+                            ++ [(voter, actionId, procedure)]
                     }
                 conv
                 (k ())
@@ -941,6 +989,15 @@ assembleTxWith extraIns pp st =
         proposals =
             OSet.fromList $
                 map fst (tsProposals st)
+        votes =
+            VotingProcedures $
+                Map.fromListWith
+                    Map.union
+                    [ ( voter
+                      , Map.singleton actionId procedure
+                      )
+                    | (voter, actionId, procedure) <- tsVotes st
+                    ]
         -- Build redeemers
         spendRdmrs =
             collectSpendRedeemers
@@ -993,6 +1050,7 @@ assembleTxWith extraIns pp st =
                 & withdrawalsTxBodyL .~ withdrawals
                 & certsTxBodyL .~ certs
                 & proposalProceduresTxBodyL .~ proposals
+                & votingProceduresTxBodyL .~ votes
                 & reqSignerHashesTxBodyL
                     .~ tsSigners st
                 & vldtTxBodyL

--- a/lib-tx-build/Cardano/Node/Client/TxBuild.hs
+++ b/lib-tx-build/Cardano/Node/Client/TxBuild.hs
@@ -262,12 +262,14 @@ import Cardano.Node.Client.Balance (
     BalanceResult (..),
     CollateralUtxos (..),
     balanceTxWith,
+ )
+import Cardano.Node.Client.Inputs (spendingIndex)
+import Cardano.Node.Client.Ledger (ConwayTx)
+import Cardano.Node.Client.Scripts (
     computeScriptIntegrity,
     evalBudgetExUnits,
     refScriptsSize,
  )
-import Cardano.Node.Client.Inputs (spendingIndex)
-import Cardano.Node.Client.Ledger (ConwayTx)
 import Cardano.Slotting.Slot (SlotNo)
 import Lens.Micro ((&), (.~), (^.))
 import PlutusCore.Data qualified as PLC

--- a/lib-tx-build/Cardano/Node/Client/TxBuild.hs
+++ b/lib-tx-build/Cardano/Node/Client/TxBuild.hs
@@ -266,6 +266,7 @@ import Cardano.Node.Client.Balance (
     evalBudgetExUnits,
     refScriptsSize,
  )
+import Cardano.Node.Client.Inputs (spendingIndex)
 import Cardano.Node.Client.Ledger (ConwayTx)
 import Cardano.Slotting.Slot (SlotNo)
 import Lens.Micro ((&), (.~), (^.))
@@ -1838,19 +1839,6 @@ bumpFee chIdx tx targetFee =
 -- ----------------------------------------------------
 -- Internal helpers
 -- ----------------------------------------------------
-
-{- | Compute the spending index of a 'TxIn' in the
-sorted input set.
--}
-spendingIndex :: TxIn -> Set TxIn -> Word32
-spendingIndex needle inputs =
-    go 0 (Set.toAscList inputs)
-  where
-    go _ [] =
-        error "spendingIndex: TxIn not in set"
-    go n (x : xs)
-        | x == needle = n
-        | otherwise = go (n + 1) xs
 
 withdrawalIndex ::
     AccountAddress ->

--- a/lib-tx-build/Cardano/Node/Client/Witnesses.hs
+++ b/lib-tx-build/Cardano/Node/Client/Witnesses.hs
@@ -1,0 +1,92 @@
+{- |
+Module      : Cardano.Node.Client.Witnesses
+Description : Witness counting helpers
+License     : Apache-2.0
+
+Helpers for deriving witness counts from transaction
+body fields and resolved UTxOs.
+-}
+module Cardano.Node.Client.Witnesses (
+    estimatedKeyWitnessCount,
+) where
+
+import Data.Foldable (toList)
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Lens.Micro ((^.))
+
+import Cardano.Ledger.Address (Withdrawals (..))
+import Cardano.Ledger.Api.Tx.Body (
+    TxBody,
+    certsTxBodyL,
+    reqSignerHashesTxBodyL,
+    votingProceduresTxBodyL,
+    withdrawalsTxBodyL,
+ )
+import Cardano.Ledger.Api.Tx.Out (
+    TxOut,
+    addrTxOutL,
+ )
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway.Governance (
+    VotingProcedures (..),
+ )
+import Cardano.Ledger.Conway.TxCert (
+    getVKeyWitnessConwayTxCert,
+ )
+import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Node.Client.Credentials (
+    accountKeyHashBytes,
+    addrPaymentKeyHashBytes,
+    keyHashBytes,
+    voterKeyHashBytes,
+ )
+
+estimatedKeyWitnessCount ::
+    TxBody l ConwayEra ->
+    Set.Set TxIn ->
+    [(TxIn, TxOut ConwayEra)] ->
+    Int
+estimatedKeyWitnessCount body bodyInputs inputUtxos =
+    max 1 $
+        Set.size $
+            inputWitnesses
+                <> certWitnesses
+                <> requiredSignerWitnesses
+                <> votingWitnesses
+                <> withdrawalWitnesses
+  where
+    inputWitnesses =
+        Set.fromList
+            [ kh
+            | (txIn, txOut) <- inputUtxos
+            , Set.member txIn bodyInputs
+            , Just kh <- [addrPaymentKeyHashBytes (txOut ^. addrTxOutL)]
+            ]
+    certWitnesses =
+        Set.fromList
+            [ keyHashBytes kh
+            | cert <- toList (body ^. certsTxBodyL)
+            , Just kh <- [getVKeyWitnessConwayTxCert cert]
+            ]
+    requiredSignerWitnesses =
+        Set.fromList
+            [ keyHashBytes kh
+            | kh <- Set.toList (body ^. reqSignerHashesTxBodyL)
+            ]
+    votingWitnesses =
+        let VotingProcedures procedures =
+                body ^. votingProceduresTxBodyL
+         in Set.fromList
+                [ bytes
+                | voter <- Map.keys procedures
+                , Just bytes <- [voterKeyHashBytes voter]
+                ]
+    withdrawalWitnesses =
+        let Withdrawals withdrawals =
+                body ^. withdrawalsTxBodyL
+         in Set.fromList
+                [ kh
+                | account <- Map.keys withdrawals
+                , Just kh <- [accountKeyHashBytes account]
+                ]

--- a/lib/Cardano/Node/Client/Address.hs
+++ b/lib/Cardano/Node/Client/Address.hs
@@ -1,0 +1,68 @@
+{- |
+Module      : Cardano.Node.Client.Address
+Description : Typed address and credential helpers
+License     : Apache-2.0
+
+Small helpers for working with ledger address types without shelling
+out to @cardano-cli address info@.
+-}
+module Cardano.Node.Client.Address (
+    paymentCredentialFromAddr,
+    stakeCredentialFromAddr,
+    rewardAccountFromCredential,
+    rewardAccountCredential,
+    keyCredential,
+    scriptCredential,
+) where
+
+import Cardano.Ledger.Address (
+    AccountAddress (..),
+    AccountId (..),
+    Addr (..),
+ )
+import Cardano.Ledger.BaseTypes (Network)
+import Cardano.Ledger.Credential (
+    Credential (..),
+    StakeReference (..),
+ )
+import Cardano.Ledger.Hashes (ScriptHash)
+import Cardano.Ledger.Keys (KeyHash, KeyRole (Payment, Staking))
+
+-- | Extract the payment credential from a Shelley-style address.
+paymentCredentialFromAddr :: Addr -> Maybe (Credential Payment)
+paymentCredentialFromAddr (Addr _network credential _stakeRef) =
+    Just credential
+paymentCredentialFromAddr (AddrBootstrap _) =
+    Nothing
+
+-- | Extract a base stake credential when an address carries one.
+stakeCredentialFromAddr :: Addr -> Maybe (Credential Staking)
+stakeCredentialFromAddr (Addr _network _payment (StakeRefBase credential)) =
+    Just credential
+stakeCredentialFromAddr _ =
+    Nothing
+
+-- | Build a reward account from a network and stake credential.
+rewardAccountFromCredential ::
+    Network ->
+    Credential Staking ->
+    AccountAddress
+rewardAccountFromCredential network credential =
+    AccountAddress
+        network
+        (AccountId credential)
+
+-- | Extract the stake credential carried by a reward account.
+rewardAccountCredential :: AccountAddress -> Credential Staking
+rewardAccountCredential (AccountAddress _network (AccountId credential)) =
+    credential
+
+-- | Build a credential from a key hash.
+keyCredential :: KeyHash kr -> Credential kr
+keyCredential =
+    KeyHashObj
+
+-- | Build a credential from a script hash.
+scriptCredential :: ScriptHash -> Credential kr
+scriptCredential =
+    ScriptHashObj

--- a/lib/Cardano/Node/Client/N2C/Codecs.hs
+++ b/lib/Cardano/Node/Client/N2C/Codecs.hs
@@ -5,7 +5,7 @@ License     : Apache-2.0
 
 Codec configuration shared between the N2C mini-protocols:
 LocalStateQuery, LocalTxSubmission, and ChainSync.
-Uses @CardanoNodeToClientVersion16@ and a configurable
+Uses @CardanoNodeToClientVersion19@ and a configurable
 'EpochSlots' value (default 42 for devnet).
 -}
 module Cardano.Node.Client.N2C.Codecs (
@@ -40,7 +40,7 @@ import Ouroboros.Consensus.Cardano.Block (
  )
 import Ouroboros.Consensus.Cardano.Block qualified as Consensus
 import Ouroboros.Consensus.Cardano.Node (
-    pattern CardanoNodeToClientVersion16,
+    pattern CardanoNodeToClientVersion19,
  )
 import Ouroboros.Consensus.HardFork.Combinator.NetworkVersion (
     HardForkNodeToClientVersion,
@@ -89,7 +89,7 @@ n2cVersion ::
             : Consensus.CardanoShelleyEras
                 Consensus.StandardCrypto
         )
-n2cVersion = CardanoNodeToClientVersion16
+n2cVersion = CardanoNodeToClientVersion19
 
 -- | N2C ChainSync protocol type (block-level).
 type N2CChainSync =

--- a/lib/Cardano/Node/Client/N2C/Connection.hs
+++ b/lib/Cardano/Node/Client/N2C/Connection.hs
@@ -153,7 +153,7 @@ runNodeClient magic socketPath lsqCh ltxsCh =
             (localSnocket ioManager)
             nullNetworkConnectTracers
             ( simpleSingletonVersions
-                NodeToClientV_20
+                NodeToClientV_23
                 NodeToClientVersionData
                     { networkMagic = magic
                     , query = False
@@ -226,7 +226,7 @@ mkN2CApp lsqCh ltxsCh =
             (decodeNodeToClient @Block ccfg n2cVersion)
     lsqCodec =
         codecLocalStateQuery
-            NodeToClientV_20
+            NodeToClientV_23
             (encodePoint (encodeRawHash (Proxy @Block)))
             (decodePoint (decodeRawHash (Proxy @Block)))
             ( queryEncodeNodeToClient
@@ -245,7 +245,7 @@ mkN2CApp lsqCh ltxsCh =
             (decodeResult ccfg n2cVersion)
     qv =
         nodeToClientVersionToQueryVersion
-            NodeToClientV_20
+            NodeToClientV_23
 
 {- | Connect to a Cardano node via Unix socket and run
 ChainSync + LocalStateQuery + LocalTxSubmission clients
@@ -290,7 +290,7 @@ runNodeClientFull magic epochSlots socketPath chainSyncApp lsqCh ltxsCh =
             (localSnocket ioManager)
             nullNetworkConnectTracers
             ( simpleSingletonVersions
-                NodeToClientV_20
+                NodeToClientV_23
                 NodeToClientVersionData
                     { networkMagic = magic
                     , query = False
@@ -303,7 +303,7 @@ runNodeClientFull magic epochSlots socketPath chainSyncApp lsqCh ltxsCh =
 {- | Build the N2C application with ChainSync (num 5),
 LocalTxSubmission (num 6), and LocalStateQuery (num 7) on
 the same 'OuroborosApplication'. The handshake at
-'NodeToClientV_20' admits all three together.
+'NodeToClientV_23' admits all three together.
 -}
 mkN2CFullApp ::
     EpochSlots ->
@@ -383,7 +383,7 @@ mkN2CFullApp epochSlots chainSyncApp lsqCh ltxsCh =
             (decodeNodeToClient @Block ccfg n2cVersion)
     lsqCodec =
         codecLocalStateQuery
-            NodeToClientV_20
+            NodeToClientV_23
             (encodePoint (encodeRawHash (Proxy @Block)))
             (decodePoint (decodeRawHash (Proxy @Block)))
             ( queryEncodeNodeToClient
@@ -402,7 +402,7 @@ mkN2CFullApp epochSlots chainSyncApp lsqCh ltxsCh =
             (decodeResult ccfg n2cVersion)
     qv =
         nodeToClientVersionToQueryVersion
-            NodeToClientV_20
+            NodeToClientV_23
 
 {- | Create a new 'LSQChannel' with the given queue
 capacity.

--- a/lib/Cardano/Node/Client/N2C/LocalStateQuery.hs
+++ b/lib/Cardano/Node/Client/N2C/LocalStateQuery.hs
@@ -46,6 +46,8 @@ import Control.Concurrent.STM (
  )
 import Control.Exception (
     BlockedIndefinitelyOnSTM,
+    SomeException,
+    catch,
     handle,
     mask,
     onException,
@@ -64,6 +66,7 @@ import Ouroboros.Network.Protocol.LocalStateQuery.Client (
 import Ouroboros.Network.Protocol.LocalStateQuery.Type (
     Target (..),
  )
+import System.Timeout (timeout)
 
 {- | Per-session command queue capacity.
 
@@ -277,7 +280,7 @@ withAcquiredLSQ ch action =
         takeTMVarOrConnectionLost acquiredVar
         result <-
             restore (action acquired)
-                `onException` releaseAcquiredLSQ acquired
+                `onException` releaseAcquiredLSQBestEffort acquired
         releaseAcquiredLSQ acquired
         pure result
 
@@ -307,6 +310,13 @@ releaseAcquiredLSQ acquired = do
             (AcquiredLSQRelease releaseVar)
     void $
         takeTMVarOrConnectionLost releaseVar
+
+releaseAcquiredLSQBestEffort ::
+    AcquiredLSQ ->
+    IO ()
+releaseAcquiredLSQBestEffort acquired =
+    void (timeout 1000000 (releaseAcquiredLSQ acquired))
+        `catch` \(_ :: SomeException) -> pure ()
 
 takeTMVarOrConnectionLost ::
     TMVar a ->

--- a/lib/Cardano/Node/Client/N2C/Provider.hs
+++ b/lib/Cardano/Node/Client/N2C/Provider.hs
@@ -20,16 +20,25 @@ module Cardano.Node.Client.N2C.Provider (
 ) where
 
 import Data.Bifunctor (first)
+import Data.ByteString.Lazy qualified as LBS
+import Data.Coerce (coerce)
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as T
 import Data.Time.Clock (NominalDiffTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 
+import Cardano.Binary (
+    Decoder,
+    DecoderError,
+    decodeFullDecoder,
+    decodeInteger,
+    decodeListLen,
+ )
 import Control.Monad.Trans.Except (runExcept)
 import Lens.Micro ((^.))
 
-import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Address (AccountAddress, Addr)
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (
     evalTxExUnits,
  )
@@ -39,10 +48,19 @@ import Cardano.Ledger.Api.Tx.Body (
     referenceInputsTxBodyL,
  )
 import Cardano.Ledger.Api.Tx.Out (TxOut, addrTxOutL)
+import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core (PParams, bodyTxL)
-import Cardano.Ledger.State (UTxO (..))
+import Cardano.Ledger.Credential (Credential)
+import Cardano.Ledger.DRep (DRep)
+import Cardano.Ledger.Keys (KeyRole (Staking))
+import Cardano.Ledger.State (
+    ChainAccountState,
+    GovState,
+    UTxO (..),
+ )
 import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Node.Client.Address (rewardAccountCredential)
 import Cardano.Node.Client.Ledger (ConwayTx)
 import Cardano.Slotting.EpochInfo (hoistEpochInfo)
 import Cardano.Slotting.Slot qualified as Slotting
@@ -58,8 +76,12 @@ import Ouroboros.Consensus.Block.Abstract (
 import Ouroboros.Consensus.Cardano.Block (
     pattern QueryIfCurrentConway,
  )
+import Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock (
+    EraIndex,
+    eraIndexToInt,
+ )
 import Ouroboros.Consensus.HardFork.Combinator.Ledger.Query (
-    QueryHardFork (GetInterpreter),
+    QueryHardFork (GetCurrentEra, GetInterpreter),
     pattern QueryHardFork,
  )
 import Ouroboros.Consensus.HardFork.History.EpochInfo (
@@ -73,9 +95,19 @@ import Ouroboros.Consensus.Ledger.Query (
     Query (BlockQuery, GetChainPoint, GetSystemStart),
  )
 import Ouroboros.Consensus.Shelley.Ledger.Query (
+    pattern GetAccountState,
+    pattern GetCBOR,
     pattern GetCurrentPParams,
+    pattern GetEpochNo,
+    pattern GetFilteredDelegationsAndRewardAccounts,
+    pattern GetFilteredVoteDelegatees,
+    pattern GetGovState,
     pattern GetUTxOByAddress,
     pattern GetUTxOByTxIn,
+ )
+import Ouroboros.Network.Block (
+    Serialised,
+    fromSerialised,
  )
 
 import Cardano.Node.Client.N2C.LocalStateQuery (
@@ -85,6 +117,7 @@ import Cardano.Node.Client.N2C.LocalStateQuery (
 import Cardano.Node.Client.N2C.Types (LSQChannel)
 import Cardano.Node.Client.Provider (
     EvaluateTxResult,
+    LedgerSnapshot (..),
     Provider (..),
     QueryHandle,
     QueryHandleBackend (..),
@@ -93,9 +126,15 @@ import Cardano.Node.Client.Provider (
     mkQueryHandle,
     posixMsCeilSlotH,
     posixMsToSlotH,
+    queryGovernanceStateH,
+    queryLedgerSnapshotH,
     queryProtocolParamsH,
+    queryRewardAccountsH,
+    queryStakeRewardsH,
+    queryTreasuryH,
     queryUTxOByTxInH,
     queryUTxOsH,
+    queryVoteDelegateesH,
  )
 import Cardano.Node.Client.Types (Block)
 import Cardano.Node.Client.Validity qualified as Validity
@@ -112,6 +151,21 @@ mkN2CProvider ch =
         { withAcquired = withAcquiredN2C
         , queryProtocolParams =
             withAcquiredN2C queryProtocolParamsH
+        , queryLedgerSnapshot =
+            withAcquiredN2C queryLedgerSnapshotH
+        , queryStakeRewards = \credentials ->
+            withAcquiredN2C $ \handle ->
+                queryStakeRewardsH handle credentials
+        , queryRewardAccounts = \accounts ->
+            withAcquiredN2C $ \handle ->
+                queryRewardAccountsH handle accounts
+        , queryVoteDelegatees = \credentials ->
+            withAcquiredN2C $ \handle ->
+                queryVoteDelegateesH handle credentials
+        , queryTreasury =
+            withAcquiredN2C queryTreasuryH
+        , queryGovernanceState =
+            withAcquiredN2C queryGovernanceStateH
         , queryUTxOs = \addr ->
             withAcquiredN2C $ \handle ->
                 queryUTxOsH handle addr
@@ -154,6 +208,18 @@ mkN2CQueryHandle runQuery =
             , backendQueryUTxOsAt = queryUTxOsAtN2C runQuery
             , backendQueryUTxOByTxIn = queryUTxOByTxInN2C runQuery
             , backendQueryProtocolParams = queryProtocolParamsN2C runQuery
+            , backendQueryLedgerSnapshot =
+                queryLedgerSnapshotN2C runQuery
+            , backendQueryStakeRewards =
+                queryStakeRewardsN2C runQuery
+            , backendQueryRewardAccounts =
+                queryRewardAccountsN2C runQuery
+            , backendQueryVoteDelegatees =
+                queryVoteDelegateesN2C runQuery
+            , backendQueryTreasury =
+                queryTreasuryN2C runQuery
+            , backendQueryGovernanceState =
+                queryGovernanceStateN2C runQuery
             , backendEvaluateTx = evaluateTxN2C runQuery
             , backendPosixMsToSlot = posixMsToSlotN2C runQuery
             , backendPosixMsCeilSlot = posixMsCeilSlotN2C runQuery
@@ -164,6 +230,19 @@ mkN2CQueryHandle runQuery =
             <$> queryUTxOsAtN2C
                 runQuery
                 (Set.singleton addr)
+
+eraIndexName :: EraIndex xs -> T.Text
+eraIndexName eraIndex =
+    case eraIndexToInt eraIndex of
+        0 -> "Byron"
+        1 -> "Shelley"
+        2 -> "Allegra"
+        3 -> "Mary"
+        4 -> "Alonzo"
+        5 -> "Babbage"
+        6 -> "Conway"
+        7 -> "Dijkstra"
+        n -> "Unknown era index " <> T.pack (show n)
 
 queryProtocolParamsN2C ::
     (forall result. Query Block result -> IO result) ->
@@ -180,6 +259,165 @@ queryProtocolParamsN2C runQuery = do
             error
                 "queryProtocolParams: era \
                 \mismatch — node not in Conway"
+
+queryLedgerSnapshotN2C ::
+    (forall result. Query Block result -> IO result) ->
+    IO LedgerSnapshot
+queryLedgerSnapshotN2C runQuery = do
+    currentEra <-
+        runQuery $
+            BlockQuery $
+                QueryHardFork GetCurrentEra
+    chainPoint <-
+        runQuery GetChainPoint
+    epochResult <-
+        runQuery $
+            BlockQuery $
+                QueryIfCurrentConway
+                    GetEpochNo
+    epoch <-
+        expectConway
+            "queryLedgerSnapshot"
+            epochResult
+    pure
+        LedgerSnapshot
+            { ledgerCurrentEra =
+                eraIndexName currentEra
+            , ledgerChainPoint =
+                chainPoint
+            , ledgerTipSlot =
+                fromWithOrigin
+                    (Slotting.SlotNo 0)
+                    (pointSlot chainPoint)
+            , ledgerEpoch =
+                epoch
+            }
+
+queryStakeRewardsN2C ::
+    (forall result. Query Block result -> IO result) ->
+    Set.Set (Credential Staking) ->
+    IO (Map.Map (Credential Staking) Coin)
+queryStakeRewardsN2C runQuery credentials = do
+    result <-
+        runQuery $
+            BlockQuery $
+                QueryIfCurrentConway $
+                    GetFilteredDelegationsAndRewardAccounts
+                        credentials
+    (_delegations, rewards) <-
+        expectConway
+            "queryStakeRewards"
+            result
+    pure rewards
+
+queryRewardAccountsN2C ::
+    (forall result. Query Block result -> IO result) ->
+    Set.Set AccountAddress ->
+    IO (Map.Map AccountAddress Coin)
+queryRewardAccountsN2C runQuery accounts = do
+    rewards <-
+        queryStakeRewardsN2C
+            runQuery
+            credentials
+    pure $
+        Map.fromList
+            [ (account, reward)
+            | account <- accountList
+            , let credential =
+                    rewardAccountCredential account
+            , Just reward <- [Map.lookup credential rewards]
+            ]
+  where
+    accountList =
+        Set.toList accounts
+    credentials =
+        Set.fromList $
+            rewardAccountCredential <$> accountList
+
+queryVoteDelegateesN2C ::
+    (forall result. Query Block result -> IO result) ->
+    Set.Set (Credential Staking) ->
+    IO (Map.Map (Credential Staking) DRep)
+queryVoteDelegateesN2C runQuery credentials = do
+    result <-
+        runQuery $
+            BlockQuery $
+                QueryIfCurrentConway $
+                    GetFilteredVoteDelegatees credentials
+    expectConway
+        "queryVoteDelegatees"
+        result
+
+queryTreasuryN2C ::
+    (forall result. Query Block result -> IO result) ->
+    IO Coin
+queryTreasuryN2C runQuery = do
+    result <-
+        runQuery $
+            BlockQuery $
+                QueryIfCurrentConway $
+                    GetCBOR GetAccountState
+    serialisedAccountState <-
+        expectConway
+            "queryTreasury"
+            result
+    decodeTreasury
+        serialisedAccountState
+
+decodeTreasury ::
+    Serialised ChainAccountState ->
+    IO Coin
+decodeTreasury serialised =
+    case decodeFullDecoder
+        "queryTreasury serialised account state"
+        (fromSerialised decodeTreasuryPayload (coerce serialised))
+        mempty of
+        Right treasury ->
+            pure treasury
+        Left err ->
+            error $
+                "queryTreasury: failed to decode treasury: "
+                    <> show err
+
+decodeTreasuryPayload ::
+    forall s.
+    Decoder s (LBS.ByteString -> Either DecoderError Coin)
+decodeTreasuryPayload = do
+    len <- decodeListLen
+    if len == 2
+        then do
+            treasury <-
+                Coin <$> decodeInteger
+            _reserves <-
+                decodeInteger
+            pure $ \_payload ->
+                Right treasury
+        else
+            fail $
+                "expected ChainAccountState with 2 fields, got "
+                    <> show len
+
+queryGovernanceStateN2C ::
+    (forall result. Query Block result -> IO result) ->
+    IO (GovState ConwayEra)
+queryGovernanceStateN2C runQuery = do
+    result <-
+        runQuery $
+            BlockQuery $
+                QueryIfCurrentConway
+                    GetGovState
+    expectConway
+        "queryGovernanceState"
+        result
+
+expectConway :: String -> Either mismatch a -> IO a
+expectConway name result =
+    case result of
+        Right value ->
+            pure value
+        Left _mismatch ->
+            error $
+                name <> ": era mismatch - node not in Conway"
 
 queryUTxOsAtN2C ::
     (forall result. Query Block result -> IO result) ->

--- a/lib/Cardano/Node/Client/Provider.hs
+++ b/lib/Cardano/Node/Client/Provider.hs
@@ -23,14 +23,22 @@ module Cardano.Node.Client.Provider (
     queryUTxOsAtH,
     queryUTxOByTxInH,
     queryProtocolParamsH,
+    queryLedgerSnapshotH,
+    queryStakeRewardsH,
+    queryRewardAccountsH,
+    queryVoteDelegateesH,
+    queryTreasuryH,
+    queryGovernanceStateH,
     evaluateTxH,
     posixMsToSlotH,
     posixMsCeilSlotH,
 
     -- * Result types
     EvaluateTxResult,
+    LedgerSnapshot (..),
 
     -- * Re-exports
+    EpochNo (..),
     SlotNo (..),
 ) where
 
@@ -38,8 +46,9 @@ import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
+import Data.Text (Text)
 
-import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Address (AccountAddress, Addr)
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (
     TransactionScriptFailure,
  )
@@ -48,13 +57,19 @@ import Cardano.Ledger.Alonzo.Scripts (
     PlutusPurpose,
  )
 import Cardano.Ledger.Api.Tx.Out (TxOut)
+import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core (PParams)
+import Cardano.Ledger.Credential (Credential)
+import Cardano.Ledger.DRep (DRep)
+import Cardano.Ledger.Keys (KeyRole (Staking))
 import Cardano.Ledger.Plutus (ExUnits)
+import Cardano.Ledger.State (GovState)
 import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Node.Client.Ledger (ConwayTx)
+import Cardano.Node.Client.Types (BlockPoint)
 import Cardano.Node.Client.Validity (HorizonError, ValidityChoice)
-import Cardano.Slotting.Slot (SlotNo (..))
+import Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
 
 -- | Per-script evaluation result.
 type EvaluateTxResult era =
@@ -64,6 +79,21 @@ type EvaluateTxResult era =
             (TransactionScriptFailure era)
             ExUnits
         )
+
+{- | Summary of chain state needed by local-devnet
+smoke tests.
+-}
+data LedgerSnapshot = LedgerSnapshot
+    { ledgerCurrentEra :: Text
+    -- ^ Current ledger era reported by the hard-fork query.
+    , ledgerChainPoint :: BlockPoint
+    -- ^ Chain point acquired for the query.
+    , ledgerTipSlot :: SlotNo
+    -- ^ Slot extracted from 'ledgerChainPoint'. Genesis maps to
+    -- slot zero.
+    , ledgerEpoch :: EpochNo
+    -- ^ Current epoch from the Conway ledger query.
+    }
 
 {- | Query operations bound to one acquired ledger
 snapshot.
@@ -92,6 +122,33 @@ data QueryHandle m = QueryHandle
     , queryProtocolParamsH ::
         m (PParams ConwayEra)
     -- ^ Fetch protocol parameters from the acquired
+    -- snapshot.
+    , queryLedgerSnapshotH ::
+        m LedgerSnapshot
+    -- ^ Fetch era, chain point, tip slot, and epoch from
+    -- the acquired snapshot.
+    , queryStakeRewardsH ::
+        Set (Credential Staking) ->
+        m (Map (Credential Staking) Coin)
+    -- ^ Fetch reward balances for stake credentials in
+    -- the acquired snapshot.
+    , queryRewardAccountsH ::
+        Set AccountAddress ->
+        m (Map AccountAddress Coin)
+    -- ^ Fetch reward balances by reward account in the
+    -- acquired snapshot.
+    , queryVoteDelegateesH ::
+        Set (Credential Staking) ->
+        m (Map (Credential Staking) DRep)
+    -- ^ Fetch Conway vote delegatees for stake credentials
+    -- in the acquired snapshot.
+    , queryTreasuryH ::
+        m Coin
+    -- ^ Fetch the current treasury value from the acquired
+    -- snapshot.
+    , queryGovernanceStateH ::
+        m (GovState ConwayEra)
+    -- ^ Fetch the Conway governance state from the acquired
     -- snapshot.
     , evaluateTxH ::
         ConwayTx ->
@@ -125,6 +182,21 @@ data QueryHandleBackend m = QueryHandleBackend
         m (Map TxIn (TxOut ConwayEra))
     , backendQueryProtocolParams ::
         m (PParams ConwayEra)
+    , backendQueryLedgerSnapshot ::
+        m LedgerSnapshot
+    , backendQueryStakeRewards ::
+        Set (Credential Staking) ->
+        m (Map (Credential Staking) Coin)
+    , backendQueryRewardAccounts ::
+        Set AccountAddress ->
+        m (Map AccountAddress Coin)
+    , backendQueryVoteDelegatees ::
+        Set (Credential Staking) ->
+        m (Map (Credential Staking) DRep)
+    , backendQueryTreasury ::
+        m Coin
+    , backendQueryGovernanceState ::
+        m (GovState ConwayEra)
     , backendEvaluateTx ::
         ConwayTx ->
         m (EvaluateTxResult ConwayEra)
@@ -144,6 +216,13 @@ mkQueryHandle backend =
         , queryUTxOsAtH = backendQueryUTxOsAt backend
         , queryUTxOByTxInH = backendQueryUTxOByTxIn backend
         , queryProtocolParamsH = backendQueryProtocolParams backend
+        , queryLedgerSnapshotH = backendQueryLedgerSnapshot backend
+        , queryStakeRewardsH = backendQueryStakeRewards backend
+        , queryRewardAccountsH = backendQueryRewardAccounts backend
+        , queryVoteDelegateesH = backendQueryVoteDelegatees backend
+        , queryTreasuryH = backendQueryTreasury backend
+        , queryGovernanceStateH =
+            backendQueryGovernanceState backend
         , evaluateTxH = backendEvaluateTx backend
         , posixMsToSlotH = backendPosixMsToSlot backend
         , posixMsCeilSlotH = backendPosixMsCeilSlot backend
@@ -167,6 +246,13 @@ singleShotQueryHandle provider =
             , backendQueryUTxOsAt = queryAddresses
             , backendQueryUTxOByTxIn = queryUTxOByTxIn provider
             , backendQueryProtocolParams = queryProtocolParams provider
+            , backendQueryLedgerSnapshot = queryLedgerSnapshot provider
+            , backendQueryStakeRewards = queryStakeRewards provider
+            , backendQueryRewardAccounts = queryRewardAccounts provider
+            , backendQueryVoteDelegatees = queryVoteDelegatees provider
+            , backendQueryTreasury = queryTreasury provider
+            , backendQueryGovernanceState =
+                queryGovernanceState provider
             , backendEvaluateTx = evaluateTx provider
             , backendPosixMsToSlot = posixMsToSlot provider
             , backendPosixMsCeilSlot = posixMsCeilSlot provider
@@ -212,6 +298,27 @@ data Provider m = Provider
     , queryProtocolParams ::
         m (PParams ConwayEra)
     -- ^ Fetch current protocol parameters
+    , queryLedgerSnapshot ::
+        m LedgerSnapshot
+    -- ^ Fetch current era, chain point, tip slot, and epoch.
+    , queryStakeRewards ::
+        Set (Credential Staking) ->
+        m (Map (Credential Staking) Coin)
+    -- ^ Fetch reward balances for stake credentials.
+    , queryRewardAccounts ::
+        Set AccountAddress ->
+        m (Map AccountAddress Coin)
+    -- ^ Fetch reward balances by reward account.
+    , queryVoteDelegatees ::
+        Set (Credential Staking) ->
+        m (Map (Credential Staking) DRep)
+    -- ^ Fetch Conway vote delegatees for stake credentials.
+    , queryTreasury ::
+        m Coin
+    -- ^ Fetch the current treasury value.
+    , queryGovernanceState ::
+        m (GovState ConwayEra)
+    -- ^ Fetch the Conway governance state.
     , evaluateTx ::
         ConwayTx ->
         m (EvaluateTxResult ConwayEra)

--- a/specs/044-devnet-query-support/plan.md
+++ b/specs/044-devnet-query-support/plan.md
@@ -1,0 +1,126 @@
+# Implementation Plan: Devnet node query support
+
+**Branch**: `131-devnet-query-support`
+**Spec**: [spec.md](./spec.md)
+**Issue**: [#131](https://github.com/lambdasistemi/cardano-node-clients/issues/131)
+**Base**: PR [#135](https://github.com/lambdasistemi/cardano-node-clients/pull/135)
+
+## Status
+
+**Completed**: Address helpers, provider/query-handle surface, N2C LSQ
+queries, test-provider stubs, and the `Provider.N2C` devnet conformance
+group; branch pushed and draft PR
+[#137](https://github.com/lambdasistemi/cardano-node-clients/pull/137)
+opened against PR #135.
+**Current**: The remaining proof is the downstream DevNet story: submit
+the governance action, wait for the next epoch, and observe the target
+reward account funding through the provider queries.
+**Follow-up**:
+[amaru-treasury-tx#82](https://github.com/lambdasistemi/amaru-treasury-tx/issues/82)
+owns the final governance smoke that consumes #135 + #137, submits the
+setup governance transaction, waits for the next epoch, and observes
+the reward-account balance increase.
+**Blockers**: None for the query-side PR.
+
+## Technical Context
+
+**Language/Version**: Haskell, GHC through the repository Nix shell
+**Primary Dependencies**: `cardano-ledger-*`,
+`ouroboros-consensus`, `ouroboros-network`
+**Testing**: Hspec unit tests, Hspec devnet E2E tests, `just ci`
+**Target**: Public library API in `Cardano.Node.Client.Provider` plus
+address helpers in `Cardano.Node.Client.Address`
+
+## Constitution Check
+
+- Channel-driven N2C clients: preserved; all live reads use the
+  existing LocalStateQuery channel.
+- Devnet E2E testing: add a real devnet provider smoke for the new
+  boundary.
+- Minimal dependencies: no new package dependencies expected.
+- Test-first workflow: add failing tests before production changes.
+
+## Design
+
+1. Add `Cardano.Node.Client.Address` with small typed helpers:
+   payment/stake credential extraction, reward-account construction,
+   reward-account credential extraction, and key/script credential
+   constructors.
+2. Extend `Cardano.Node.Client.Provider` with:
+   - a ledger summary containing current era text, chain point, tip
+     slot, and epoch;
+   - reward balance queries by reward account and by stake credential;
+   - vote-delegatee query by stake credential;
+   - treasury and governance-state queries.
+3. Mirror each new one-shot provider field on `QueryHandle` so callers
+   can make consistent acquired-session reads.
+4. Implement the N2C backend with Conway LocalStateQuery constructors:
+   current era, chain point, epoch, account state, filtered reward
+   accounts, filtered vote delegatees, and governance state.
+   Treasury uses `GetCBOR GetAccountState` and decodes the treasury
+   field from the returned account-state payload so the provider does not
+   depend on the reserve field decoding as a non-negative `Coin` on local
+   devnets.
+5. Keep existing tests and test providers compiling by supplying
+   explicit unused stubs where tests do not touch the new fields.
+
+## DevNet Governance Smoke Story
+
+`amaru-treasury-tx#82` should consume this PR together with #135 and
+prove the actual reward flow:
+
+1. Pin `cardano-node-clients` to a stack containing #135 and #137.
+2. Update the Amaru local provider stub for the additive Provider and
+   QueryHandle fields.
+3. Replace permanent `cardano-cli query` and `cardano-cli address info`
+   use in the governance smoke with #137 Provider/address helpers.
+4. Record the target script reward-account balance and submission epoch.
+5. Build and submit the setup governance transaction through #135.
+6. Wait until the ledger epoch is greater than the submission epoch.
+7. Query the target reward account again and assert the balance
+   increased by the requested treasury-withdrawal amount.
+
+The smoke is not accepted if it only proves that LSQ queries return.
+It must tie the observed reward balance to a submitted governance
+action and the following epoch.
+
+## Missing Work To Complete The Story
+
+This PR leaves only the upstream query dependency ready. The story is
+not complete until the downstream `amaru-treasury-tx#82` PR has these
+vertical slices:
+
+1. **Downstream stack pin and compile repair**: pin
+   `cabal.project` to a `cardano-node-clients` commit containing #135
+   and #137; add any needed `cardano-node-clients:devnet` dependency;
+   update all local Provider stubs so the downstream repo compiles.
+2. **RED governance smoke**: add a failing DevNet smoke/test that boots
+   the short-epoch devnet, records the target script reward-account
+   balance and epoch, then fails until a governance action is submitted
+   and a later epoch funds that reward account.
+3. **Governance setup submitter**: build and submit the setup
+   transaction with #135 (`registerAndVoteAbstain` and
+   `proposeTreasuryWithdrawal`) against the devnet faucet/genesis UTxO.
+4. **Epoch wait and reward assertion**: poll #137
+   `queryLedgerSnapshot` until `ledgerEpoch > submissionEpoch`, then
+   use `queryRewardAccounts`/`queryStakeRewards` to assert the exact
+   requested treasury-withdrawal amount arrived.
+5. **Summary and gate**: emit a machine-readable summary with run
+   directory, tx id, governance action id, target reward account,
+   requested amount, before/after reward balances, submission epoch,
+   observed epoch, and the `cardano-node-clients` commit; wire the
+   smoke into an explicit `just devnet-smoke-governance` gate.
+
+Do these as separate bisect-safe commits. Each commit must compile and
+must include the test/gate that proves its slice.
+
+## Verification
+
+Run, in order:
+
+```bash
+nix develop --quiet -c cabal test cardano-node-clients:unit-tests -O0 --test-show-details=direct --test-option=--match --test-option=/Address/
+nix develop --quiet -c cabal test cardano-node-clients:e2e-tests -O0 --test-show-details=direct --test-option=--match --test-option=/Provider.N2C/
+nix develop --quiet -c just format
+nix develop --quiet -c just ci
+```

--- a/specs/044-devnet-query-support/spec.md
+++ b/specs/044-devnet-query-support/spec.md
@@ -1,0 +1,121 @@
+# 044 — Devnet node query support
+
+Issue: [#131](https://github.com/lambdasistemi/cardano-node-clients/issues/131)
+Base PR: [#135](https://github.com/lambdasistemi/cardano-node-clients/pull/135)
+Status: Draft - governance reward smoke story pending
+
+## Context
+
+`amaru-treasury-tx` needs local-devnet smoke tests to observe chain
+state through typed Haskell node-to-client APIs instead of using
+`cardano-cli query` and `cardano-cli address info` as the boundary.
+PR #135 adds the Conway transaction-construction side for stake
+registration and treasury-withdrawal proposals. This slice adds the
+query-side companion on top of #135.
+
+The missing story is concrete: boot a short-epoch Conway devnet, submit
+the treasury-withdrawal governance action, wait for the next epoch, and
+prove through typed queries that the target reward account received the
+funds. Query success alone is not the proof.
+
+## User Scenarios & Testing
+
+### User Story 1 - Governance action funds reward account next epoch (P1)
+
+A downstream smoke test boots a local Conway devnet, builds and submits
+the treasury-withdrawal governance setup transaction, waits until the
+ledger advances past the submission epoch, and observes that the target
+script reward account has received the requested funds.
+
+**Independent Test**: The DevNet smoke records the target reward-account
+balance before submission, submits the governance action, waits for the
+next epoch, then queries the same reward account through
+`Cardano.Node.Client.Provider` and asserts the balance increased by the
+expected withdrawal amount. The test fails if no governance action was
+submitted, if the epoch did not advance, or if the reward balance did
+not change.
+
+### User Story 2 - Devnet smoke reads ledger state through Provider (P1)
+
+A downstream smoke test boots a local Conway devnet, submits setup
+transactions, and reads the resulting state through
+`Cardano.Node.Client.Provider`.
+
+**Independent Test**: An E2E provider test calls the N2C provider for
+current era, tip slot, epoch, protocol parameters, treasury, governance
+state, reward balances, and vote delegation data without shelling out to
+`cardano-cli`.
+
+### User Story 3 - Reward accounts are queryable by typed credentials (P1)
+
+A caller can ask for key-backed and script-backed reward-account
+balances using ledger types and receives a typed map of balances for
+registered accounts.
+
+**Independent Test**: The devnet test queries both a key reward account
+and a script reward account. Unregistered accounts return no balances
+and do not error.
+
+### User Story 4 - Address and script credentials do not require CLI parsing (P2)
+
+A caller can extract payment and stake credentials from ledger
+addresses, and can build key/script credentials and reward accounts in
+Haskell.
+
+**Independent Test**: Unit tests cover base addresses, enterprise
+addresses, reward-account construction, and account credential
+extraction.
+
+## Requirements
+
+- **FR-001**: The provider MUST continue exposing UTxO-by-address and
+  UTxO-by-TxIn queries as typed ledger values.
+- **FR-002**: The provider MUST expose reward-balance queries for sets
+  of reward accounts and for sets of stake credentials.
+- **FR-003**: The provider MUST expose vote-delegation queries for
+  stake credentials so the Conway abstain delegation can be observed.
+- **FR-004**: The provider MUST expose current era, chain point, tip
+  slot, and epoch as a typed summary.
+- **FR-005**: The provider MUST expose protocol parameters, treasury
+  value, and Conway governance state needed by the treasury-withdrawal
+  smoke.
+- **FR-006**: All new provider queries MUST be available both as
+  one-shot provider fields and acquired-session handle fields.
+- **FR-007**: Address helper functions MUST cover payment credential
+  extraction, stake credential extraction, reward-account construction,
+  and reward-account credential extraction.
+- **FR-008**: Existing provider callers MUST keep compiling with only
+  additive API changes.
+- **FR-009**: The downstream DevNet smoke MUST submit a real Conway
+  treasury-withdrawal governance action before claiming governance
+  success.
+- **FR-010**: The downstream DevNet smoke MUST wait until the ledger
+  epoch is greater than the submission epoch before checking reward
+  delivery.
+- **FR-011**: The downstream DevNet smoke MUST query the target reward
+  account before and after the epoch transition and assert the expected
+  balance increase.
+- **FR-012**: A smoke that only proves that LSQ queries return
+  successfully MUST NOT satisfy the governance proof.
+
+## Success Criteria
+
+- **SC-001**: Unit tests for address helpers pass.
+- **SC-002**: A devnet E2E test exercises the new N2C provider queries
+  without invoking `cardano-cli`.
+- **SC-003**: `nix develop --quiet -c just ci` passes.
+- **SC-004**: The work is delivered in a separate draft PR stacked on
+  #135 and is not merged by this session.
+- **SC-005**: The downstream governance smoke in
+  `amaru-treasury-tx#82` passes against a stack containing #135 and
+  #137 by submitting the governance action and observing the reward
+  account funding in the following epoch.
+
+## Out Of Scope
+
+- Implementing the Conway setup transaction constructors. PR #135 owns
+  that work; the downstream smoke still has to use those constructors to
+  submit a real transaction.
+- Querying every Conway governance substructure. This slice exposes the
+  typed `GovState ConwayEra` boundary and specific reward/delegation
+  summaries needed by the current smoke.

--- a/specs/044-devnet-query-support/tasks.md
+++ b/specs/044-devnet-query-support/tasks.md
@@ -1,0 +1,122 @@
+# Tasks: Devnet node query support
+
+## Phase 1 - RED tests
+
+- [X] T001 Add unit tests for `Cardano.Node.Client.Address`.
+- [X] T002 Add provider E2E expectations for ledger summary, treasury,
+  governance state, reward balances, and vote delegatees.
+- [X] T003 Run targeted tests and confirm the new tests fail before
+  production code exists.
+
+## Phase 2 - Provider API
+
+- [X] T004 Add `Cardano.Node.Client.Address` and expose it from the
+  main library.
+- [X] T005 Extend `Provider`, `QueryHandle`, and
+  `QueryHandleBackend` with the new query fields.
+- [X] T006 Update test providers to stub the additive fields.
+
+## Phase 3 - N2C backend
+
+- [X] T007 Implement the new LocalStateQuery calls in
+  `Cardano.Node.Client.N2C.Provider`.
+- [X] T008 Keep one-shot fields delegating through `withAcquired`.
+- [X] T009 Verify the devnet provider smoke runs against the N2C
+  boundary.
+
+## Phase 4 - PR handoff
+
+- [X] T010 Run format and full CI.
+- [X] T011 Commit a vertical, bisect-safe slice.
+- [X] T012 Push `131-devnet-query-support` and open a draft PR with base
+  `042-upstream-proposal-slices`.
+
+## Phase 5 - Governance reward smoke story
+
+- [X] T013 Replace the review-boundary prose with the actual downstream
+  story: submit a treasury-withdrawal governance action on DevNet, wait
+  for the next epoch, and assert the target reward account was funded.
+
+## Phase 6 - Downstream DevNet proof
+
+- [ ] T014 [US1] Create/update the downstream Spec Kit artifacts for
+  Amaru issue #82 in
+  `/code/amaru-treasury-tx/specs/007-devnet-governance-action/spec.md`,
+  `/code/amaru-treasury-tx/specs/007-devnet-governance-action/plan.md`,
+  and
+  `/code/amaru-treasury-tx/specs/007-devnet-governance-action/tasks.md`
+  so User Story 1 is exactly: submit the treasury-withdrawal governance
+  action, wait for the next epoch, assert the target reward account was
+  funded.
+- [ ] T015 [US1] Pin `/code/amaru-treasury-tx/cabal.project` to a
+  `cardano-node-clients` commit containing #135 and #137, refresh the
+  `--sha256`, and add any needed `cardano-node-clients:devnet` or
+  `cardano-node-clients:tx-build` dependency in
+  `/code/amaru-treasury-tx/amaru-treasury-tx.cabal`.
+- [ ] T016 [US1] Add or centralize downstream Provider test stubs in
+  `/code/amaru-treasury-tx/test/unit/Amaru/Treasury/TestProvider.hs`
+  and update existing stubs in
+  `/code/amaru-treasury-tx/test/unit/Amaru/Treasury/Registry/VerifySpec.hs`,
+  `/code/amaru-treasury-tx/test/unit/Amaru/Treasury/Tx/SwapWizardSpec.hs`,
+  and
+  `/code/amaru-treasury-tx/test/unit/Amaru/Treasury/Tx/WithdrawWizardSpec.hs`
+  for the additive #137 Provider/QueryHandle fields.
+- [ ] T017 [US1] Replace the downstream direct LSQ reward helper in
+  `/code/amaru-treasury-tx/lib/Amaru/Treasury/Backend/N2C.hs` and
+  `/code/amaru-treasury-tx/app/amaru-treasury-tx/Main.hs` with #137
+  Provider queries (`queryRewardAccounts` or `queryStakeRewards`) so
+  reward observation goes through the same boundary as the smoke.
+- [ ] T018 [US1] Add a RED unit test for epoch waiting and reward delta
+  in
+  `/code/amaru-treasury-tx/test/unit/Amaru/Treasury/DevNet/GovernanceSmokeSpec.hs`:
+  a fake Provider reports epoch N and reward R before submission, then
+  epoch N+1 and reward R+amount, and the assertion returns the funded
+  summary.
+- [ ] T019 [US1] Implement the pure/IO-free smoke state machine in
+  `/code/amaru-treasury-tx/lib/Amaru/Treasury/DevNet/GovernanceSmoke.hs`
+  with functions for reading `ledgerEpoch`, recording before/after
+  reward balances, waiting for `ledgerEpoch > submissionEpoch`, and
+  asserting the exact requested amount.
+- [ ] T020 [US1] Add a RED integration smoke entry point in
+  `/code/amaru-treasury-tx/app/devnet-governance-smoke/Main.hs` and its
+  cabal executable stanza in
+  `/code/amaru-treasury-tx/amaru-treasury-tx.cabal`; it must boot/use a
+  short-epoch devnet, record pre-submit reward state, and fail until the
+  setup transaction is actually submitted.
+- [ ] T021 [US1] Implement the setup transaction builder in
+  `/code/amaru-treasury-tx/lib/Amaru/Treasury/DevNet/GovernanceSetup.hs`
+  using #135 `registerAndVoteAbstain` and
+  `proposeTreasuryWithdrawal`, funded by the devnet faucet/genesis UTxO
+  and targeting the Amaru script reward account.
+- [ ] T022 [US1] Submit the setup transaction in
+  `/code/amaru-treasury-tx/app/devnet-governance-smoke/Main.hs` through
+  the N2C submitter, capture the tx id and governance action id, and
+  wait until the tx is observable before starting the epoch wait.
+- [ ] T023 [US1] Complete the smoke in
+  `/code/amaru-treasury-tx/app/devnet-governance-smoke/Main.hs` by
+  waiting for `ledgerEpoch > submissionEpoch`, querying the target
+  reward account through #137 Provider queries, and failing unless
+  `afterReward - beforeReward == requestedWithdrawal`.
+- [ ] T024 [US1] Emit the machine-readable summary from
+  `/code/amaru-treasury-tx/app/devnet-governance-smoke/Main.hs` to the
+  run directory with tx id, governance action id, reward account,
+  requested amount, before/after rewards, submission epoch, observed
+  epoch, tip slot, and `cardano-node-clients` commit.
+- [ ] T025 [US1] Wire `/code/amaru-treasury-tx/justfile` with
+  `devnet-smoke-governance` and add
+  `/code/amaru-treasury-tx/scripts/smoke/devnet-governance` so the
+  proof is one command and cannot pass by running zero examples.
+- [ ] T026 [US1] Run
+  `nix develop --quiet -c just unit GovernanceSmoke`,
+  `nix develop --quiet -c just devnet-smoke-governance`, and
+  `nix develop --quiet -c just ci` in `/code/amaru-treasury-tx`; commit
+  only after all three gates pass.
+
+## Phase 7 - Commit discipline for the downstream PR
+
+- [ ] T027 [US1] Commit the downstream work as vertical, bisect-safe
+  slices: stack pin/compile repair; RED smoke harness; setup tx
+  submitter; epoch wait plus reward assertion; summary/gate wiring.
+- [ ] T028 [US1] Keep `amaru-treasury-tx#82` draft until
+  `just devnet-smoke-governance` proves the funded reward account in a
+  later epoch, not merely that LSQ queries return.

--- a/test/Cardano/Node/Client/AddressSpec.hs
+++ b/test/Cardano/Node/Client/AddressSpec.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.Node.Client.AddressSpec (spec) where
+
+import Test.Hspec (
+    Spec,
+    describe,
+    it,
+    shouldBe,
+ )
+
+import Cardano.Crypto.Hash (
+    Hash,
+    HashAlgorithm,
+    hashFromBytes,
+ )
+import Cardano.Ledger.Address (
+    AccountAddress (..),
+    AccountId (..),
+    Addr (..),
+ )
+import Cardano.Ledger.BaseTypes (Network (Testnet))
+import Cardano.Ledger.Credential (
+    Credential (..),
+    StakeReference (..),
+ )
+import Cardano.Ledger.Hashes (ScriptHash (..))
+import Cardano.Ledger.Keys (
+    KeyHash (..),
+    KeyRole (Payment, Staking),
+ )
+import Data.ByteString qualified as BS
+import Data.Maybe (fromJust)
+import Data.Word (Word8)
+
+import Cardano.Node.Client.Address (
+    keyCredential,
+    paymentCredentialFromAddr,
+    rewardAccountCredential,
+    rewardAccountFromCredential,
+    scriptCredential,
+    stakeCredentialFromAddr,
+ )
+
+spec :: Spec
+spec =
+    describe "Cardano.Node.Client.Address" $ do
+        it "extracts payment and stake credentials from a base address" $ do
+            let paymentCred =
+                    mkPaymentCredential 1
+                stakeCred =
+                    mkStakeCredential 2
+                addr =
+                    Addr
+                        Testnet
+                        paymentCred
+                        (StakeRefBase stakeCred)
+            paymentCredentialFromAddr addr
+                `shouldBe` Just paymentCred
+            stakeCredentialFromAddr addr
+                `shouldBe` Just stakeCred
+
+        it "extracts payment credentials from enterprise addresses" $ do
+            let paymentCred =
+                    mkPaymentCredential 3
+                addr =
+                    Addr
+                        Testnet
+                        paymentCred
+                        StakeRefNull
+            paymentCredentialFromAddr addr
+                `shouldBe` Just paymentCred
+            stakeCredentialFromAddr addr
+                `shouldBe` Nothing
+
+        it "round-trips typed reward-account credentials" $ do
+            let stakeCred =
+                    mkStakeCredential 4
+                rewardAccount =
+                    rewardAccountFromCredential
+                        Testnet
+                        stakeCred
+            rewardAccount
+                `shouldBe` AccountAddress
+                    Testnet
+                    (AccountId stakeCred)
+            rewardAccountCredential rewardAccount
+                `shouldBe` stakeCred
+
+        it "builds key and script credentials without CLI parsing" $ do
+            let keyHash =
+                    KeyHash (mkHash28 5)
+                scriptHash =
+                    ScriptHash (mkHash28 6)
+            (keyCredential keyHash :: Credential Staking)
+                `shouldBe` KeyHashObj keyHash
+            (scriptCredential scriptHash :: Credential Staking)
+                `shouldBe` ScriptHashObj scriptHash
+
+mkPaymentCredential :: Word8 -> Credential Payment
+mkPaymentCredential n =
+    KeyHashObj (KeyHash (mkHash28 n))
+
+mkStakeCredential :: Word8 -> Credential Staking
+mkStakeCredential n =
+    KeyHashObj (KeyHash (mkHash28 n))
+
+mkHash28 ::
+    (HashAlgorithm h) =>
+    Word8 ->
+    Hash h a
+mkHash28 n =
+    fromJust $
+        hashFromBytes $
+            BS.pack $
+                replicate 27 0 ++ [n]

--- a/test/Cardano/Node/Client/BalanceSpec.hs
+++ b/test/Cardano/Node/Client/BalanceSpec.hs
@@ -3,6 +3,7 @@ module Cardano.Node.Client.BalanceSpec (spec) where
 import Data.List (nub, sort)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromJust, fromMaybe)
+import Data.OSet.Strict qualified as OSet
 import Data.Sequence.Strict qualified as StrictSeq
 import Data.Set qualified as Set
 import Lens.Micro ((&), (.~), (^.))
@@ -10,7 +11,11 @@ import Test.Hspec
 import Test.QuickCheck
 
 import Cardano.Crypto.Hash (hashFromStringAsHex)
-import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Address (
+    AccountAddress (..),
+    AccountId (..),
+    Addr (..),
+ )
 import Cardano.Ledger.Alonzo.Scripts (
     AsIx (..),
     fromPlutusScript,
@@ -27,10 +32,12 @@ import Cardano.Ledger.Api.Tx (
     mkBasicTx,
  )
 import Cardano.Ledger.Api.Tx.Body (
+    certsTxBodyL,
     feeTxBodyL,
     mintTxBodyL,
     mkBasicTxBody,
     outputsTxBodyL,
+    proposalProceduresTxBodyL,
     referenceInputsTxBodyL,
  )
 import Cardano.Ledger.Api.Tx.Out (
@@ -45,6 +52,7 @@ import Cardano.Ledger.BaseTypes (
     StrictMaybe (..),
     TxIx (..),
     boundRational,
+    textToUrl,
  )
 import Cardano.Ledger.Coin (
     Coin (..),
@@ -53,25 +61,37 @@ import Cardano.Ledger.Coin (
  )
 import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway.Governance (
+    Anchor (..),
+    GovAction (..),
+    ProposalProcedure (..),
+ )
 import Cardano.Ledger.Conway.PParams (
     ppMinFeeRefScriptCostPerByteL,
  )
 import Cardano.Ledger.Conway.Scripts (
     ConwayPlutusPurpose (..),
  )
+import Cardano.Ledger.Conway.TxCert (
+    ConwayDelegCert (..),
+    ConwayTxCert (..),
+    Delegatee (..),
+ )
 import Cardano.Ledger.Core (
     Script,
     emptyPParams,
     getMinFeeTx,
+    ppKeyDepositL,
  )
 import Cardano.Ledger.Credential (
     Credential (KeyHashObj),
     StakeReference (StakeRefNull),
  )
+import Cardano.Ledger.DRep (DRep (..))
 import Cardano.Ledger.Hashes (ScriptHash (..), unsafeMakeSafeHash)
 import Cardano.Ledger.Keys (
     KeyHash (..),
-    KeyRole (Payment),
+    KeyRole (Payment, Staking),
  )
 import Cardano.Ledger.Mary.Value (
     AssetName (..),
@@ -107,6 +127,7 @@ spec = describe "Balance helpers" $ do
     computeScriptIntegritySpec
     placeholderExUnitsSpec
     balanceTxSpec
+    balanceTxDepositSpec
     balanceTxMultiAssetSpec
     refScriptsSizeSpec
     balanceTxRefScriptFeeSpec
@@ -155,6 +176,40 @@ mkAddr n =
     hexDigit d
         | d < 10 = toEnum (fromEnum '0' + d)
         | otherwise = toEnum (fromEnum 'a' + d - 10)
+
+mkStakeCredential :: Int -> Credential Staking
+mkStakeCredential n =
+    let hexStr =
+            replicate 52 '0'
+                ++ hexByte (n `div` 256)
+                ++ hexByte (n `mod` 256)
+        h = fromJust (hashFromStringAsHex hexStr)
+     in KeyHashObj (KeyHash h :: KeyHash Staking)
+  where
+    hexByte b =
+        let (hi, lo) = b `divMod` 16
+         in [hexDigit hi, hexDigit lo]
+    hexDigit d
+        | d < 10 = toEnum (fromEnum '0' + d)
+        | otherwise = toEnum (fromEnum 'a' + d - 10)
+
+mkRewardAccount :: Int -> AccountAddress
+mkRewardAccount n =
+    AccountAddress Testnet (AccountId (mkStakeCredential n))
+
+mkAnchor :: Anchor
+mkAnchor =
+    Anchor
+        (fromJust $ textToUrl 128 "https://example.invalid/balance.json")
+        ( unsafeMakeSafeHash $
+            fromJust $
+                hashFromStringAsHex $
+                    replicate 63 '0' ++ "1"
+        )
+
+minusCoin :: Coin -> Coin -> Coin
+minusCoin (Coin a) (Coin b) =
+    Coin (a - b)
 
 -- -----------------------------------------------------------
 -- spendingIndex
@@ -371,6 +426,99 @@ balanceTxSpec =
                 Right _ ->
                     expectationFailure
                         "expected InsufficientFee"
+
+balanceTxDepositSpec :: Spec
+balanceTxDepositSpec =
+    describe "balanceTx deposit accounting" $
+        it "subtracts certificate and proposal deposits from change" $ do
+            let stakeDeposit =
+                    Coin 400_000
+                pp =
+                    emptyPParams @ConwayEra
+                        & ppTxFeePerByteL
+                            .~ CoinPerByte
+                                (compactCoinOrError (Coin 44))
+                        & ppTxFeeFixedL .~ Coin 155381
+                        & ppKeyDepositL .~ stakeDeposit
+                stakeCredential =
+                    mkStakeCredential 4
+                legacyStakeCredential =
+                    mkStakeCredential 5
+                returnAccount =
+                    mkRewardAccount 4
+                proposalDeposit =
+                    Coin 1_000_000
+                inputCoin =
+                    Coin 10_000_000
+                outputCoin =
+                    Coin 3_000_000
+                inputUtxos =
+                    [
+                        ( mkTxIn 1
+                        , mkBasicTxOut
+                            (mkAddr 1)
+                            (inject inputCoin)
+                        )
+                    ]
+                cert =
+                    ConwayTxCertDeleg $
+                        ConwayRegDelegCert
+                            stakeCredential
+                            (DelegVote DRepAlwaysAbstain)
+                            stakeDeposit
+                legacyCert =
+                    ConwayTxCertDeleg $
+                        ConwayRegCert
+                            legacyStakeCredential
+                            SNothing
+                proposal =
+                    ProposalProcedure
+                        proposalDeposit
+                        returnAccount
+                        ( TreasuryWithdrawals
+                            (Map.singleton returnAccount (Coin 1))
+                            SNothing
+                        )
+                        mkAnchor
+                template =
+                    mkBasicTx $
+                        mkBasicTxBody
+                            & outputsTxBodyL
+                                .~ StrictSeq.singleton
+                                    ( mkBasicTxOut
+                                        (mkAddr 2)
+                                        (inject outputCoin)
+                                    )
+                            & certsTxBodyL
+                                .~ StrictSeq.fromList
+                                    [ cert
+                                    , legacyCert
+                                    ]
+                            & proposalProceduresTxBodyL
+                                .~ OSet.singleton proposal
+            case balanceTx
+                pp
+                inputUtxos
+                []
+                (mkAddr 3)
+                template of
+                Left err ->
+                    expectationFailure (show err)
+                Right BalanceResult{balancedTx = tx} -> do
+                    let outs =
+                            foldr
+                                (:)
+                                []
+                                (tx ^. bodyTxL . outputsTxBodyL)
+                        fee =
+                            tx ^. bodyTxL . feeTxBodyL
+                    last outs ^. coinTxOutL
+                        `shouldBe` inputCoin
+                            `minusCoin` outputCoin
+                            `minusCoin` fee
+                            `minusCoin` stakeDeposit
+                            `minusCoin` stakeDeposit
+                            `minusCoin` proposalDeposit
 
 -- -----------------------------------------------------------
 -- refScriptsSize + balanceTx ref-script fee accounting (#74)

--- a/test/Cardano/Node/Client/E2E/GovernanceSmokeSpec.hs
+++ b/test/Cardano/Node/Client/E2E/GovernanceSmokeSpec.hs
@@ -1,0 +1,645 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Cardano.Node.Client.E2E.GovernanceSmokeSpec
+Description : Devnet governance smoke test
+License     : Apache-2.0
+-}
+module Cardano.Node.Client.E2E.GovernanceSmokeSpec (spec) where
+
+import Cardano.Crypto.DSIGN (
+    Ed25519DSIGN,
+    SignKeyDSIGN,
+    deriveVerKeyDSIGN,
+ )
+import Cardano.Crypto.Hash (
+    Hash,
+    HashAlgorithm,
+    hashFromBytes,
+ )
+import Cardano.Ledger.Address (
+    AccountAddress (..),
+    AccountId (..),
+    Addr (..),
+ )
+import Cardano.Ledger.Api.Tx (txIdTx)
+import Cardano.Ledger.Api.Tx.Out (TxOut)
+import Cardano.Ledger.BaseTypes (
+    Inject (..),
+    Network (..),
+    StrictMaybe (SNothing),
+    textToUrl,
+ )
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway.Governance (Anchor (..))
+import Cardano.Ledger.Core (PParams)
+import Cardano.Ledger.Credential (
+    Credential (..),
+    StakeReference (..),
+ )
+import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
+import Cardano.Ledger.Keys (
+    KeyHash,
+    KeyRole (DRepRole, Payment, Staking),
+    VKey (..),
+    hashKey,
+ )
+import Cardano.Ledger.TxIn (TxId, TxIn (..))
+import Cardano.Node.Client.E2E.Setup (
+    addKeyWitness,
+    genesisAddr,
+    genesisDir,
+    genesisSignKey,
+    mkSignKey,
+    withDevnetFromGenesis,
+ )
+import Cardano.Node.Client.N2C.Provider (mkN2CProvider)
+import Cardano.Node.Client.N2C.Submitter (mkN2CSubmitter)
+import Cardano.Node.Client.Provider (
+    EpochNo (..),
+    LedgerSnapshot (..),
+    Provider (..),
+ )
+import Cardano.Node.Client.Submitter (
+    SubmitResult (..),
+    Submitter (..),
+ )
+import Cardano.Node.Client.TxBuild (
+    CertWitness (..),
+    ConwayDelegCert (..),
+    ConwayGovCert (..),
+    ConwayTxCert (..),
+    DRep (..),
+    Delegatee (..),
+    GovActionId (..),
+    GovActionIx (..),
+    InterpretIO (..),
+    ProposalWitness (..),
+    TxBuild,
+    Vote (..),
+    Voter (..),
+    build,
+    certify,
+    payTo,
+    proposeTreasuryWithdrawal,
+    registerAndVoteAbstain,
+    spend,
+    validTo,
+    vote,
+ )
+import Cardano.Slotting.Slot (SlotNo (..))
+import Control.Concurrent (threadDelay)
+import Data.ByteString qualified as BS
+import Data.ByteString.Char8 qualified as BS8
+import Data.Foldable (traverse_)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromJust)
+import Data.Set qualified as Set
+import Data.Void (Void)
+import Data.Word (Word64, Word8)
+import System.Directory (
+    copyFile,
+    createDirectoryIfMissing,
+ )
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec (
+    Spec,
+    around,
+    describe,
+    expectationFailure,
+    it,
+    shouldBe,
+ )
+
+spec :: Spec
+spec =
+    around withGovernanceEnv $
+        describe "DevNet governance smoke" $
+            it
+                "submits a treasury withdrawal and observes the target reward after an epoch"
+                submitTreasuryWithdrawal
+
+type Env =
+    ( Provider IO
+    , Submitter IO
+    , PParams ConwayEra
+    , [(TxIn, TxOut ConwayEra)]
+    )
+
+data NoCtx a
+
+withdrawalAmount :: Coin
+withdrawalAmount = Coin 2_000_000
+
+stakeDeposit :: Coin
+stakeDeposit = Coin 400_000
+
+governanceDeposit :: Coin
+governanceDeposit = Coin 1_000_000
+
+drepDeposit :: Coin
+drepDeposit = Coin 500_000
+
+stakeOutputCoin :: Coin
+stakeOutputCoin = Coin 5_000_000
+
+targetSignKey :: SignKeyDSIGN Ed25519DSIGN
+targetSignKey =
+    mkSignKey "e2e-governance-target-key-000001"
+
+withGovernanceEnv :: (Env -> IO ()) -> IO ()
+withGovernanceEnv action =
+    withGovernanceGenesis $ \gDir ->
+        withDevnetFromGenesis gDir $ \lsq ltxs -> do
+            let provider =
+                    mkN2CProvider lsq
+                submitter =
+                    mkN2CSubmitter ltxs
+            _ <- waitForTreasury provider withdrawalAmount 120
+            pp <- queryProtocolParams provider
+            utxos <- queryUTxOs provider genesisAddr
+            action (provider, submitter, pp, utxos)
+
+submitTreasuryWithdrawal :: Env -> IO ()
+submitTreasuryWithdrawal (provider, submitter, pp, utxos) = do
+    seed@(seedIn, _) <- case utxos of
+        u : _ -> pure u
+        [] -> fail "no genesis UTxOs"
+
+    let returnAccount =
+            rewardAccountFromSignKey genesisSignKey
+        targetAccount =
+            rewardAccountFromSignKey targetSignKey
+        targetCredential =
+            stakeCredentialFromSignKey targetSignKey
+        returnCredential =
+            stakeCredentialFromSignKey genesisSignKey
+        drepCredential =
+            drepCredentialFromSignKey targetSignKey
+        drepKey =
+            drepKeyHashFromSignKey targetSignKey
+        targetBaseAddr =
+            baseAddrFromSignKey targetSignKey targetCredential
+        interpret :: InterpretIO NoCtx
+        interpret =
+            InterpretIO $ \case {}
+        eval tx =
+            fmap
+                (Map.map (either (Left . show) Right))
+                (evaluateTx provider tx)
+        prog :: TxBuild NoCtx Void ()
+        prog = do
+            _ <- spend seedIn
+            _ <-
+                registerAndVoteAbstain
+                    returnCredential
+                    stakeDeposit
+                    PubKeyCert
+            _ <-
+                certify
+                    ( ConwayTxCertGov $
+                        ConwayRegDRep
+                            drepCredential
+                            drepDeposit
+                            SNothing
+                    )
+                    PubKeyCert
+            _ <-
+                certify
+                    ( ConwayTxCertDeleg $
+                        ConwayRegDelegCert
+                            targetCredential
+                            (DelegVote (DRepKeyHash drepKey))
+                            stakeDeposit
+                    )
+                    PubKeyCert
+            _ <-
+                payTo
+                    targetBaseAddr
+                    (inject stakeOutputCoin)
+            _ <-
+                proposeTreasuryWithdrawal
+                    governanceDeposit
+                    returnAccount
+                    governanceAnchor
+                    (Map.singleton targetAccount withdrawalAmount)
+                    SNothing
+                    NoProposalScript
+            validTo (SlotNo 1_000_000)
+
+    rewardBefore <- rewardBalance provider targetAccount
+    build pp interpret eval [seed] [] genesisAddr prog
+        >>= \case
+            Left err ->
+                expectationFailure (show err)
+            Right tx -> do
+                let signed =
+                        addKeyWitness targetSignKey $
+                            addKeyWitness genesisSignKey tx
+                    setupTxId =
+                        txIdTx signed
+                submitTx submitter signed
+                    >>= \case
+                        Submitted _ -> pure ()
+                        Rejected reason ->
+                            expectationFailure $
+                                "submitTx rejected: "
+                                    <> show reason
+                waitForTxChange provider setupTxId genesisAddr 60
+                setupSnapshot <- queryLedgerSnapshot provider
+                waitForEpochAfter
+                    provider
+                    (ledgerEpoch setupSnapshot)
+                    60
+                voteUtxos <-
+                    waitForUtxos provider targetBaseAddr 60
+                voteSeed <- case voteUtxos of
+                    u : _ -> pure u
+                    [] -> fail "target base UTxO disappeared"
+                let actionId =
+                        GovActionId setupTxId (GovActionIx 0)
+                submitVote
+                    provider
+                    submitter
+                    pp
+                    targetBaseAddr
+                    voteSeed
+                    drepCredential
+                    actionId
+                voteSnapshot <- queryLedgerSnapshot provider
+                rewardAfter <-
+                    waitForRewardIncrease
+                        provider
+                        targetAccount
+                        (ledgerEpoch voteSnapshot)
+                        rewardBefore
+                        withdrawalAmount
+                        180
+                rewardAfter `shouldBe` addCoin rewardBefore withdrawalAmount
+
+submitVote ::
+    Provider IO ->
+    Submitter IO ->
+    PParams ConwayEra ->
+    Addr ->
+    (TxIn, TxOut ConwayEra) ->
+    Credential DRepRole ->
+    GovActionId ->
+    IO ()
+submitVote
+    provider
+    submitter
+    pp
+    targetBaseAddr
+    seed@(seedIn, _)
+    drepCredential
+    actionId = do
+        let interpret :: InterpretIO NoCtx
+            interpret =
+                InterpretIO $ \case {}
+            eval tx =
+                fmap
+                    (Map.map (either (Left . show) Right))
+                    (evaluateTx provider tx)
+            prog :: TxBuild NoCtx Void ()
+            prog = do
+                _ <- spend seedIn
+                vote
+                    (DRepVoter drepCredential)
+                    actionId
+                    VoteYes
+                    SNothing
+                validTo (SlotNo 1_000_000)
+        build
+            pp
+            interpret
+            eval
+            [seed]
+            []
+            targetBaseAddr
+            prog
+            >>= \case
+                Left err ->
+                    expectationFailure (show err)
+                Right tx -> do
+                    let signed =
+                            addKeyWitness targetSignKey tx
+                        txId =
+                            txIdTx signed
+                    submitTx submitter signed
+                        >>= \case
+                            Submitted _ -> pure ()
+                            Rejected reason ->
+                                expectationFailure $
+                                    "submitVote rejected: "
+                                        <> show reason
+                    waitForTxChange provider txId targetBaseAddr 60
+
+governanceAnchor :: Anchor
+governanceAnchor =
+    Anchor
+        ( fromJust $
+            textToUrl
+                128
+                "https://example.invalid/devnet-governance-smoke.json"
+        )
+        (unsafeMakeSafeHash (mkHash32 42))
+
+rewardAccountFromSignKey ::
+    SignKeyDSIGN Ed25519DSIGN ->
+    AccountAddress
+rewardAccountFromSignKey sk =
+    AccountAddress
+        Testnet
+        (AccountId (stakeCredentialFromSignKey sk))
+
+stakeCredentialFromSignKey ::
+    SignKeyDSIGN Ed25519DSIGN ->
+    Credential Staking
+stakeCredentialFromSignKey =
+    KeyHashObj . stakeKeyHashFromSignKey
+
+stakeKeyHashFromSignKey ::
+    SignKeyDSIGN Ed25519DSIGN ->
+    KeyHash Staking
+stakeKeyHashFromSignKey =
+    hashKey
+        . VKey
+        . deriveVerKeyDSIGN
+
+drepCredentialFromSignKey ::
+    SignKeyDSIGN Ed25519DSIGN ->
+    Credential DRepRole
+drepCredentialFromSignKey =
+    KeyHashObj . drepKeyHashFromSignKey
+
+drepKeyHashFromSignKey ::
+    SignKeyDSIGN Ed25519DSIGN ->
+    KeyHash DRepRole
+drepKeyHashFromSignKey =
+    hashKey
+        . VKey
+        . deriveVerKeyDSIGN
+
+paymentKeyHashFromSignKey ::
+    SignKeyDSIGN Ed25519DSIGN ->
+    KeyHash Payment
+paymentKeyHashFromSignKey =
+    hashKey
+        . VKey
+        . deriveVerKeyDSIGN
+
+baseAddrFromSignKey ::
+    SignKeyDSIGN Ed25519DSIGN ->
+    Credential Staking ->
+    Addr
+baseAddrFromSignKey sk stakeCredential =
+    Addr
+        Testnet
+        (KeyHashObj (paymentKeyHashFromSignKey sk))
+        (StakeRefBase stakeCredential)
+
+rewardBalance ::
+    Provider IO ->
+    AccountAddress ->
+    IO Coin
+rewardBalance provider account =
+    Map.findWithDefault (Coin 0) account
+        <$> queryRewardAccounts provider (Set.singleton account)
+
+waitForTreasury ::
+    Provider IO ->
+    Coin ->
+    Int ->
+    IO Coin
+waitForTreasury _ minimumCoin attempts
+    | attempts <= 0 =
+        expectationFailure
+            ( "timed out waiting for treasury >= "
+                <> show minimumCoin
+            )
+            >> pure (Coin 0)
+waitForTreasury provider minimumCoin attempts = do
+    treasury <- queryTreasury provider
+    if treasury >= minimumCoin
+        then pure treasury
+        else do
+            threadDelay 500_000
+            waitForTreasury provider minimumCoin (attempts - 1)
+
+waitForUtxos ::
+    Provider IO ->
+    Addr ->
+    Int ->
+    IO [(TxIn, TxOut ConwayEra)]
+waitForUtxos _ addr attempts
+    | attempts <= 0 =
+        expectationFailure
+            ("timed out waiting for UTxOs at " <> show addr)
+            >> pure []
+waitForUtxos provider addr attempts = do
+    utxos <- queryUTxOs provider addr
+    if null utxos
+        then do
+            threadDelay 500_000
+            waitForUtxos provider addr (attempts - 1)
+        else pure utxos
+
+waitForTxChange ::
+    Provider IO ->
+    TxId ->
+    Addr ->
+    Int ->
+    IO ()
+waitForTxChange _ txId _ attempts
+    | attempts <= 0 =
+        expectationFailure $
+            "timed out waiting for tx change output: " <> show txId
+waitForTxChange provider txId addr attempts = do
+    utxos <- queryUTxOs provider addr
+    if any (hasTxId txId . fst) utxos
+        then pure ()
+        else do
+            threadDelay 500_000
+            waitForTxChange provider txId addr (attempts - 1)
+
+waitForEpochAfter ::
+    Provider IO ->
+    EpochNo ->
+    Int ->
+    IO ()
+waitForEpochAfter _ epoch attempts
+    | attempts <= 0 =
+        expectationFailure
+            ("timed out waiting for epoch after " <> show epoch)
+waitForEpochAfter provider epoch attempts = do
+    snapshot <- queryLedgerSnapshot provider
+    if epochNumber (ledgerEpoch snapshot) > epochNumber epoch
+        then pure ()
+        else do
+            threadDelay 500_000
+            waitForEpochAfter provider epoch (attempts - 1)
+
+waitForRewardIncrease ::
+    Provider IO ->
+    AccountAddress ->
+    EpochNo ->
+    Coin ->
+    Coin ->
+    Int ->
+    IO Coin
+waitForRewardIncrease _ account _ _ expected attempts
+    | attempts <= 0 =
+        expectationFailure
+            ( "timed out waiting for treasury withdrawal at "
+                <> show account
+                <> " to increase by "
+                <> show expected
+            )
+            >> pure (Coin 0)
+waitForRewardIncrease
+    provider
+    account
+    submittedEpoch
+    before
+    expected
+    attempts = do
+        snapshot <- queryLedgerSnapshot provider
+        after <- rewardBalance provider account
+        if epochNumber (ledgerEpoch snapshot)
+            > epochNumber submittedEpoch
+            && after == addCoin before expected
+            then pure after
+            else do
+                threadDelay 500_000
+                waitForRewardIncrease
+                    provider
+                    account
+                    submittedEpoch
+                    before
+                    expected
+                    (attempts - 1)
+
+hasTxId :: TxId -> TxIn -> Bool
+hasTxId txId (TxIn utxoTxId _) =
+    txId == utxoTxId
+
+addCoin :: Coin -> Coin -> Coin
+addCoin (Coin a) (Coin b) =
+    Coin (a + b)
+
+epochNumber :: EpochNo -> Word64
+epochNumber (EpochNo epoch) =
+    epoch
+
+withGovernanceGenesis :: (FilePath -> IO a) -> IO a
+withGovernanceGenesis action = do
+    source <- genesisDir
+    withSystemTempDirectory "cardano-governance-genesis" $
+        \dir -> do
+            copyGenesisSource source dir
+            patchGenesis dir
+            action dir
+
+copyGenesisSource :: FilePath -> FilePath -> IO ()
+copyGenesisSource source target = do
+    createDirectoryIfMissing True target
+    createDirectoryIfMissing True (target </> "delegate-keys")
+    traverse_
+        copyGenesisFile
+        [ "alonzo-genesis.json"
+        , "byron-genesis.json"
+        , "conway-genesis.json"
+        , "dijkstra-genesis.json"
+        , "node-config.json"
+        , "shelley-genesis.json"
+        , "topology.json"
+        ]
+    traverse_
+        copyDelegateKey
+        [ "delegate1.kes.skey"
+        , "delegate1.opcert"
+        , "delegate1.vrf.skey"
+        ]
+  where
+    copyGenesisFile name =
+        copyFile (source </> name) (target </> name)
+    copyDelegateKey name =
+        copyFile
+            (source </> "delegate-keys" </> name)
+            (target </> "delegate-keys" </> name)
+
+patchGenesis :: FilePath -> IO ()
+patchGenesis dir = do
+    patchFile
+        (dir </> "shelley-genesis.json")
+        [ ("\"epochLength\": 500", "\"epochLength\": 50")
+        ,
+            ( "\"maxLovelaceSupply\": 30000000000000000"
+            , "\"maxLovelaceSupply\": 60000000000000000"
+            )
+        ]
+    patchFile
+        (dir </> "conway-genesis.json")
+        [ ("\"treasuryWithdrawal\": 0.67", "\"treasuryWithdrawal\": 0.0")
+        , ("\"committeeMinSize\": 7", "\"committeeMinSize\": 0")
+        ,
+            ( "\"committee\": {\n    \"members\": {\n    },\n    \"threshold\": 0.67\n  }"
+            , "\"committee\": {\n    \"members\": {\n      \"keyHash-4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a\": 100000\n    },\n    \"threshold\": 0.0\n  }"
+            )
+        ,
+            ( "\"dRepDeposit\": 500000000"
+            , "\"dRepDeposit\": 500000"
+            )
+        ,
+            ( "\"govActionDeposit\": 50000000000"
+            , "\"govActionDeposit\": 1000000"
+            )
+        ]
+
+patchFile ::
+    FilePath ->
+    [(BS.ByteString, BS.ByteString)] ->
+    IO ()
+patchFile path replacements = do
+    content <- BS.readFile path
+    BS.writeFile path $
+        foldl'
+            ( \bytes (needle, replacement) ->
+                replaceRequired needle replacement bytes
+            )
+            content
+            replacements
+
+replaceRequired ::
+    BS.ByteString ->
+    BS.ByteString ->
+    BS.ByteString ->
+    BS.ByteString
+replaceRequired needle replacement content =
+    let (before, after) =
+            BS.breakSubstring needle content
+     in if BS.null after
+            then
+                error $
+                    "governance smoke genesis patch did not find "
+                        <> BS8.unpack needle
+            else
+                before
+                    <> replacement
+                    <> BS.drop (BS.length needle) after
+
+mkHash32 ::
+    (HashAlgorithm h) => Word8 -> Hash h a
+mkHash32 n =
+    fromJust $
+        hashFromBytes $
+            BS.pack $
+                replicate 31 0 ++ [n]

--- a/test/Cardano/Node/Client/E2E/ProviderSpec.hs
+++ b/test/Cardano/Node/Client/E2E/ProviderSpec.hs
@@ -8,20 +8,38 @@ License     : Apache-2.0
 -}
 module Cardano.Node.Client.E2E.ProviderSpec (spec) where
 
+import Control.Exception qualified as Exception
+import Control.Monad (void)
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
+import Data.Text qualified as T
+import Data.Word (Word64, Word8)
 import Lens.Micro ((^.))
+import System.Timeout (timeout)
 import Test.Hspec (
     Spec,
     around,
     describe,
+    expectationFailure,
     it,
     shouldBe,
     shouldSatisfy,
  )
 
+import Cardano.Ledger.Address (AccountAddress)
 import Cardano.Ledger.Api.PParams (ppMaxTxSizeL)
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Credential (Credential)
+import Cardano.Ledger.DRep (DRep)
+import Cardano.Ledger.Keys (KeyRole (Staking))
 
+import Cardano.Node.Client.Address (
+    rewardAccountCredential,
+ )
+import Cardano.Node.Client.ConwayFixtures (
+    mkRewardAccount,
+    mkScriptRewardAccount,
+ )
 import Cardano.Node.Client.E2E.Setup (
     genesisAddr,
     withDevnet,
@@ -30,44 +48,198 @@ import Cardano.Node.Client.N2C.Provider (
     mkN2CProvider,
  )
 import Cardano.Node.Client.Provider (
+    EpochNo (..),
+    LedgerSnapshot (..),
     Provider (..),
+    SlotNo (..),
+    queryGovernanceStateH,
+    queryLedgerSnapshotH,
     queryProtocolParamsH,
+    queryRewardAccountsH,
+    queryStakeRewardsH,
+    queryTreasuryH,
     queryUTxOByTxInH,
     queryUTxOsAtH,
+    queryVoteDelegateesH,
  )
 
 spec :: Spec
 spec =
     around withDevnet' $
-        describe "Provider.N2C" $
-            do
-                it "queryProtocolParams returns valid PParams" $
-                    \(lsq, _) -> do
-                        let provider =
-                                mkN2CProvider lsq
-                        pp <-
+        describe "Provider.N2C" $ do
+            it "queryProtocolParams returns valid PParams" $
+                \(lsq, _) -> do
+                    let provider =
+                            mkN2CProvider lsq
+                    pp <-
+                        expectWithin "queryProtocolParams" $
                             queryProtocolParams provider
-                        let maxTxSize =
-                                pp ^. ppMaxTxSizeL
-                        maxTxSize
-                            `shouldSatisfy` (> 0)
+                    let maxTxSize =
+                            pp ^. ppMaxTxSizeL
+                    maxTxSize
+                        `shouldSatisfy` (> 0)
 
-                it "queryUTxOs returns genesis funds" $
-                    \(lsq, _) -> do
-                        let provider =
-                                mkN2CProvider lsq
-                        utxos <-
+            it "queryUTxOs returns genesis funds" $
+                \(lsq, _) -> do
+                    let provider =
+                            mkN2CProvider lsq
+                    utxos <-
+                        expectWithin "queryUTxOs" $
                             queryUTxOs
                                 provider
                                 genesisAddr
-                        utxos
-                            `shouldSatisfy` (not . null)
+                    utxos
+                        `shouldSatisfy` (not . null)
 
-                it "withAcquired serves multiple queries through one handle" $
-                    \(lsq, _) -> do
-                        let provider =
-                                mkN2CProvider lsq
-                        (maxTxSize, byAddr, byTxIn) <-
+            it "queries ledger position through LSQ" $
+                \(lsq, _) -> do
+                    let provider =
+                            mkN2CProvider lsq
+                    snapshot <-
+                        expectWithin "queryLedgerSnapshot" $
+                            queryLedgerSnapshot provider
+                    assertLedgerSnapshot snapshot
+
+            it "queries treasury through LSQ" $
+                \(lsq, _) -> do
+                    let provider =
+                            mkN2CProvider lsq
+                    treasury <-
+                        expectWithin "queryTreasury" $
+                            queryTreasury provider
+                    treasury
+                        `shouldSatisfy` (>= Coin 0)
+
+            it "queries governance state through LSQ" $
+                \(lsq, _) -> do
+                    let provider =
+                            mkN2CProvider lsq
+                    govState <-
+                        expectWithin "queryGovernanceState" $
+                            queryGovernanceState provider
+                    void $ Exception.evaluate govState
+
+            it "queries reward balances and vote delegatees through LSQ" $
+                \(lsq, _) -> do
+                    let provider =
+                            mkN2CProvider lsq
+                        accounts =
+                            sampleAccounts 11 12
+                        credentials =
+                            accountCredentials accounts
+                    rewardBalances <-
+                        expectWithin "queryRewardAccounts" $
+                            queryRewardAccounts
+                                provider
+                                accounts
+                    stakeRewards <-
+                        expectWithin "queryStakeRewards" $
+                            queryStakeRewards
+                                provider
+                                credentials
+                    voteDelegatees <-
+                        expectWithin "queryVoteDelegatees" $
+                            queryVoteDelegatees
+                                provider
+                                credentials
+                    assertRewardGroup
+                        accounts
+                        credentials
+                        rewardBalances
+                        stakeRewards
+                        voteDelegatees
+
+            it "groups UTxO queries in one acquired LSQ session" $
+                \(lsq, _) -> do
+                    let provider =
+                            mkN2CProvider lsq
+                    (byAddr, byTxIn) <-
+                        expectWithin "withAcquired UTxO group" $
+                            withAcquired provider $ \handle -> do
+                                utxosAt <-
+                                    queryUTxOsAtH
+                                        handle
+                                        (Set.singleton genesisAddr)
+                                let txIns =
+                                        firstTxInsAt genesisAddr utxosAt
+                                utxosByTxIn <-
+                                    queryUTxOByTxInH
+                                        handle
+                                        txIns
+                                pure (utxosAt, utxosByTxIn)
+                    let addrUtxos =
+                            Map.findWithDefault
+                                []
+                                genesisAddr
+                                byAddr
+                        txIns =
+                            Set.fromList $
+                                take 1 $
+                                    fmap fst addrUtxos
+                    addrUtxos
+                        `shouldSatisfy` (not . null)
+                    Map.keysSet byTxIn
+                        `shouldBe` txIns
+
+            it "groups ledger/account queries in one acquired LSQ session" $
+                \(lsq, _) -> do
+                    let provider =
+                            mkN2CProvider lsq
+                        accounts =
+                            sampleAccounts 21 22
+                        credentials =
+                            accountCredentials accounts
+                    (snapshot, treasury, govState, rewards, votes) <-
+                        expectWithin "withAcquired ledger/account group" $
+                            withAcquired provider $ \handle -> do
+                                ledgerSnapshot <-
+                                    queryLedgerSnapshotH handle
+                                treasuryValue <-
+                                    queryTreasuryH handle
+                                governanceState <-
+                                    queryGovernanceStateH handle
+                                rewardBalances <-
+                                    queryRewardAccountsH
+                                        handle
+                                        accounts
+                                voteDelegatees <-
+                                    queryVoteDelegateesH
+                                        handle
+                                        credentials
+                                pure
+                                    ( ledgerSnapshot
+                                    , treasuryValue
+                                    , governanceState
+                                    , rewardBalances
+                                    , voteDelegatees
+                                    )
+                    assertLedgerSnapshot snapshot
+                    treasury
+                        `shouldSatisfy` (>= Coin 0)
+                    void $ Exception.evaluate govState
+                    Map.keysSet rewards
+                        `shouldSatisfy` (`Set.isSubsetOf` accounts)
+                    Map.keysSet votes
+                        `shouldSatisfy` (`Set.isSubsetOf` credentials)
+
+            it "combines devnet query families without cardano-cli" $
+                \(lsq, _) -> do
+                    let provider =
+                            mkN2CProvider lsq
+                        accounts =
+                            sampleAccounts 31 32
+                        credentials =
+                            accountCredentials accounts
+                    ( maxTxSize
+                        , byAddr
+                        , byTxIn
+                        , snapshot
+                        , treasury
+                        , rewardBalances
+                        , stakeRewards
+                        , voteDelegatees
+                        ) <-
+                        expectWithin "withAcquired combined query group" $
                             withAcquired provider $ \handle -> do
                                 pp <-
                                     queryProtocolParamsH handle
@@ -76,39 +248,135 @@ spec =
                                         handle
                                         (Set.singleton genesisAddr)
                                 let txIns =
-                                        Set.fromList $
-                                            take
-                                                1
-                                                ( fst
-                                                    <$> Map.findWithDefault
-                                                        []
-                                                        genesisAddr
-                                                        utxosAt
-                                                )
+                                        firstTxInsAt genesisAddr utxosAt
                                 utxosByTxIn <-
                                     queryUTxOByTxInH
                                         handle
                                         txIns
+                                ledgerSnapshot <-
+                                    queryLedgerSnapshotH handle
+                                treasuryValue <-
+                                    queryTreasuryH handle
+                                rewards <-
+                                    queryRewardAccountsH
+                                        handle
+                                        accounts
+                                stakeRewardBalances <-
+                                    queryStakeRewardsH
+                                        handle
+                                        credentials
+                                votes <-
+                                    queryVoteDelegateesH
+                                        handle
+                                        credentials
                                 pure
                                     ( pp ^. ppMaxTxSizeL
                                     , utxosAt
                                     , utxosByTxIn
+                                    , ledgerSnapshot
+                                    , treasuryValue
+                                    , rewards
+                                    , stakeRewardBalances
+                                    , votes
                                     )
-                        let addrUtxos =
-                                Map.findWithDefault
-                                    []
-                                    genesisAddr
-                                    byAddr
-                            txIns =
-                                Set.fromList $
-                                    take 1 $
-                                        fmap fst addrUtxos
-                        maxTxSize
-                            `shouldSatisfy` (> 0)
-                        addrUtxos
-                            `shouldSatisfy` (not . null)
-                        Map.keysSet byTxIn
-                            `shouldBe` txIns
+                    let addrUtxos =
+                            Map.findWithDefault
+                                []
+                                genesisAddr
+                                byAddr
+                        txIns =
+                            Set.fromList $
+                                take 1 $
+                                    fmap fst addrUtxos
+                    maxTxSize
+                        `shouldSatisfy` (> 0)
+                    addrUtxos
+                        `shouldSatisfy` (not . null)
+                    Map.keysSet byTxIn
+                        `shouldBe` txIns
+                    assertLedgerSnapshot snapshot
+                    treasury
+                        `shouldSatisfy` (>= Coin 0)
+                    assertRewardGroup
+                        accounts
+                        credentials
+                        rewardBalances
+                        stakeRewards
+                        voteDelegatees
   where
     withDevnet' action =
         withDevnet $ curry action
+
+sampleAccounts :: Word8 -> Word8 -> Set.Set AccountAddress
+sampleAccounts keyAccount scriptAccount =
+    Set.fromList
+        [ mkRewardAccount keyAccount
+        , mkScriptRewardAccount scriptAccount
+        ]
+
+accountCredentials ::
+    Set.Set AccountAddress ->
+    Set.Set (Credential Staking)
+accountCredentials =
+    Set.map rewardAccountCredential
+
+expectWithin :: String -> IO a -> IO a
+expectWithin label action = do
+    result <-
+        timeout 30000000 action
+    case result of
+        Just value ->
+            pure value
+        Nothing ->
+            expectationFailure message >> fail message
+  where
+    message =
+        label <> " timed out after 30 seconds"
+
+assertLedgerSnapshot :: LedgerSnapshot -> IO ()
+assertLedgerSnapshot snapshot = do
+    ledgerCurrentEra snapshot
+        `shouldSatisfy` T.isInfixOf "Conway"
+    slotNumber (ledgerTipSlot snapshot)
+        `shouldSatisfy` (>= 0)
+    epochNumber (ledgerEpoch snapshot)
+        `shouldSatisfy` (>= 0)
+
+assertRewardGroup ::
+    Set.Set AccountAddress ->
+    Set.Set (Credential Staking) ->
+    Map.Map AccountAddress Coin ->
+    Map.Map (Credential Staking) Coin ->
+    Map.Map (Credential Staking) DRep ->
+    IO ()
+assertRewardGroup accounts credentials rewardBalances stakeRewards votes = do
+    Map.keysSet rewardBalances
+        `shouldSatisfy` (`Set.isSubsetOf` accounts)
+    Map.keysSet stakeRewards
+        `shouldSatisfy` (`Set.isSubsetOf` credentials)
+    Map.keysSet votes
+        `shouldSatisfy` (`Set.isSubsetOf` credentials)
+
+firstTxInsAt ::
+    (Ord addr, Ord txIn) =>
+    addr ->
+    Map.Map addr [(txIn, txOut)] ->
+    Set.Set txIn
+firstTxInsAt addr utxosAt =
+    Set.fromList $
+        take
+            1
+            ( fst
+                <$> Map.findWithDefault
+                    []
+                    addr
+                    utxosAt
+            )
+
+slotNumber :: SlotNo -> Word64
+slotNumber (SlotNo slot) =
+    slot
+
+epochNumber :: EpochNo -> Word64
+epochNumber (EpochNo epoch) =
+    epoch

--- a/test/Cardano/Node/Client/TxBuildPublicApiSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildPublicApiSpec.hs
@@ -47,6 +47,14 @@ _proposeTreasuryWithdrawal ::
     TxBuild q e Word32
 _proposeTreasuryWithdrawal = proposeTreasuryWithdrawal
 
+_vote ::
+    Voter ->
+    GovActionId ->
+    Vote ->
+    StrictMaybe Anchor ->
+    TxBuild q e ()
+_vote = vote
+
 _pubKeyCertWitness :: CertWitness
 _pubKeyCertWitness = PubKeyCert
 

--- a/test/Cardano/Node/Client/TxBuildSpec.hs
+++ b/test/Cardano/Node/Client/TxBuildSpec.hs
@@ -140,6 +140,7 @@ import Cardano.Node.Client.ConwayFixtures qualified as ConwayFixtures
 import Cardano.Node.Client.Evaluate (evaluateAndBalance)
 import Cardano.Node.Client.Ledger (ConwayTx)
 import Cardano.Node.Client.Provider (
+    LedgerSnapshot (..),
     Provider (..),
     singleShotWithAcquired,
  )
@@ -160,7 +161,7 @@ import Cardano.Node.Client.TxBuild hiding (
     ScriptHash (..),
     StrictMaybe (..),
  )
-import Cardano.Slotting.Slot (SlotNo (..))
+import Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
 import Lens.Micro ((&), (.~), (^.))
 import PlutusCore.Data qualified as PLC
 
@@ -2062,6 +2063,33 @@ outputCountingProvider pp perOutput =
             , queryUTxOs = const (pure [])
             , queryUTxOByTxIn = const (pure Map.empty)
             , queryProtocolParams = pure pp
+            , queryLedgerSnapshot =
+                pure
+                    LedgerSnapshot
+                        { ledgerCurrentEra =
+                            T.pack "Conway"
+                        , ledgerChainPoint =
+                            error
+                                "outputCountingProvider: \
+                                \ledgerChainPoint unused"
+                        , ledgerTipSlot =
+                            SlotNo 0
+                        , ledgerEpoch =
+                            EpochNo 0
+                        }
+            , queryStakeRewards = \_ ->
+                pure Map.empty
+            , queryRewardAccounts = \_ ->
+                pure Map.empty
+            , queryVoteDelegatees = \_ ->
+                pure Map.empty
+            , queryTreasury =
+                pure (Coin 0)
+            , queryGovernanceState =
+                pure $
+                    error
+                        "outputCountingProvider: \
+                        \governanceState unused"
             , evaluateTx =
                 pure
                     . Map.singleton

--- a/test/Cardano/Node/Client/TxGenerator/SelectionSpec.hs
+++ b/test/Cardano/Node/Client/TxGenerator/SelectionSpec.hs
@@ -312,6 +312,18 @@ stubProvider tip =
             , queryUTxOByTxIn = pure . Map.restrictKeys tip
             , queryProtocolParams =
                 pure (unused "queryProtocolParams")
+            , queryLedgerSnapshot =
+                pure (unused "queryLedgerSnapshot")
+            , queryStakeRewards = \_ ->
+                pure (unused "queryStakeRewards")
+            , queryRewardAccounts = \_ ->
+                pure (unused "queryRewardAccounts")
+            , queryVoteDelegatees = \_ ->
+                pure (unused "queryVoteDelegatees")
+            , queryTreasury =
+                pure (unused "queryTreasury")
+            , queryGovernanceState =
+                pure (unused "queryGovernanceState")
             , evaluateTx = \_ ->
                 pure (unused "evaluateTx")
             , posixMsToSlot = \_ ->

--- a/test/main.hs
+++ b/test/main.hs
@@ -5,6 +5,7 @@ import Test.Hspec (hspec)
 import Cardano.Node.Client.E2E.BalanceSpec qualified as BalanceSpec
 import Cardano.Node.Client.E2E.ChainPopulatorSpec qualified as ChainPopulatorSpec
 import Cardano.Node.Client.E2E.ChainSyncSpec qualified as ChainSyncSpec
+import Cardano.Node.Client.E2E.GovernanceSmokeSpec qualified as GovernanceSmokeSpec
 import Cardano.Node.Client.E2E.HorizonSpec qualified as HorizonSpec
 import Cardano.Node.Client.E2E.Issue97ReproSpec qualified as Issue97ReproSpec
 import Cardano.Node.Client.E2E.MultiAssetChangeSpec qualified as MultiAssetChangeSpec
@@ -26,6 +27,7 @@ import Cardano.Node.Client.E2E.UTxOIndexerSpec qualified as UTxOIndexerSpec
 main :: IO ()
 main = hspec $ do
     ProviderSpec.spec
+    GovernanceSmokeSpec.spec
     BalanceSpec.spec
     TxBuildSpec.spec
     MultiAssetChangeSpec.spec

--- a/test/unit-main.hs
+++ b/test/unit-main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Test.Hspec (hspec)
 
+import Cardano.Node.Client.AddressSpec qualified as AddressSpec
 import Cardano.Node.Client.BalanceSpec qualified as BalanceSpec
 import Cardano.Node.Client.N2C.ProbeSpec qualified as N2CProbeSpec
 import Cardano.Node.Client.N2C.TraceSpec qualified as N2CTraceSpec
@@ -23,6 +24,7 @@ import Data.List.SampleFibonacciSpec qualified as SampleFibonacciSpec
 
 main :: IO ()
 main = hspec $ do
+    AddressSpec.spec
     SampleFibonacciSpec.spec
     BalanceSpec.spec
     TxBuildSpec.spec


### PR DESCRIPTION
## Summary
- record and implement the downstream story: submit a treasury-withdrawal governance action on DevNet, vote it through, wait for the next epoch, and observe the target reward account funding
- add typed address/reward-account helpers and live Conway LSQ queries for ledger snapshot, rewards, vote-delegatees, treasury, and governance state
- fix the TxBuild builder path needed by the smoke: Conway voting procedures, certificate/proposal deposit accounting, and key-witness fee estimation
- keep `Balance` as the public facade while factoring balance concepts into `Inputs`, `Scripts`, `Credentials`, `Witnesses`, and `Deposits`

## Commit structure
- `docs(spec): state devnet governance reward proof`
- `feat(address): add typed reward-account helpers`
- `feat(provider): add live Conway LSQ queries`
- `feat(tx-build): support Conway governance voting`
- `test(e2e): prove DevNet treasury withdrawal rewards`
- `refactor(balance): extract input indexing`
- `refactor(balance): extract script helpers`
- `refactor(balance): extract credential helpers`
- `refactor(balance): extract witness counting`
- `refactor(balance): extract deposit accounting`

## Stack
- Base: #132 / `feat/conway-stake-treasury-withdrawal`
- Includes lower stack #135, now merged into the base branch
- Issue: #131
- Downstream governance smoke ticket: https://github.com/lambdasistemi/amaru-treasury-tx/issues/82

## Verification
- `nix develop --quiet -c just ci` exited 0 after rebasing onto #135 / `feat/conway-stake-treasury-withdrawal`
- Full e2e: 35 examples, 0 failures, including `DevNet governance smoke`
- Unit tests: 244 examples, 0 failures
- Tx-build tests: 37 examples, 0 failures
- `cabal-fmt -c`, `fourmolu -m check`, and `hlint` passed; hlint reported `No hints`
- Existing tx-generator restart cases still print the known broken-pipe log noise while their assertions pass