### PR TITLE
feat(tx-diff): add tree render modes

### DIFF
--- a/app/tx-diff/Main.hs
+++ b/app/tx-diff/Main.hs
@@ -14,12 +14,18 @@ import Cardano.Node.Client.TxDiff (
     defaultTxDiffOptions,
     diffConwayTxInputWith,
     diffNodeHasChanges,
-    renderDiffNodeHuman,
+    renderDiffNodeHumanWith,
  )
 import Cardano.Node.Client.TxDiff.Blueprint (
     Blueprint,
     blueprintDataDecoder,
     parseBlueprintJSON,
+ )
+import Cardano.Node.Client.TxDiff.Cli (
+    TxDiffCliError (..),
+    TxDiffCliOptions (..),
+    parseTxDiffCliArgs,
+    txDiffCliUsage,
  )
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
@@ -28,36 +34,14 @@ import System.Environment (getArgs, getProgName)
 import System.Exit (exitFailure, exitSuccess)
 import System.IO (hPutStrLn, stderr)
 
-data CliOptions = CliOptions
-    { cliBlueprintPaths :: [FilePath]
-    , cliLeftPath :: FilePath
-    , cliRightPath :: FilePath
-    }
-
 main :: IO ()
 main = do
     args <- getArgs
-    maybe dieUsage runDiff (parseArgs args)
+    either dieUsage runDiff (parseTxDiffCliArgs args)
 
-parseArgs :: [String] -> Maybe CliOptions
-parseArgs =
-    go []
-  where
-    go blueprintPaths ("--blueprint" : blueprintPath : rest) =
-        go (blueprintPath : blueprintPaths) rest
-    go blueprintPaths [leftPath, rightPath] =
-        Just
-            CliOptions
-                { cliBlueprintPaths = reverse blueprintPaths
-                , cliLeftPath = leftPath
-                , cliRightPath = rightPath
-                }
-    go _ _ =
-        Nothing
-
-runDiff :: CliOptions -> IO ()
+runDiff :: TxDiffCliOptions -> IO ()
 runDiff cliOptions = do
-    blueprints <- traverse loadBlueprint (cliBlueprintPaths cliOptions)
+    blueprints <- traverse loadBlueprint (txDiffCliBlueprintPaths cliOptions)
     left <- BS.readFile leftPath
     right <- BS.readFile rightPath
     let options =
@@ -74,15 +58,18 @@ runDiff cliOptions = do
             hPutStrLn stderr ("tx-diff: failed to decode input: " <> show err)
             exitFailure
         Right diff -> do
-            TextIO.putStr (renderDiffNodeHuman diff)
+            TextIO.putStr $
+                renderDiffNodeHumanWith
+                    (txDiffCliHumanRenderOptions cliOptions)
+                    diff
             if diffNodeHasChanges diff
                 then exitFailure
                 else exitSuccess
   where
     leftPath =
-        cliLeftPath cliOptions
+        txDiffCliLeftPath cliOptions
     rightPath =
-        cliRightPath cliOptions
+        txDiffCliRightPath cliOptions
 
 loadBlueprint :: FilePath -> IO Blueprint
 loadBlueprint blueprintPath = do
@@ -96,8 +83,9 @@ loadBlueprint blueprintPath = do
         Right blueprint ->
             pure blueprint
 
-dieUsage :: IO a
-dieUsage = do
+dieUsage :: TxDiffCliError -> IO a
+dieUsage (TxDiffCliUsageError err) = do
     prog <- getProgName
-    hPutStrLn stderr $ "Usage: " <> prog <> " [--blueprint FILE ...] TX_A TX_B"
+    hPutStrLn stderr ("tx-diff: " <> err)
+    hPutStrLn stderr (txDiffCliUsage prog)
     exitFailure

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -94,6 +94,7 @@ library
     Cardano.Node.Client.SampleList
     Cardano.Node.Client.Submitter
     Cardano.Node.Client.TxDiff
+    Cardano.Node.Client.TxDiff.Cli
     Cardano.Node.Client.TxGenerator.Build
     Cardano.Node.Client.TxGenerator.Daemon
     Cardano.Node.Client.TxGenerator.Fanout
@@ -170,6 +171,7 @@ library
     , text
     , time
     , transformers
+    , tree-view
     , typed-protocols
     , unix
 
@@ -304,6 +306,7 @@ test-suite unit-tests
     Cardano.Node.Client.TxBuildGoldenSpec
     Cardano.Node.Client.TxBuildSpec
     Cardano.Node.Client.TxDiff.BlueprintSpec
+    Cardano.Node.Client.TxDiff.CliSpec
     Cardano.Node.Client.TxDiff.ConwaySpec
     Cardano.Node.Client.TxDiff.CoreSpec
     Cardano.Node.Client.TxDiffSpec

--- a/lib/Cardano/Node/Client/TxDiff.hs
+++ b/lib/Cardano/Node/Client/TxDiff.hs
@@ -14,12 +14,16 @@ module Cardano.Node.Client.TxDiff (
     DiffPlan (..),
     DiffPath (..),
     DiffProjection (..),
+    HumanRenderOptions (..),
     OpenValue (..),
+    RenderShape (..),
     TxDiffDataDecoder,
     TxDiffDataKind (..),
     TxDiffDataSelector (..),
     TxDiffOptions (..),
     TxInputDecodeError (..),
+    TreeArt (..),
+    defaultHumanRenderOptions,
     defaultTxDiffOptions,
     decodeConwayTxInput,
     diffConwayTxInput,
@@ -31,6 +35,7 @@ module Cardano.Node.Client.TxDiff (
     diffWith,
     renderConwayTxInputDiff,
     renderDiffNodeHuman,
+    renderDiffNodeHumanWith,
 ) where
 
 import Data.Aeson ((.:), (.=))
@@ -43,14 +48,17 @@ import Data.ByteString.Base16 qualified as Base16
 import Data.ByteString.Char8 qualified as BS8
 import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Short qualified as SBS
-import Data.Char (isHexDigit, isSpace)
+import Data.Char (isDigit, isHexDigit, isSpace)
 import Data.Foldable (toList)
+import Data.List qualified as List
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as TextEncoding
+import Data.Tree qualified as Tree
+import Data.Tree.View qualified as TreeView
 import Lens.Micro ((^.))
 import Text.Read (readMaybe)
 
@@ -65,7 +73,7 @@ import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
 import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..), TxDats (..))
 import Cardano.Ledger.Api.Scripts.Data (
-    Data,
+    Data (..),
     Datum (..),
     binaryDataToData,
  )
@@ -131,6 +139,7 @@ import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Cardano.Node.Client.Ledger (ConwayTx)
 import Cardano.Slotting.Slot (SlotNo (..))
+import PlutusCore.Data qualified as PLC
 
 newtype DiffPath = DiffPath [Text]
     deriving stock (Eq, Show)
@@ -207,6 +216,33 @@ defaultTxDiffOptions =
     TxDiffOptions
         { txDiffIncludeWitnesses = False
         , txDiffDecodeData = Nothing
+        }
+
+-- | Human diff render shape.
+data RenderShape
+    = RenderTree
+    | RenderPaths
+    deriving stock (Eq, Show)
+
+-- | Tree connector style for tree-shaped human output.
+data TreeArt
+    = TreeArtAscii
+    | TreeArtUnicode
+    deriving stock (Eq, Show)
+
+-- | Options for human-oriented diff rendering.
+data HumanRenderOptions = HumanRenderOptions
+    { humanRenderShape :: RenderShape
+    , humanTreeArt :: TreeArt
+    }
+    deriving stock (Eq, Show)
+
+-- | Default human renderer: grouped tree output with portable ASCII art.
+defaultHumanRenderOptions :: HumanRenderOptions
+defaultHumanRenderOptions =
+    HumanRenderOptions
+        { humanRenderShape = RenderTree
+        , humanTreeArt = TreeArtAscii
         }
 
 data ConwayDiffValue
@@ -461,7 +497,202 @@ objectValue fields =
 
 renderDiffNodeHuman :: DiffNode -> Text
 renderDiffNodeHuman =
-    Text.unlines . renderDiffNodeLines
+    renderDiffNodeHumanWith defaultHumanRenderOptions
+
+renderDiffNodeHumanWith :: HumanRenderOptions -> DiffNode -> Text
+renderDiffNodeHumanWith options diff =
+    case humanRenderShape options of
+        RenderPaths ->
+            Text.unlines (renderDiffNodeLines diff)
+        RenderTree ->
+            renderDiffNodeTree (humanTreeArt options) diff
+
+data RenderTrie = RenderTrie
+    { renderTrieLeaves :: [Tree.Tree Text]
+    , renderTrieChildren :: Map Text RenderTrie
+    }
+
+data RenderSegmentSortKey
+    = RenderSegmentNumber Integer Text
+    | RenderSegmentText Text
+    deriving stock (Eq, Ord, Show)
+
+emptyRenderTrie :: RenderTrie
+emptyRenderTrie =
+    RenderTrie
+        { renderTrieLeaves = []
+        , renderTrieChildren = Map.empty
+        }
+
+renderDiffNodeTree :: TreeArt -> DiffNode -> Text
+renderDiffNodeTree treeArt diff@(DiffNode _ change) =
+    case change of
+        DiffSame _ ->
+            Text.unlines (renderDiffNodeLines diff)
+        _ ->
+            renderForest treeArt $
+                renderTrieForest (collectDiffTree emptyRenderTrie diff)
+
+collectDiffTree :: RenderTrie -> DiffNode -> RenderTrie
+collectDiffTree trie (DiffNode path change) =
+    case change of
+        DiffSame _ ->
+            trie
+        DiffChanged left right ->
+            insertPath
+                (renderChangedPathSegments path left right)
+                []
+                trie
+        DiffObject _ changed onlyA onlyB ->
+            let withChanged =
+                    foldl' collectDiffTree trie (Map.elems changed)
+                withOnlyA =
+                    foldl'
+                        (insertObjectOnly "-" path)
+                        withChanged
+                        (Map.toAscList onlyA)
+             in foldl'
+                    (insertObjectOnly "+" path)
+                    withOnlyA
+                    (Map.toAscList onlyB)
+        DiffArray _ changed onlyA onlyB ->
+            let withChanged =
+                    foldl'
+                        collectDiffTree
+                        trie
+                        (map snd changed)
+                withOnlyA =
+                    foldl'
+                        (insertArrayOnly "-" path)
+                        withChanged
+                        onlyA
+             in foldl'
+                    (insertArrayOnly "+" path)
+                    withOnlyA
+                    onlyB
+
+insertObjectOnly ::
+    Text ->
+    DiffPath ->
+    RenderTrie ->
+    (Text, Aeson.Value) ->
+    RenderTrie
+insertObjectOnly prefix path trie (key, value) =
+    insertOnlyValue prefix (path </> key) value trie
+
+insertArrayOnly ::
+    Text ->
+    DiffPath ->
+    RenderTrie ->
+    (Int, Aeson.Value) ->
+    RenderTrie
+insertArrayOnly prefix path trie (index, value) =
+    insertOnlyValue prefix (path </> Text.pack (show index)) value trie
+
+insertOnlyValue :: Text -> DiffPath -> Aeson.Value -> RenderTrie -> RenderTrie
+insertOnlyValue prefix (DiffPath segments) value =
+    case reverse segments of
+        [] ->
+            insertPath
+                ["<root>"]
+                [Tree.Node (prefix <> " " <> renderJsonValue value) []]
+        key : parentSegments ->
+            insertPath
+                (reverse parentSegments)
+                [ Tree.Node
+                    ( prefix
+                        <> " "
+                        <> key
+                        <> ": "
+                        <> renderJsonValue value
+                    )
+                    []
+                ]
+
+insertPath :: [Text] -> [Tree.Tree Text] -> RenderTrie -> RenderTrie
+insertPath [] leaves trie =
+    trie
+        { renderTrieLeaves = renderTrieLeaves trie <> leaves
+        }
+insertPath (segment : segments) leaves trie =
+    let children =
+            renderTrieChildren trie
+        child =
+            Map.findWithDefault emptyRenderTrie segment children
+     in trie
+            { renderTrieChildren =
+                Map.insert segment (insertPath segments leaves child) children
+            }
+
+renderedPathSegments :: DiffPath -> [Text]
+renderedPathSegments (DiffPath []) =
+    ["<root>"]
+renderedPathSegments (DiffPath segments) =
+    segments
+
+renderTrieForest :: RenderTrie -> [Tree.Tree Text]
+renderTrieForest trie =
+    renderTrieLeaves trie
+        <> [ Tree.Node label (renderTrieForest child)
+           | (label, child) <-
+                List.sortOn
+                    (renderSegmentSortKey . fst)
+                    (Map.toList (renderTrieChildren trie))
+           ]
+
+renderForest :: TreeArt -> [Tree.Tree Text] -> Text
+renderForest treeArt forest =
+    case treeArt of
+        TreeArtAscii ->
+            Text.unlines (concatMap renderAsciiTree forest)
+        TreeArtUnicode ->
+            Text.pack $
+                concatMap (TreeView.showTree . fmap Text.unpack) forest
+
+renderAsciiTree :: Tree.Tree Text -> [Text]
+renderAsciiTree (Tree.Node label children) =
+    label : renderAsciiChildren "" children
+
+renderAsciiChildren :: Text -> [Tree.Tree Text] -> [Text]
+renderAsciiChildren prefix children =
+    concat
+        [ (prefix <> connector <> label)
+            : renderAsciiChildren (prefix <> extension) grandchildren
+        | (index, Tree.Node label grandchildren) <- zip [0 :: Int ..] children
+        , let isLast = index == length children - 1
+              connector =
+                if isLast then "`- " else "+- "
+              extension =
+                if isLast then "   " else "|  "
+        ]
+
+renderChangedPathSegments :: DiffPath -> Aeson.Value -> Aeson.Value -> [Text]
+renderChangedPathSegments path left right =
+    case reverse (renderedPathSegments path) of
+        [] ->
+            [changedLabel "<root>" left right]
+        key : parentSegments ->
+            reverse parentSegments <> [changedLabel key left right]
+
+changedLabel :: Text -> Aeson.Value -> Aeson.Value -> Text
+changedLabel key left right =
+    key
+        <> ": A: "
+        <> renderJsonValue left
+        <> " | B: "
+        <> renderJsonValue right
+
+renderSegmentSortKey :: Text -> RenderSegmentSortKey
+renderSegmentSortKey label =
+    case readMaybe (Text.unpack sortText) of
+        Just number
+            | not (Text.null sortText) && Text.all isDigit sortText ->
+                RenderSegmentNumber number label
+        _ ->
+            RenderSegmentText label
+  where
+    sortText =
+        Text.takeWhile (/= ':') label
 
 renderDiffNodeLines :: DiffNode -> [Text]
 renderDiffNodeLines (DiffNode path change) =
@@ -947,21 +1178,21 @@ dataDiffProjection ::
 dataDiffProjection options selector datum =
     case txDiffDecodeData options of
         Nothing ->
-            DiffAtomic (dataValue datum)
+            openValueDiffProjection (dataOpenValue datum)
         Just decodeData ->
             case decodeData selector datum of
                 Right value ->
                     openValueDiffProjection value
-                Left reason ->
-                    DiffAtomic (dataDecodeFallbackValue reason datum)
+                Left _ ->
+                    openValueDiffProjection (dataOpenValue datum)
 
 datumDiffProjection ::
     TxDiffOptions -> Datum ConwayEra -> DiffProjection ConwayDiffValue
 datumDiffProjection options datum =
-    case (txDiffDecodeData options, inlineDatumData datum) of
-        (Just _, Just datumData) ->
+    case inlineDatumData datum of
+        Just datumData ->
             dataDiffProjection options datumDataSelector datumData
-        _ ->
+        Nothing ->
             DiffAtomic (datumValue datum)
 
 inlineDatumData :: Datum ConwayEra -> Maybe (Data ConwayEra)
@@ -980,12 +1211,32 @@ openValueDiffProjection value =
         DiffArrayChildren values ->
             DiffArrayChildren (map ConwayOpenValue values)
 
-dataDecodeFallbackValue :: Text -> Data ConwayEra -> Aeson.Value
-dataDecodeFallbackValue reason datum =
-    Aeson.object
-        [ "fallback" .= reason
-        , "raw" .= dataValue datum
+dataOpenValue :: Data ConwayEra -> OpenValue
+dataOpenValue (Data value) =
+    plutusDataOpenValue value
+
+plutusDataOpenValue :: PLC.Data -> OpenValue
+plutusDataOpenValue (PLC.I integer) =
+    OpenInteger integer
+plutusDataOpenValue (PLC.B bytes) =
+    OpenBytes (hexText bytes)
+plutusDataOpenValue (PLC.List values) =
+    OpenArray (map plutusDataOpenValue values)
+plutusDataOpenValue (PLC.Map entries) =
+    OpenArray
+        [ OpenObject $
+            Map.fromList
+                [ ("key", plutusDataOpenValue key)
+                , ("value", plutusDataOpenValue itemValue)
+                ]
+        | (key, itemValue) <- entries
         ]
+plutusDataOpenValue (PLC.Constr index fields) =
+    OpenObject $
+        Map.fromList
+            [ ("constructor", OpenInteger index)
+            , ("fields", OpenArray (map plutusDataOpenValue fields))
+            ]
 
 coinValue :: Coin -> Aeson.Value
 coinValue (Coin lovelace) =

--- a/lib/Cardano/Node/Client/TxDiff/Cli.hs
+++ b/lib/Cardano/Node/Client/TxDiff/Cli.hs
@@ -1,0 +1,97 @@
+{- |
+Module      : Cardano.Node.Client.TxDiff.Cli
+Description : tx-diff command-line option parsing.
+License     : Apache-2.0
+
+Pure parser for the `tx-diff` executable. Keeping parsing separate from file
+IO guarantees invalid render flags fail before transaction inputs or
+blueprints are read.
+-}
+module Cardano.Node.Client.TxDiff.Cli (
+    TxDiffCliError (..),
+    TxDiffCliOptions (..),
+    parseTxDiffCliArgs,
+    txDiffCliUsage,
+) where
+
+import Cardano.Node.Client.TxDiff (
+    HumanRenderOptions (..),
+    RenderShape (..),
+    TreeArt (..),
+    defaultHumanRenderOptions,
+ )
+
+data TxDiffCliOptions = TxDiffCliOptions
+    { txDiffCliBlueprintPaths :: [FilePath]
+    , txDiffCliHumanRenderOptions :: HumanRenderOptions
+    , txDiffCliLeftPath :: FilePath
+    , txDiffCliRightPath :: FilePath
+    }
+    deriving stock (Eq, Show)
+
+newtype TxDiffCliError = TxDiffCliUsageError String
+    deriving stock (Eq, Show)
+
+parseTxDiffCliArgs :: [String] -> Either TxDiffCliError TxDiffCliOptions
+parseTxDiffCliArgs =
+    go [] defaultHumanRenderOptions
+  where
+    go blueprintPaths renderOptions ("--blueprint" : blueprintPath : rest) =
+        go (blueprintPath : blueprintPaths) renderOptions rest
+    go _ _ ["--blueprint"] =
+        Left (TxDiffCliUsageError "missing value for --blueprint")
+    go blueprintPaths renderOptions ("--render" : value : rest) =
+        case parseRenderShape value of
+            Left err ->
+                Left err
+            Right renderShape ->
+                go
+                    blueprintPaths
+                    renderOptions{humanRenderShape = renderShape}
+                    rest
+    go _ _ ["--render"] =
+        Left (TxDiffCliUsageError "missing value for --render")
+    go blueprintPaths renderOptions ("--tree-art" : value : rest) =
+        case parseTreeArt value of
+            Left err ->
+                Left err
+            Right treeArt ->
+                go
+                    blueprintPaths
+                    renderOptions{humanTreeArt = treeArt}
+                    rest
+    go _ _ ["--tree-art"] =
+        Left (TxDiffCliUsageError "missing value for --tree-art")
+    go blueprintPaths renderOptions [leftPath, rightPath] =
+        Right
+            TxDiffCliOptions
+                { txDiffCliBlueprintPaths = reverse blueprintPaths
+                , txDiffCliHumanRenderOptions = renderOptions
+                , txDiffCliLeftPath = leftPath
+                , txDiffCliRightPath = rightPath
+                }
+    go _ _ _ =
+        Left (TxDiffCliUsageError "expected TX_A TX_B")
+
+parseRenderShape :: String -> Either TxDiffCliError RenderShape
+parseRenderShape "tree" =
+    Right RenderTree
+parseRenderShape "paths" =
+    Right RenderPaths
+parseRenderShape value =
+    Left (TxDiffCliUsageError ("unsupported --render value: " <> value))
+
+parseTreeArt :: String -> Either TxDiffCliError TreeArt
+parseTreeArt "ascii" =
+    Right TreeArtAscii
+parseTreeArt "unicode" =
+    Right TreeArtUnicode
+parseTreeArt value =
+    Left (TxDiffCliUsageError ("unsupported --tree-art value: " <> value))
+
+txDiffCliUsage :: String -> String
+txDiffCliUsage prog =
+    "Usage: "
+        <> prog
+        <> " [--render tree|paths] [--tree-art ascii|unicode]"
+        <> " [--blueprint FILE ...] TX_A TX_B"

--- a/specs/132-tx-diff-render-modes/checklists/requirements.md
+++ b/specs/132-tx-diff-render-modes/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: tx-diff Render Modes
+
+**Purpose**: Validate specification completeness and quality before planning  
+**Created**: 2026-05-14  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The specification intentionally requires a planning-phase dependency
+  decision for tree rendering rather than choosing a package in the
+  stakeholder-level spec.

--- a/specs/132-tx-diff-render-modes/contracts/cli.md
+++ b/specs/132-tx-diff-render-modes/contracts/cli.md
@@ -1,0 +1,76 @@
+# CLI Contract: tx-diff Render Modes
+
+## Command Shape
+
+```text
+tx-diff [--render MODE] [--tree-art ART] [--blueprint FILE ...] TX_A TX_B
+```
+
+## Render Mode
+
+Accepted values:
+
+- `tree`: human hierarchy mode.
+- `paths`: flat path-line mode compatible with the first release.
+
+Default:
+
+- `tree`.
+
+Invalid value:
+
+- Print usage to stderr.
+- Exit non-zero.
+- Do not read `TX_A`, `TX_B`, or blueprint files.
+
+## Tree Art
+
+Accepted values:
+
+- `unicode`: Unicode connector art.
+- `ascii`: ASCII connector art.
+
+Optional value:
+
+- `plain`: indentation-only tree if the implementation decides it is useful
+  and tests it.
+
+Default:
+
+- `ascii`.
+
+Invalid value:
+
+- Print usage to stderr.
+- Exit non-zero.
+- Do not read transaction inputs.
+
+## Compatibility
+
+`--render paths` must preserve the semantic meaning of the first release's
+human output: every changed leaf line carries enough path context to be read
+alone.
+
+## Examples
+
+```bash
+tx-diff tx-a.cbor tx-b.cbor
+```
+
+Equivalent to:
+
+```bash
+tx-diff --render tree --tree-art ascii tx-a.cbor tx-b.cbor
+```
+
+```bash
+tx-diff --render tree --tree-art unicode tx-a.cbor tx-b.cbor
+```
+
+```bash
+tx-diff --render tree --tree-art ascii tx-a.cbor tx-b.cbor
+```
+
+```bash
+tx-diff --render paths --blueprint plutus.json tx-a.cbor tx-b.cbor
+```

--- a/specs/132-tx-diff-render-modes/data-model.md
+++ b/specs/132-tx-diff-render-modes/data-model.md
@@ -1,0 +1,69 @@
+# Data Model: tx-diff Render Modes
+
+## RenderShape
+
+Represents the high-level structure of human output.
+
+Fields:
+
+- `tree`: group shared path prefixes and render changed leaves below them.
+- `paths`: render changed leaves as standalone full path lines.
+
+Default:
+
+- `tree`.
+
+Validation:
+
+- Values outside the supported set are rejected before transaction inputs are
+  read.
+
+## TreeArt
+
+Represents connector and indentation style for tree-shaped output.
+
+Fields:
+
+- `unicode`: readable connector art for Unicode-capable terminals.
+- `ascii`: portable connector art for logs and minimal terminals.
+- `plain`: optional indentation-only spelling if implementation chooses to
+  support it separately from ASCII.
+
+Default:
+
+- `ascii`.
+
+Validation:
+
+- Applies only when `RenderShape` is `tree`.
+- Unsupported values are usage errors.
+
+## HumanRenderOptions
+
+User-facing rendering selection.
+
+Fields:
+
+- `renderShape`: selected `RenderShape`.
+- `treeArt`: selected `TreeArt` when tree rendering is active.
+
+Relationships:
+
+- Consumed by the library renderer.
+- Derived from CLI flags in `tx-diff`.
+
+## RenderedDiffNode
+
+A presentation node derived from an existing `DiffNode`.
+
+Fields:
+
+- `label`: path segment or leaf marker shown on the current line.
+- `kind`: branch, changed leaf, only-A leaf, only-B leaf, or same marker.
+- `children`: rendered child nodes.
+- `valueA` / `valueB`: rendered side values for changed leaves.
+
+Validation:
+
+- Must not contain transaction comparison logic.
+- Must not expand equal subtrees that the diff model suppressed.

--- a/specs/132-tx-diff-render-modes/plan.md
+++ b/specs/132-tx-diff-render-modes/plan.md
@@ -1,0 +1,112 @@
+# Implementation Plan: tx-diff Render Modes
+
+**Branch**: `132-tx-diff-render-modes` | **Date**: 2026-05-14 |
+**Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from
+`specs/132-tx-diff-render-modes/spec.md`; GitHub issue #139.
+
+## Summary
+
+Add an explicit rendering contract for `tx-diff`: tree-shaped human output
+for readability, path-line output for scripts, and selectable tree art for
+Unicode-capable terminals versus plain logs. The default is tree shape with
+ASCII tree art. The implementation must keep comparison logic in the existing
+diff tree and limit rendering changes to the presentation layer and CLI option
+parsing.
+
+## Technical Context
+
+**Language/Version**: Haskell, GHC 9.12.3  
+**Primary Dependencies**: Existing `containers`; candidate renderer packages
+recorded in [research.md](./research.md)  
+**Storage**: N/A  
+**Testing**: Hspec via `just unit`; lint/format through `just ci`  
+**Target Platform**: `tx-diff` CLI and library renderer API  
+**Project Type**: Haskell library plus CLI executable  
+**Performance Goals**: Rendering must be linear in the number of rendered
+diff nodes and must not force traversal of equal subtrees  
+**Constraints**: Preserve minimal dependencies; do not recompute transaction
+diffs in the renderer; support non-Unicode output  
+**Scale/Scope**: Human rendering of one `DiffNode` tree at a time
+
+## Constitution Check
+
+- **Channel-Driven N2C Clients**: Not applicable; this change is offline
+  rendering only.
+- **Devnet E2E Testing**: No node boundary is touched. Unit tests are the
+  main proof; full `just ci` remains the merge gate.
+- **Minimal Dependencies**: Active gate. Any new rendering dependency must be
+  justified in research and in the implementation commit.
+- **Test Utilities Are First-Class**: Renderer fixtures should stay in the
+  unit test surface and remain reusable.
+
+Initial result: PASS, with the dependency decision explicitly deferred to
+Phase 0 research.
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/132-tx-diff-render-modes/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── cli.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+lib/Cardano/Node/Client/TxDiff.hs
+app/tx-diff/Main.hs
+test/Cardano/Node/Client/TxDiff/CoreSpec.hs
+test/Cardano/Node/Client/TxDiff/ConwaySpec.hs
+cardano-node-clients.cabal
+```
+
+**Structure Decision**: Keep rendering in `TxDiff.hs` for this slice unless
+the implementation becomes large enough to justify a dedicated renderer
+module. CLI parsing stays in `app/tx-diff/Main.hs`.
+
+## Phase 0: Research
+
+Research output is captured in [research.md](./research.md).
+
+Key decision to revisit during implementation:
+
+- Prefer no new dependency if ASCII/plain tree output satisfies the accepted
+  default contract.
+- Prefer `tree-render-text` if Unicode and ASCII connector styles are both
+  required through a maintained library.
+- Do not use `tree-diff` as the primary renderer unless its license and data
+  model fit are explicitly accepted.
+
+## Phase 1: Design
+
+Design output:
+
+- [data-model.md](./data-model.md)
+- [contracts/cli.md](./contracts/cli.md)
+- [quickstart.md](./quickstart.md)
+
+## Implementation Approach
+
+1. Add RED tests for render shape and tree art selection.
+2. Add renderer option data types in the library.
+3. Preserve the current path renderer behind an explicit mode.
+4. Implement tree rendering from the existing `DiffNode`.
+5. Wire CLI parsing and usage text.
+6. Run focused unit tests, then full gate.
+
+## Post-Design Constitution Check
+
+PASS if implementation either avoids new dependencies or records a narrow,
+licensed, Nix/Cabal-compatible dependency choice. Any dependency addition must
+be part of the same vertical commit as its tests and CLI behavior.

--- a/specs/132-tx-diff-render-modes/plan.md
+++ b/specs/132-tx-diff-render-modes/plan.md
@@ -5,6 +5,16 @@
 **Input**: Feature specification from
 `specs/132-tx-diff-render-modes/spec.md`; GitHub issue #139.
 
+## Status
+
+**Completed**: Setup/dependency decision, RED renderer and CLI tests, tree
+and path render implementation, CLI flag parsing, Conway expectation updates,
+focused unit verification, and full local CI.
+
+**Current**: Ready for PR review.
+
+**Blockers**: None.
+
 ## Summary
 
 Add an explicit rendering contract for `tx-diff`: tree-shaped human output
@@ -17,8 +27,8 @@ parsing.
 ## Technical Context
 
 **Language/Version**: Haskell, GHC 9.12.3  
-**Primary Dependencies**: Existing `containers`; candidate renderer packages
-recorded in [research.md](./research.md)  
+**Primary Dependencies**: Existing `containers`; add `tree-view` for Unicode
+tree connector rendering, as recorded in [research.md](./research.md)
 **Storage**: N/A  
 **Testing**: Hspec via `just unit`; lint/format through `just ci`  
 **Target Platform**: `tx-diff` CLI and library renderer API  
@@ -79,14 +89,13 @@ module. CLI parsing stays in `app/tx-diff/Main.hs`.
 
 Research output is captured in [research.md](./research.md).
 
-Key decision to revisit during implementation:
+Key decision:
 
-- Prefer no new dependency if ASCII/plain tree output satisfies the accepted
-  default contract.
-- Prefer `tree-render-text` if Unicode and ASCII connector styles are both
-  required through a maintained library.
-- Do not use `tree-diff` as the primary renderer unless its license and data
-  model fit are explicitly accepted.
+- Use `containers` / `Data.Tree.drawForest` for ASCII connector style.
+- Use `tree-view` for Unicode connector style.
+- Keep comparison logic in the existing `DiffNode` traversal.
+- Do not use `tree-diff` as the primary renderer because it is a diff engine
+  and has a license mismatch concern for this project.
 
 ## Phase 1: Design
 
@@ -107,6 +116,6 @@ Design output:
 
 ## Post-Design Constitution Check
 
-PASS if implementation either avoids new dependencies or records a narrow,
-licensed, Nix/Cabal-compatible dependency choice. Any dependency addition must
-be part of the same vertical commit as its tests and CLI behavior.
+PASS: implementation records a narrow, BSD-3-Clause,
+Nix/Cabal-compatible dependency choice. The dependency addition must be part
+of the same vertical commit as its tests and CLI behavior.

--- a/specs/132-tx-diff-render-modes/quickstart.md
+++ b/specs/132-tx-diff-render-modes/quickstart.md
@@ -1,0 +1,55 @@
+# Quickstart: tx-diff Render Modes
+
+## Tree Mode Smoke
+
+Use two transactions that differ under a shared output or datum path:
+
+```bash
+tx-diff tx-a.cbor tx-b.cbor
+```
+
+This is equivalent to:
+
+```bash
+tx-diff --render tree --tree-art ascii tx-a.cbor tx-b.cbor
+```
+
+Expected:
+
+- Shared parent path appears once.
+- Changed leaves appear underneath.
+- Side values are still labelled `A` and `B`.
+
+## Path Mode Smoke
+
+```bash
+tx-diff --render paths tx-a.cbor tx-b.cbor
+```
+
+Expected:
+
+- Changed leaves include full paths.
+- No hierarchy-only parent lines are required to understand a changed leaf.
+
+## Blueprint Smoke
+
+```bash
+tx-diff --render tree --tree-art ascii --blueprint plutus.json tx-a.cbor tx-b.cbor
+```
+
+Expected:
+
+- Matching datum/redeemer fields are grouped under the ledger path.
+- Decoded field names remain visible.
+
+## Invalid Flag Smoke
+
+```bash
+tx-diff --render nope tx-a.cbor tx-b.cbor
+```
+
+Expected:
+
+- Usage error.
+- Non-zero exit.
+- No transaction decode attempt.

--- a/specs/132-tx-diff-render-modes/research.md
+++ b/specs/132-tx-diff-render-modes/research.md
@@ -36,14 +36,16 @@ require richer Unicode connectors.
 
 Source: https://hackage-content.haskell.org/package/containers-0.8/docs/Data-Tree.html
 
-## Decision: `tree-render-text` is the strongest dependency candidate
+## Decision: `tree-render-text` is not usable with this GHC
 
 `tree-render-text` exposes `renderTree` / `renderForest` and render options,
 including traced Unicode and traced ASCII options.
 
-**Rationale**: It directly matches the requirement for selectable tree art.
-It is more targeted than `tree-view` because it documents both Unicode and
-ASCII traced render options.
+**Rationale**: It directly matches the requirement for selectable tree art,
+but the latest available package declares `base ^>=4.12.0.0`. This repository
+builds with GHC 9.12.3 and `base-4.21`, so using it would require an
+`allow-newer` workaround or a vendored patch. That is not acceptable for this
+small rendering feature.
 
 **Alternatives considered**:
 
@@ -56,6 +58,30 @@ Sources:
 
 - https://hackage.haskell.org/package/tree-render-text/docs/Data-Tree-Render-Text.html
 - https://hackage.haskell.org/package/tree-view
+
+## Decision: Use `containers` for ASCII and `tree-view` for Unicode
+
+Use `Data.Tree.drawForest` from the existing `containers` dependency for the
+default ASCII tree. Add `tree-view` only for Unicode tree art. Keep the
+transaction diff traversal and displayed leaf formatting inside
+`Cardano.Node.Client.TxDiff`; only delegate connector layout to these tree
+renderers.
+
+**Rationale**: `containers` is already present and gives a portable
+non-Unicode tree. `tree-view` is BSD3, declares `base < 5`, and renders
+Unicode tree art. This satisfies both accepted art modes without adding a
+stale package or a second diff engine.
+
+**Verification**:
+
+- `nix develop --quiet -c cabal list tree-render-text --simple-output`
+  lists `tree-render-text 0.4.0.0`.
+- `nix develop --quiet -c cabal get tree-render-text-0.4.0.0`
+  downloads the source package and shows the incompatible `base ^>=4.12.0.0`
+  bound.
+- `nix develop --quiet -c cabal get tree-view`
+  downloads `tree-view-0.5.1`, whose cabal file declares `BSD3` and
+  `base < 5`.
 
 ## Decision: Render shape and tree art are separate concepts
 
@@ -73,9 +99,8 @@ prevents invalid combinations from leaking into renderer internals.
   This is compact for CLI parsing but mixes two user choices and makes future
   additions less clear.
 
-## Open Implementation Check
+## Closed Implementation Check
 
-Before coding, verify whether `tree-render-text` is available in the pinned
-Nix/Haskell package set used by this repository. If not, either use
-`Data.Tree.drawTree` for the first implementation or add the dependency with
-explicit Nix/Cabal proof.
+`tree-render-text` is visible at the pinned index state but is incompatible
+with this GHC. Implementation will add `tree-view` as the narrow Unicode
+rendering dependency and keep ASCII rendering on `containers`.

--- a/specs/132-tx-diff-render-modes/research.md
+++ b/specs/132-tx-diff-render-modes/research.md
@@ -1,0 +1,81 @@
+# Research: tx-diff Render Modes
+
+## Decision: Keep comparison separate from rendering
+
+The existing `DiffNode` is already hierarchical. The renderer should consume
+that tree and should not run `tree-diff` or any other comparison algorithm
+over transactions again.
+
+**Rationale**: Re-diffing would duplicate logic and could diverge from the
+Conway/blueprint-aware comparison model.
+
+**Alternatives considered**:
+
+- `tree-diff`: Hackage describes it as an expression-tree diff package with
+  pretty-printing support and generic derivation helpers. It is useful
+  context, but it is a diff engine, not just tree art. It also carries a
+  GPL-2.0-or-later license, so it is not a casual dependency for this
+  Apache-licensed project.
+  Source: https://hackage.haskell.org/package/tree-diff
+
+## Decision: Treat `containers` / `Data.Tree` as the baseline option
+
+The project already depends on `containers`. `Data.Tree` provides a rose tree
+type plus `drawTree` and `drawForest` for ASCII drawings.
+
+**Rationale**: This satisfies the constitution's minimal-dependency rule and
+is enough for a portable ASCII/plain tree if the accepted design does not
+require richer Unicode connectors.
+
+**Alternatives considered**:
+
+- Hand-rolled indentation over `DiffNode`: simplest code, but it risks
+  exactly the kind of invented tree art the ticket asks us to avoid.
+- Adding a rendering package immediately: may be justified, but only if the
+  required art modes exceed `Data.Tree`'s capability.
+
+Source: https://hackage-content.haskell.org/package/containers-0.8/docs/Data-Tree.html
+
+## Decision: `tree-render-text` is the strongest dependency candidate
+
+`tree-render-text` exposes `renderTree` / `renderForest` and render options,
+including traced Unicode and traced ASCII options.
+
+**Rationale**: It directly matches the requirement for selectable tree art.
+It is more targeted than `tree-view` because it documents both Unicode and
+ASCII traced render options.
+
+**Alternatives considered**:
+
+- `tree-view`: Hackage describes it as rendering trees as foldable HTML and
+  Unicode art, with a concise Unicode example. It is attractive for Unicode
+  output, but it does not obviously cover ASCII/plain logs.
+- `Data.Tree.drawTree`: lower dependency cost, weaker art control.
+
+Sources:
+
+- https://hackage.haskell.org/package/tree-render-text/docs/Data-Tree-Render-Text.html
+- https://hackage.haskell.org/package/tree-view
+
+## Decision: Render shape and tree art are separate concepts
+
+The user-facing model should distinguish:
+
+- render shape: `tree` or `paths`
+- tree art: Unicode or ASCII/plain, applicable only when shape is `tree`
+
+**Rationale**: Path output has no tree art. Keeping the concepts separate
+prevents invalid combinations from leaking into renderer internals.
+
+**Alternatives considered**:
+
+- One enum with values like `paths`, `tree-unicode`, `tree-ascii`.
+  This is compact for CLI parsing but mixes two user choices and makes future
+  additions less clear.
+
+## Open Implementation Check
+
+Before coding, verify whether `tree-render-text` is available in the pinned
+Nix/Haskell package set used by this repository. If not, either use
+`Data.Tree.drawTree` for the first implementation or add the dependency with
+explicit Nix/Cabal proof.

--- a/specs/132-tx-diff-render-modes/spec.md
+++ b/specs/132-tx-diff-render-modes/spec.md
@@ -1,0 +1,171 @@
+# Feature Specification: tx-diff Render Modes
+
+**Feature Branch**: `132-tx-diff-render-modes`  
+**Created**: 2026-05-14  
+**Status**: Draft  
+**Input**: GitHub issue #139: improve `tx-diff` human rendering with tree
+hierarchy, path compatibility, and explicit rendering art selection.
+
+## User Scenarios & Testing
+
+### User Story 1 - Read shared hierarchy once (Priority: P1)
+
+A transaction reviewer compares two Conway transactions and sees related
+changes grouped under their shared transaction path instead of repeated as
+full dotted paths on every line.
+
+**Why this priority**: This is the usability problem. Several meaningful
+changes often live under the same output, datum, redeemer, or witness path.
+Repeating the full path makes the report longer while hiding the structure
+that the user already understands.
+
+**Independent Test**: Compare two values with two changed leaves under one
+shared parent. The human output shows the parent once and both changed leaves
+below it.
+
+**Acceptance Scenarios**:
+
+1. **Given** two transactions with multiple changes under the same output,
+   **When** the default human renderer is used, **Then** the output path is
+   shown once and the changed fields appear as children.
+2. **Given** a datum decoded with a matching blueprint, **When** two fields
+   inside the decoded datum change, **Then** the datum path is shown once and
+   the decoded field names appear as children.
+3. **Given** two unrelated changed paths, **When** the tree renderer is used,
+   **Then** each path appears under its own branch and no fake shared parent
+   is introduced.
+
+---
+
+### User Story 2 - Keep grep-friendly path output (Priority: P2)
+
+A script author or reviewer who prefers the previous flat format can request
+path-line output explicitly.
+
+**Why this priority**: The first release exposed flat path lines. Even if tree
+mode becomes the better default for humans, path lines remain useful for
+copying, searching, and simple text processing.
+
+**Independent Test**: Run the renderer with the path-line selection. The
+output uses full paths for changed leaves and does not emit hierarchy-only
+parent lines.
+
+**Acceptance Scenarios**:
+
+1. **Given** a transaction difference at `body.fee`, **When** path-line mode
+   is selected, **Then** the output contains the full path on the changed
+   line.
+2. **Given** sibling changes under one parent, **When** path-line mode is
+   selected, **Then** each changed leaf line remains independently readable
+   without relying on indentation context.
+
+---
+
+### User Story 3 - Select terminal-safe tree art (Priority: P3)
+
+An operator chooses tree art that fits the output medium: readable Unicode
+for terminals that support it, or ASCII/plain indentation for CI logs,
+markdown, and terminals with uncertain glyph support.
+
+**Why this priority**: Tree hierarchy is useful only if it renders reliably.
+Unicode box drawing is readable in good terminals, but release logs and
+minimal environments need a safe fallback.
+
+**Independent Test**: Render the same tree with each supported art selection.
+The structural grouping is the same, while connector characters match the
+selected art.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Unicode-capable terminal, **When** Unicode tree art is
+   selected, **Then** branch connectors are visually clear and aligned.
+2. **Given** a plain log environment, **When** ASCII/plain art is selected,
+   **Then** the output contains only ASCII characters while preserving the
+   same hierarchy.
+3. **Given** an unsupported art value, **When** the CLI is invoked, **Then**
+   it rejects the value with usage guidance and does not attempt a diff.
+
+### Edge Cases
+
+- A single changed root value still renders as one changed value, not an
+  empty tree.
+- Only-side object keys and array tail entries must be located under the same
+  hierarchy rules as changed paired leaves.
+- Equal subtrees must remain suppressed; tree mode must not expand equal
+  branches just to make the tree look complete.
+- Keys or labels containing dots must not become ambiguous with dotted path
+  separators in path-line mode.
+- Output copied into markdown or CI logs must remain comprehensible without
+  terminal colors.
+- Unknown or unsupported render options must fail before reading transaction
+  inputs.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The system MUST support a human tree rendering mode that groups
+  shared path prefixes and renders changed leaves under those prefixes.
+- **FR-002**: The system MUST preserve a human path-line rendering mode where
+  changed leaves are shown with their full paths.
+- **FR-003**: The command-line interface MUST expose explicit rendering
+  selection so users can choose tree output or path-line output.
+- **FR-004**: The command-line interface MUST expose or define tree art
+  behavior so users can obtain Unicode-friendly output and a
+  non-Unicode-safe output.
+- **FR-005**: The default human output MUST be deterministic: tree render
+  shape with ASCII tree art.
+- **FR-006**: Tree rendering MUST preserve existing semantic content:
+  side labels `A` and `B`, exact ADA/lovelace values, compact CBOR summaries,
+  only-side values, and blueprint-decoded datum/redeemer fields.
+- **FR-007**: Path-line rendering MUST remain compatible with the first
+  release's meaning: every changed leaf can be read without parent context.
+- **FR-008**: Invalid render mode or art values MUST produce a usage error
+  before transaction inputs are read or decoded.
+- **FR-009**: The design MUST evaluate existing tree rendering or
+  diff-rendering libraries before implementation and record the dependency
+  decision.
+- **FR-010**: The renderer MUST consume the existing diff tree and MUST NOT
+  recompute transaction comparison or blueprint decoding.
+- **FR-011**: Tests MUST cover both render shape selection and tree art
+  selection for representative object and array paths.
+- **FR-012**: Tests MUST prove that two sibling differences under a shared
+  parent are grouped under that parent in tree mode.
+
+### Key Entities
+
+- **Render Shape**: The high-level output structure selected by the user,
+  such as tree hierarchy or flat path lines.
+- **Tree Art**: The connector and indentation style used when render shape is
+  tree, such as Unicode connectors or ASCII/plain connectors.
+- **Rendered Diff Node**: A displayed branch or leaf derived from the existing
+  structural diff result.
+- **Changed Leaf**: A rendered difference with side `A` and side `B` values,
+  an only-side value, or an equal-context marker when explicitly shown.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A fixture with two sibling changes under one parent renders the
+  parent path exactly once in tree mode.
+- **SC-002**: The same fixture renders each changed leaf with a full path in
+  path-line mode.
+- **SC-003**: Every supported rendering selection is documented in CLI usage
+  and has at least one automated test.
+- **SC-004**: Invalid rendering selections fail without decoding transaction
+  input files.
+- **SC-005**: No existing value formatting regression occurs for ADA/lovelace
+  amounts, CBOR summaries, or blueprint-decoded fields.
+
+## Assumptions
+
+- `tx-diff` remains a text CLI; colorized or interactive rendering is out of
+  scope for this ticket.
+- The existing structural diff model remains the source of truth.
+- Because this package has a minimal-dependency constitution, any new
+  rendering dependency must be justified before implementation.
+- The first implementation may support a small finite set of modes and art
+  styles; open-ended plugin rendering is out of scope.
+- Unicode tree art is an explicit opt-in so CI logs, markdown snippets, and
+  minimal terminals receive portable output by default.

--- a/specs/132-tx-diff-render-modes/tasks.md
+++ b/specs/132-tx-diff-render-modes/tasks.md
@@ -6,41 +6,41 @@
 
 ## Phase 1: Setup
 
-- [ ] T001 Confirm implementation matches the final CLI contract: default `--render tree`, default `--tree-art ascii`, explicit `--render paths`, and explicit `--tree-art unicode`.
-- [ ] T002 Verify whether `tree-render-text` is available in the pinned Nix/Haskell package set and record the result in `specs/132-tx-diff-render-modes/research.md`.
-- [ ] T003 Decide whether implementation uses existing `containers` only or adds a renderer dependency; update `specs/132-tx-diff-render-modes/plan.md`.
+- [X] T001 Confirm implementation matches the final CLI contract: default `--render tree`, default `--tree-art ascii`, explicit `--render paths`, and explicit `--tree-art unicode`.
+- [X] T002 Verify whether `tree-render-text` is available in the pinned Nix/Haskell package set and record the result in `specs/132-tx-diff-render-modes/research.md`.
+- [X] T003 Decide whether implementation uses existing `containers` only or adds a renderer dependency; update `specs/132-tx-diff-render-modes/plan.md`.
 
 ## Phase 2: Foundational Tests
 
-- [ ] T004 [P] Add RED unit tests for tree grouping of sibling object changes in `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
-- [ ] T005 [P] Add RED unit tests for path-line compatibility in `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
-- [ ] T006 [P] Add RED unit tests for ASCII and Unicode tree art selection in `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
-- [ ] T007 Add RED CLI parsing/usage tests for invalid render values in the appropriate unit test module.
+- [X] T004 [P] Add RED unit tests for tree grouping of sibling object changes in `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
+- [X] T005 [P] Add RED unit tests for path-line compatibility in `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
+- [X] T006 [P] Add RED unit tests for ASCII and Unicode tree art selection in `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
+- [X] T007 Add RED CLI parsing/usage tests for invalid render values in the appropriate unit test module.
 
 ## Phase 3: User Story 1 - Tree Hierarchy
 
-- [ ] T008 [US1] Add renderer option types and tree renderer entry points in `lib/Cardano/Node/Client/TxDiff.hs`.
-- [ ] T009 [US1] Build a render tree from `DiffNode` without recomputing comparison in `lib/Cardano/Node/Client/TxDiff.hs`.
-- [ ] T010 [US1] Render object and array changed children under shared parent paths in `lib/Cardano/Node/Client/TxDiff.hs`.
-- [ ] T011 [US1] Update Conway renderer expectations for nested fee/output/datum paths in `test/Cardano/Node/Client/TxDiff/ConwaySpec.hs`.
+- [X] T008 [US1] Add renderer option types and tree renderer entry points in `lib/Cardano/Node/Client/TxDiff.hs`.
+- [X] T009 [US1] Build a render tree from `DiffNode` without recomputing comparison in `lib/Cardano/Node/Client/TxDiff.hs`.
+- [X] T010 [US1] Render object and array changed children under shared parent paths in `lib/Cardano/Node/Client/TxDiff.hs`.
+- [X] T011 [US1] Update Conway renderer expectations for nested fee/output/datum paths in `test/Cardano/Node/Client/TxDiff/ConwaySpec.hs`.
 
 ## Phase 4: User Story 2 - Path Compatibility
 
-- [ ] T012 [US2] Preserve the existing path-line renderer behind an explicit render shape in `lib/Cardano/Node/Client/TxDiff.hs`.
-- [ ] T013 [US2] Ensure only-side object and array entries render correctly in path mode in `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
+- [X] T012 [US2] Preserve the existing path-line renderer behind an explicit render shape in `lib/Cardano/Node/Client/TxDiff.hs`.
+- [X] T013 [US2] Ensure only-side object and array entries render correctly in path mode in `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
 
 ## Phase 5: User Story 3 - Tree Art Selection
 
-- [ ] T014 [US3] Implement ASCII tree art rendering in `lib/Cardano/Node/Client/TxDiff.hs`.
-- [ ] T015 [US3] Implement Unicode tree art rendering or document why ASCII/plain is the accepted first release style.
-- [ ] T016 [US3] Add CLI flags for render shape and tree art in `app/tx-diff/Main.hs`.
-- [ ] T017 [US3] Update usage text and invalid-argument handling in `app/tx-diff/Main.hs`.
+- [X] T014 [US3] Implement ASCII tree art rendering in `lib/Cardano/Node/Client/TxDiff.hs`.
+- [X] T015 [US3] Implement Unicode tree art rendering or document why ASCII/plain is the accepted first release style.
+- [X] T016 [US3] Add CLI flags for render shape and tree art in `app/tx-diff/Main.hs`.
+- [X] T017 [US3] Update usage text and invalid-argument handling in `app/tx-diff/Main.hs`.
 
 ## Phase 6: Verification
 
-- [ ] T018 Run `nix develop --quiet -c just unit`.
-- [ ] T019 Run `nix develop --quiet -c just ci`.
-- [ ] T020 Update issue #139 with the chosen renderer dependency/art decision and verification evidence.
+- [X] T018 Run `nix develop --quiet -c just unit`.
+- [X] T019 Run `nix develop --quiet -c just ci`.
+- [X] T020 Update issue #139 with the chosen renderer dependency/art decision and verification evidence.
 
 ## Dependencies
 

--- a/specs/132-tx-diff-render-modes/tasks.md
+++ b/specs/132-tx-diff-render-modes/tasks.md
@@ -1,0 +1,69 @@
+# Tasks: tx-diff Render Modes
+
+**Input**: [spec.md](./spec.md), [plan.md](./plan.md),
+[research.md](./research.md), [contracts/cli.md](./contracts/cli.md)  
+**Issue**: https://github.com/lambdasistemi/cardano-node-clients/issues/139
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm implementation matches the final CLI contract: default `--render tree`, default `--tree-art ascii`, explicit `--render paths`, and explicit `--tree-art unicode`.
+- [ ] T002 Verify whether `tree-render-text` is available in the pinned Nix/Haskell package set and record the result in `specs/132-tx-diff-render-modes/research.md`.
+- [ ] T003 Decide whether implementation uses existing `containers` only or adds a renderer dependency; update `specs/132-tx-diff-render-modes/plan.md`.
+
+## Phase 2: Foundational Tests
+
+- [ ] T004 [P] Add RED unit tests for tree grouping of sibling object changes in `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
+- [ ] T005 [P] Add RED unit tests for path-line compatibility in `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
+- [ ] T006 [P] Add RED unit tests for ASCII and Unicode tree art selection in `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
+- [ ] T007 Add RED CLI parsing/usage tests for invalid render values in the appropriate unit test module.
+
+## Phase 3: User Story 1 - Tree Hierarchy
+
+- [ ] T008 [US1] Add renderer option types and tree renderer entry points in `lib/Cardano/Node/Client/TxDiff.hs`.
+- [ ] T009 [US1] Build a render tree from `DiffNode` without recomputing comparison in `lib/Cardano/Node/Client/TxDiff.hs`.
+- [ ] T010 [US1] Render object and array changed children under shared parent paths in `lib/Cardano/Node/Client/TxDiff.hs`.
+- [ ] T011 [US1] Update Conway renderer expectations for nested fee/output/datum paths in `test/Cardano/Node/Client/TxDiff/ConwaySpec.hs`.
+
+## Phase 4: User Story 2 - Path Compatibility
+
+- [ ] T012 [US2] Preserve the existing path-line renderer behind an explicit render shape in `lib/Cardano/Node/Client/TxDiff.hs`.
+- [ ] T013 [US2] Ensure only-side object and array entries render correctly in path mode in `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
+
+## Phase 5: User Story 3 - Tree Art Selection
+
+- [ ] T014 [US3] Implement ASCII tree art rendering in `lib/Cardano/Node/Client/TxDiff.hs`.
+- [ ] T015 [US3] Implement Unicode tree art rendering or document why ASCII/plain is the accepted first release style.
+- [ ] T016 [US3] Add CLI flags for render shape and tree art in `app/tx-diff/Main.hs`.
+- [ ] T017 [US3] Update usage text and invalid-argument handling in `app/tx-diff/Main.hs`.
+
+## Phase 6: Verification
+
+- [ ] T018 Run `nix develop --quiet -c just unit`.
+- [ ] T019 Run `nix develop --quiet -c just ci`.
+- [ ] T020 Update issue #139 with the chosen renderer dependency/art decision and verification evidence.
+
+## Dependencies
+
+- T001-T003 block implementation.
+- T004-T007 must fail before T008-T017 begin.
+- US1 is the MVP and can ship before US2/US3 only if the CLI contract is
+  deliberately narrowed before implementation.
+- US2 must complete before changing default behavior.
+- US3 completes the user's render-art requirement.
+
+## Parallel Opportunities
+
+- T004, T005, and T006 can be drafted independently.
+- T008-T010 should stay serial because they shape the renderer API.
+- T014 and T016 can proceed in parallel after render option types exist.
+
+## Implementation Strategy
+
+Implement vertically by user story with TDD:
+
+1. Establish the final CLI/render contract.
+2. Write RED tests for tree hierarchy and compatibility.
+3. Implement tree rendering without touching comparison logic.
+4. Restore path compatibility.
+5. Add art selection and CLI usage.
+6. Run the full gate before PR.

--- a/test/Cardano/Node/Client/TxDiff/CliSpec.hs
+++ b/test/Cardano/Node/Client/TxDiff/CliSpec.hs
@@ -1,0 +1,81 @@
+module Cardano.Node.Client.TxDiff.CliSpec (spec) where
+
+import Test.Hspec
+
+import Cardano.Node.Client.TxDiff (
+    HumanRenderOptions (..),
+    RenderShape (..),
+    TreeArt (..),
+    defaultHumanRenderOptions,
+ )
+import Cardano.Node.Client.TxDiff.Cli (
+    TxDiffCliError (..),
+    TxDiffCliOptions (..),
+    parseTxDiffCliArgs,
+ )
+
+spec :: Spec
+spec =
+    describe "tx-diff CLI parsing" $ do
+        it "defaults to tree rendering with ASCII art" $
+            parseTxDiffCliArgs ["tx-a.cbor", "tx-b.cbor"]
+                `shouldBe` Right
+                    TxDiffCliOptions
+                        { txDiffCliBlueprintPaths = []
+                        , txDiffCliHumanRenderOptions = defaultHumanRenderOptions
+                        , txDiffCliLeftPath = "tx-a.cbor"
+                        , txDiffCliRightPath = "tx-b.cbor"
+                        }
+
+        it "accepts explicit path rendering" $
+            parseTxDiffCliArgs ["--render", "paths", "tx-a.cbor", "tx-b.cbor"]
+                `shouldBe` Right
+                    TxDiffCliOptions
+                        { txDiffCliBlueprintPaths = []
+                        , txDiffCliHumanRenderOptions =
+                            defaultHumanRenderOptions
+                                { humanRenderShape = RenderPaths
+                                }
+                        , txDiffCliLeftPath = "tx-a.cbor"
+                        , txDiffCliRightPath = "tx-b.cbor"
+                        }
+
+        it "accepts explicit Unicode tree art" $
+            parseTxDiffCliArgs ["--tree-art", "unicode", "tx-a.cbor", "tx-b.cbor"]
+                `shouldBe` Right
+                    TxDiffCliOptions
+                        { txDiffCliBlueprintPaths = []
+                        , txDiffCliHumanRenderOptions =
+                            defaultHumanRenderOptions
+                                { humanTreeArt = TreeArtUnicode
+                                }
+                        , txDiffCliLeftPath = "tx-a.cbor"
+                        , txDiffCliRightPath = "tx-b.cbor"
+                        }
+
+        it "preserves repeated blueprint paths in input order" $
+            parseTxDiffCliArgs
+                [ "--blueprint"
+                , "one.json"
+                , "--blueprint"
+                , "two.json"
+                , "tx-a.cbor"
+                , "tx-b.cbor"
+                ]
+                `shouldBe` Right
+                    TxDiffCliOptions
+                        { txDiffCliBlueprintPaths = ["one.json", "two.json"]
+                        , txDiffCliHumanRenderOptions = defaultHumanRenderOptions
+                        , txDiffCliLeftPath = "tx-a.cbor"
+                        , txDiffCliRightPath = "tx-b.cbor"
+                        }
+
+        it "rejects invalid render mode before inputs are read" $
+            parseTxDiffCliArgs ["--render", "json", "missing-a", "missing-b"]
+                `shouldBe` Left
+                    (TxDiffCliUsageError "unsupported --render value: json")
+
+        it "rejects invalid tree art before inputs are read" $
+            parseTxDiffCliArgs ["--tree-art", "emoji", "missing-a", "missing-b"]
+                `shouldBe` Left
+                    (TxDiffCliUsageError "unsupported --tree-art value: emoji")

--- a/test/Cardano/Node/Client/TxDiff/ConwaySpec.hs
+++ b/test/Cardano/Node/Client/TxDiff/ConwaySpec.hs
@@ -175,10 +175,10 @@ spec =
                 Left err ->
                     expectationFailure ("failed to render tx diff: " <> show err)
                 Right output -> do
-                    output `shouldSatisfy` Text.isInfixOf "~ body.fee"
+                    output `shouldSatisfy` Text.isInfixOf "`- fee"
                     output
                         `shouldSatisfy` Text.isInfixOf
-                            "  B: 0.000042 ADA (42 lovelace)"
+                            "B: 0.000042 ADA (42 lovelace)"
 
         it "reports a Conway fee change at body.fee" $ do
             tx <- loadFixture sampleHash
@@ -447,9 +447,7 @@ spec =
                                                                 ( datumJson
                                                                     oldDatum
                                                                 )
-                                                                ( datumJson
-                                                                    newDatum
-                                                                )
+                                                                (Aeson.Number 42)
                                                             )
                                                         )
                                                     )
@@ -952,7 +950,7 @@ spec =
                                                 Map.empty
                                                 ( Map.singleton
                                                     datumPath
-                                                    (dataJson datumData)
+                                                    (Aeson.Number 42)
                                                 )
                                             )
                                         )
@@ -1036,12 +1034,8 @@ spec =
                                                                         ]
                                                                     )
                                                                     ( DiffChanged
-                                                                        ( dataJson
-                                                                            oldRedeemer
-                                                                        )
-                                                                        ( dataJson
-                                                                            newRedeemer
-                                                                        )
+                                                                        (Aeson.Number 1)
+                                                                        (Aeson.Number 2)
                                                                     )
                                                                 )
                                                             )
@@ -1101,9 +1095,44 @@ spec =
                         output = renderDiffNodeHuman (diffConwayTxWith options txA txB)
                     output
                         `shouldSatisfy` Text.isInfixOf
-                            "~ body.outputs.0.datum.amount"
-                    output `shouldSatisfy` Text.isInfixOf "  A: 42"
-                    output `shouldSatisfy` Text.isInfixOf "  B: 43"
+                            "amount: A: 42 | B: 43"
+
+        it "descends into inline output datum as raw Plutus data without a matching blueprint" $ do
+            tx <- loadFixture sampleHash
+            let outputs = toList (tx ^. bodyTxL . outputsTxBodyL)
+            case outputs of
+                [] ->
+                    expectationFailure "fixture has no outputs"
+                firstOutput : otherOutputs -> do
+                    let oldDatum = inlineOrderDatum 42
+                        newDatum = inlineOrderDatum 43
+                        txA =
+                            tx
+                                & bodyTxL
+                                    . outputsTxBodyL
+                                    .~ StrictSeq.fromList
+                                        ( ( firstOutput
+                                                & datumTxOutL .~ oldDatum
+                                          )
+                                            : otherOutputs
+                                        )
+                        txB =
+                            tx
+                                & bodyTxL
+                                    . outputsTxBodyL
+                                    .~ StrictSeq.fromList
+                                        ( ( firstOutput
+                                                & datumTxOutL .~ newDatum
+                                          )
+                                            : otherOutputs
+                                        )
+                        output =
+                            renderDiffNodeHuman
+                                (diffConwayTxWith defaultTxDiffOptions txA txB)
+                    output `shouldSatisfy` Text.isInfixOf "`- datum"
+                    output `shouldSatisfy` Text.isInfixOf "`- fields"
+                    output `shouldSatisfy` Text.isInfixOf "0: A: 42 | B: 43"
+                    output `shouldNotSatisfy` Text.isInfixOf "cbor:"
 
         it "uses a matched blueprint decoder to descend into redeemer data fields" $ do
             tx <- loadFixture sampleHash
@@ -1132,10 +1161,9 @@ spec =
                 output = renderDiffNodeHuman (diffConwayTxWith options txA txB)
             output
                 `shouldSatisfy` Text.isInfixOf
-                    "~ witnesses.redeemers.spending.0.data.amount"
+                    "amount: A: 42 | B: 43"
             output
-                `shouldSatisfy` Text.isInfixOf
-                    "  B: 43"
+                `shouldNotSatisfy` Text.isInfixOf "cbor:"
 
         it "reports an opt-in Conway key witness deletion keyed by key hash" $ do
             tx <- loadFixture sampleHash

--- a/test/Cardano/Node/Client/TxDiff/CoreSpec.hs
+++ b/test/Cardano/Node/Client/TxDiff/CoreSpec.hs
@@ -31,10 +31,15 @@ import Cardano.Node.Client.TxDiff (
     DiffNode (..),
     DiffPath (..),
     DiffPlan (..),
+    HumanRenderOptions (..),
     OpenValue (..),
+    RenderShape (..),
+    TreeArt (..),
+    defaultHumanRenderOptions,
     diffOpenValue,
     diffWith,
     renderDiffNodeHuman,
+    renderDiffNodeHumanWith,
  )
 
 spec :: Spec
@@ -182,7 +187,37 @@ spec =
                         [(3, Aeson.String "inserted")]
                     )
 
-        it "renders collected diff tree as human-readable path lines" $ do
+        it "renders collected diff tree as grouped ASCII tree by default" $ do
+            let left =
+                    OpenObject
+                        [
+                            ( "body"
+                            , OpenObject
+                                [ ("fee", OpenInteger 1)
+                                , ("ttl", OpenInteger 10)
+                                , ("same", OpenText "keep")
+                                ]
+                            )
+                        ]
+                right =
+                    OpenObject
+                        [
+                            ( "body"
+                            , OpenObject
+                                [ ("fee", OpenInteger 2)
+                                , ("ttl", OpenInteger 11)
+                                , ("same", OpenText "keep")
+                                ]
+                            )
+                        ]
+            renderDiffNodeHuman (diffOpenValue left right)
+                `shouldBe` Text.unlines
+                    [ "body"
+                    , "+- fee: A: 1 | B: 2"
+                    , "`- ttl: A: 10 | B: 11"
+                    ]
+
+        it "renders collected diff tree as explicit path lines" $ do
             let left =
                     OpenObject
                         [ ("same", OpenInteger 1)
@@ -195,13 +230,119 @@ spec =
                         , ("changed", OpenText "right")
                         , ("onlyB", OpenBytes "bb")
                         ]
-            renderDiffNodeHuman (diffOpenValue left right)
+                options =
+                    defaultHumanRenderOptions
+                        { humanRenderShape = RenderPaths
+                        }
+            renderDiffNodeHumanWith options (diffOpenValue left right)
                 `shouldBe` Text.unlines
                     [ "~ changed"
                     , "  A: \"left\""
                     , "  B: \"right\""
                     , "- onlyA: {\"bytes\":\"aa\"}"
                     , "+ onlyB: {\"bytes\":\"bb\"}"
+                    ]
+
+        it "preserves array-only tail entries in explicit path mode" $ do
+            let left =
+                    OpenArray
+                        [ OpenText "same"
+                        , OpenText "left-tail"
+                        ]
+                right =
+                    OpenArray
+                        [ OpenText "same"
+                        , OpenText "right-tail"
+                        , OpenText "inserted"
+                        ]
+                options =
+                    defaultHumanRenderOptions
+                        { humanRenderShape = RenderPaths
+                        }
+            renderDiffNodeHumanWith options (diffOpenValue left right)
+                `shouldBe` Text.unlines
+                    [ "~ 1"
+                    , "  A: \"left-tail\""
+                    , "  B: \"right-tail\""
+                    , "+ 2: \"inserted\""
+                    ]
+
+        it "renders tree output with Unicode connector art on request" $ do
+            let left =
+                    OpenObject
+                        [
+                            ( "body"
+                            , OpenObject
+                                [ ("fee", OpenInteger 1)
+                                , ("ttl", OpenInteger 10)
+                                ]
+                            )
+                        ]
+                right =
+                    OpenObject
+                        [
+                            ( "body"
+                            , OpenObject
+                                [ ("fee", OpenInteger 2)
+                                , ("ttl", OpenInteger 11)
+                                ]
+                            )
+                        ]
+                options =
+                    defaultHumanRenderOptions
+                        { humanTreeArt = TreeArtUnicode
+                        }
+            renderDiffNodeHumanWith options (diffOpenValue left right)
+                `shouldBe` Text.unlines
+                    [ "body"
+                    , " ├╴fee: A: 1 | B: 2"
+                    , " └╴ttl: A: 10 | B: 11"
+                    ]
+
+        it "orders numeric tree path segments numerically" $ do
+            let left =
+                    OpenObject
+                        [
+                            ( "outputs"
+                            , OpenArray
+                                [ OpenText "same"
+                                , OpenText "same"
+                                , OpenInteger 2
+                                , OpenText "same"
+                                , OpenText "same"
+                                , OpenText "same"
+                                , OpenText "same"
+                                , OpenText "same"
+                                , OpenText "same"
+                                , OpenText "same"
+                                , OpenInteger 10
+                                ]
+                            )
+                        ]
+                right =
+                    OpenObject
+                        [
+                            ( "outputs"
+                            , OpenArray
+                                [ OpenText "same"
+                                , OpenText "same"
+                                , OpenInteger 20
+                                , OpenText "same"
+                                , OpenText "same"
+                                , OpenText "same"
+                                , OpenText "same"
+                                , OpenText "same"
+                                , OpenText "same"
+                                , OpenText "same"
+                                , OpenInteger 100
+                                ]
+                            )
+                        ]
+            renderDiffNodeHuman (diffOpenValue left right)
+                `shouldBe` Text.unlines
+                    [ "outputs"
+                    , "+- 2: A: 2 | B: 20"
+                    , "`- 10: A: 10 | B: 100"
                     ]
 
         it "renders known coin values with exact ADA and lovelace units" $ do
@@ -214,9 +355,8 @@ spec =
                         )
             renderDiffNodeHuman diff
                 `shouldBe` Text.unlines
-                    [ "~ body.fee"
-                    , "  A: 1.000000 ADA (1000000 lovelace)"
-                    , "  B: 1.500000 ADA (1500000 lovelace)"
+                    [ "body"
+                    , "`- fee: A: 1.000000 ADA (1000000 lovelace) | B: 1.500000 ADA (1500000 lovelace)"
                     ]
 
         it "summarizes raw CBOR payloads in human-readable output" $ do
@@ -229,9 +369,10 @@ spec =
                         )
             renderDiffNodeHuman diff
                 `shouldBe` Text.unlines
-                    [ "~ body.outputs.0.datum"
-                    , "  A: cbor:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa... (40 bytes)"
-                    , "  B: cbor:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb... (40 bytes)"
+                    [ "body"
+                    , "`- outputs"
+                    , "   `- 0"
+                    , "      `- datum: A: cbor:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa... (40 bytes) | B: cbor:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb... (40 bytes)"
                     ]
 
         it "reports any equal generated value as same at the root" $

--- a/test/Cardano/Node/Client/TxDiffSpec.hs
+++ b/test/Cardano/Node/Client/TxDiffSpec.hs
@@ -3,6 +3,7 @@ module Cardano.Node.Client.TxDiffSpec (spec) where
 import Test.Hspec
 
 import Cardano.Node.Client.TxDiff.BlueprintSpec qualified as BlueprintSpec
+import Cardano.Node.Client.TxDiff.CliSpec qualified as CliSpec
 import Cardano.Node.Client.TxDiff.ConwaySpec qualified as ConwaySpec
 import Cardano.Node.Client.TxDiff.CoreSpec qualified as CoreSpec
 
@@ -10,5 +11,6 @@ spec :: Spec
 spec =
     describe "TxDiff structural traversal" $ do
         BlueprintSpec.spec
+        CliSpec.spec
         CoreSpec.spec
         ConwaySpec.spec


### PR DESCRIPTION
## Summary

- add explicit tx-diff human render options: tree vs paths, ASCII vs Unicode tree art
- default human output to compact ASCII tree rendering while preserving path-line rendering with `--render paths`
- keep changed leaves on one line as `A: ... | B: ...`, sort numeric path segments numerically, and avoid `Data.Tree.drawForest` spacer noise
- decode inline datum/redeemer data through the provided blueprints when possible, then fall back to structural Plutus `Data` instead of CBOR blobs
- move tx-diff CLI parsing into a pure parser so invalid render/art flags fail before input files are read
- record the Spec Kit dependency decision and implementation status

Closes #139

## Smoke Artifact

- Gist: https://gist.github.com/paolino/0097174c0fd21c2c1e99c5c6b7e341b5
- The gist now includes `plutus.json` and regenerates with:
  `tx-diff --blueprint plutus.json swap.cbor.hex bash.tx.json > tx-diff.human.txt`
- Verified remote gist output is ASCII-only, has no `Human` prefix, has no Unicode tree art, and has no `cbor:` datum rendering.

## Verification

- RED observed before implementation: `nix develop --quiet -c just unit` failed on missing render option/API and CLI parser module
- Regression observed during this fix: `nix develop --quiet -c just unit` failed while old Conway datum/redeemer expectations still asserted CBOR summaries
- `nix develop --quiet -c just unit` passed: 296 unit examples, 37 tx-build examples
- `nix develop --quiet -c just ci` passed: build, unit suites, cabal-fmt check, Fourmolu check, HLint; HLint reported `No hints`
