### PR TITLE
tx-diff: add named YAML collapse views

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Channel-driven Haskell clients for Cardano node Ouroboros mini-protocols (N2C + 
 - **Submitter** -- submit signed transactions
 - **Balance** -- exact-fee transaction balancing plus fee-dependent output convergence
 - **TxBuild** -- Conway-era transaction builder DSL with `Peek`, `Ctx`, and `Valid`
+- **TxDiff** -- structural Conway transaction diffing with blueprint-aware datum/redeemer decoding
 - **N2C** -- LocalStateQuery + LocalTxSubmission over Unix socket
 
 `Balance`, `TxBuild`, and the shared Conway transaction alias are also
@@ -21,6 +22,12 @@ existing users.
 
 ## Executables
 
+- [`tx-diff`](app/tx-diff/) -- compare two Conway
+  transactions, decode application-level datum/redeemer fields with Plutus
+  blueprints, and group repeated list diffs with YAML collapse rules. See the
+  [manual](docs/executables/tx-diff.md). Released builds are distributed as
+  Linux AppImage/DEB/RPM assets and as a macOS Homebrew formula:
+  `brew tap lambdasistemi/tap && brew install tx-diff`.
 - [`utxo-indexer`](app/utxo-indexer/) -- address->UTxO indexer daemon
   (in-memory or RocksDB-backed) exposing NDJSON snapshot/await over a
   Unix socket. In-process auto-reconnect on upstream-relay disconnect

--- a/app/tx-diff/Main.hs
+++ b/app/tx-diff/Main.hs
@@ -10,10 +10,13 @@ non-zero status when differences are present.
 module Main (main) where
 
 import Cardano.Node.Client.TxDiff (
+    CollapseRules,
+    HumanRenderOptions (..),
     TxDiffOptions (..),
     defaultTxDiffOptions,
     diffConwayTxInputWith,
     diffNodeHasChanges,
+    parseCollapseRulesYaml,
     renderDiffNodeHumanWith,
  )
 import Cardano.Node.Client.TxDiff.Blueprint (
@@ -42,6 +45,7 @@ main = do
 runDiff :: TxDiffCliOptions -> IO ()
 runDiff cliOptions = do
     blueprints <- traverse loadBlueprint (txDiffCliBlueprintPaths cliOptions)
+    collapseRules <- traverse loadCollapseRules (txDiffCliCollapseRulesPath cliOptions)
     left <- BS.readFile leftPath
     right <- BS.readFile rightPath
     let options =
@@ -60,7 +64,10 @@ runDiff cliOptions = do
         Right diff -> do
             TextIO.putStr $
                 renderDiffNodeHumanWith
-                    (txDiffCliHumanRenderOptions cliOptions)
+                    ( (txDiffCliHumanRenderOptions cliOptions)
+                        { humanCollapseRules = collapseRules
+                        }
+                    )
                     diff
             if diffNodeHasChanges diff
                 then exitFailure
@@ -82,6 +89,22 @@ loadBlueprint blueprintPath = do
             exitFailure
         Right blueprint ->
             pure blueprint
+
+loadCollapseRules :: FilePath -> IO CollapseRules
+loadCollapseRules collapseRulesPath = do
+    input <- BS.readFile collapseRulesPath
+    case parseCollapseRulesYaml input of
+        Left err -> do
+            hPutStrLn
+                stderr
+                ( "tx-diff: failed to decode collapse rules "
+                    <> collapseRulesPath
+                    <> ": "
+                    <> err
+                )
+            exitFailure
+        Right rules ->
+            pure rules
 
 dieUsage :: TxDiffCliError -> IO a
 dieUsage (TxDiffCliUsageError err) = do

--- a/app/tx-diff/README.md
+++ b/app/tx-diff/README.md
@@ -1,0 +1,29 @@
+# tx-diff
+
+`tx-diff` compares two encoded Conway transactions and prints structural
+differences.
+
+Install released builds:
+
+```bash
+# macOS
+brew tap lambdasistemi/tap
+brew install tx-diff
+```
+
+Linux users can download `tx-diff-<version>-x86_64-linux.AppImage`,
+`.deb`, or `.rpm` from the
+[GitHub Releases](https://github.com/lambdasistemi/cardano-node-clients/releases)
+page.
+
+Use the main documentation for the executable manual, tutorials, collapse-rule
+YAML, blueprint behavior, exit codes, and troubleshooting:
+
+- [tx-diff manual](../../docs/executables/tx-diff.md)
+- [TxDiff architecture](../../docs/modules/tx-diff.md)
+
+Quick command:
+
+```bash
+tx-diff --collapse-rules collapse.yaml --blueprint plutus.json tx-a.cbor tx-b.cbor
+```

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -174,6 +174,7 @@ library
     , tree-view
     , typed-protocols
     , unix
+    , yaml
 
 library plutus-blueprint
   import:           warnings

--- a/docs/executables/tx-diff.md
+++ b/docs/executables/tx-diff.md
@@ -1,0 +1,390 @@
+# tx-diff
+
+`tx-diff` compares two encoded Conway transactions and prints the actionable
+structural differences. It is meant for reviewing how two transaction builders,
+scripts, wallets, or command lines differ before submission.
+
+The executable understands:
+
+- CBOR hex transactions
+- raw CBOR transactions
+- cardano-cli JSON transaction envelopes
+
+It compares the transaction structure, optionally decodes Plutus datum and
+redeemer data with Plutus blueprints, and renders a human diff.
+
+## Install
+
+Use the release artifacts unless you are developing the repository.
+
+### macOS
+
+`tx-diff` is published to the `lambdasistemi/homebrew-tap` Homebrew tap:
+
+```bash
+brew tap lambdasistemi/tap
+brew install tx-diff
+```
+
+The release workflow builds and smoke-tests an Apple Silicon tarball named:
+
+```text
+tx-diff-<version>-aarch64-darwin.tar.gz
+```
+
+The tarball is attached to the matching GitHub Release, and the Homebrew
+formula points at that release asset.
+
+### Linux
+
+Linux releases are attached to the
+[GitHub Releases](https://github.com/lambdasistemi/cardano-node-clients/releases)
+page as AppImage, DEB, and RPM artifacts:
+
+```text
+tx-diff-<version>-x86_64-linux.AppImage
+tx-diff-<version>-x86_64-linux.deb
+tx-diff-<version>-x86_64-linux.rpm
+SHA256SUMS
+```
+
+For an AppImage:
+
+```bash
+chmod +x tx-diff-<version>-x86_64-linux.AppImage
+./tx-diff-<version>-x86_64-linux.AppImage tx-a.cbor tx-b.cbor
+```
+
+For Debian or Ubuntu:
+
+```bash
+sudo apt install ./tx-diff-<version>-x86_64-linux.deb
+```
+
+For Fedora, RHEL, or compatible distributions:
+
+```bash
+sudo dnf install ./tx-diff-<version>-x86_64-linux.rpm
+```
+
+Verify downloaded artifacts with:
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+### Development Channels
+
+Unreleased Linux builds can be published to the `dev-linux` prerelease.
+Unreleased macOS builds can be published through the `tx-diff-dev` Homebrew
+formula:
+
+```bash
+brew tap lambdasistemi/tap
+brew install tx-diff-dev
+```
+
+Use these only when testing a branch before a normal release.
+
+## Build From Source
+
+```bash
+nix develop -c just build
+nix develop -c cabal run cardano-node-clients:exe:tx-diff -- tx-a.cbor tx-b.cbor
+```
+
+For a local development binary path:
+
+```bash
+nix develop -c cabal list-bin cardano-node-clients:exe:tx-diff -O0
+```
+
+## Quick Start
+
+Compare two transactions:
+
+```bash
+tx-diff tx-a.cbor tx-b.cbor
+```
+
+Use a Plutus blueprint to decode application-level datum and redeemer fields:
+
+```bash
+tx-diff --blueprint plutus.json tx-a.cbor tx-b.cbor
+```
+
+Use a collapse-rules file to group repeated list-item diffs into semantic
+views:
+
+```bash
+tx-diff --collapse-rules collapse.yaml --blueprint plutus.json tx-a.cbor tx-b.cbor
+```
+
+## CLI Reference
+
+```text
+tx-diff [--render tree|paths] [--tree-art ascii|unicode] \
+  [--collapse-rules FILE] [--blueprint FILE ...] TX_A TX_B
+```
+
+Arguments:
+
+- `TX_A`: first transaction input.
+- `TX_B`: second transaction input.
+
+Options:
+
+- `--render tree`: render a grouped tree. This is the default.
+- `--render paths`: render one changed path per line.
+- `--tree-art ascii`: use ASCII connectors. This is the default.
+- `--tree-art unicode`: use Unicode tree connectors.
+- `--blueprint FILE`: load a Plutus blueprint. The option can be repeated.
+- `--collapse-rules FILE`: load YAML rules for named list-diff views.
+
+Exit status:
+
+- `0`: the decoded transactions are equal.
+- `1`: the decoded transactions differ.
+- `1`: input, blueprint, collapse-rule, or CLI parsing failed.
+
+## Render Modes
+
+Tree mode groups changed leaves by path:
+
+```text
+body
+`- fee
+   +- A: 1.038522 ADA (1038522 lovelace)
+   `- B: 1.042614 ADA (1042614 lovelace)
+```
+
+Path mode is useful for scripts that want stable text lines:
+
+```bash
+tx-diff --render paths tx-a.cbor tx-b.cbor
+```
+
+Use Unicode tree art only when the output target preserves it:
+
+```bash
+tx-diff --tree-art unicode tx-a.cbor tx-b.cbor
+```
+
+## Blueprint Decoding
+
+Without a blueprint, Plutus datum and redeemer data are rendered as raw Plutus
+data. With `--blueprint`, `tx-diff` tries to decode that data into the open
+application structure described by the blueprint.
+
+```bash
+tx-diff --blueprint plutus.json tx-a.cbor tx-b.cbor
+```
+
+Multiple blueprints are accepted:
+
+```bash
+tx-diff --blueprint order.plutus.json --blueprint pool.plutus.json tx-a.cbor tx-b.cbor
+```
+
+The decoder uses only unambiguous matches. If no blueprint argument matches, or
+if multiple matches are ambiguous, that datum or redeemer remains rendered as
+raw Plutus data. This keeps the diff honest: the tool does not invent
+application semantics.
+
+## Collapse Rules
+
+Collapse rules are a YAML rendering layer for repeated list differences. They
+do not change the transaction comparison. They only define named views over
+changed list items so a user can read repeated application-level differences
+without scanning every raw index.
+
+Create `collapse.yaml`:
+
+```yaml
+version: 1
+
+views:
+  raw: hide
+
+collapse:
+  - name: swapOrders
+    at: body.outputs
+    match:
+      required:
+        - coin
+        - datum.fields.4.fields.0.2
+        - datum.fields.4.fields.1.2
+```
+
+Run:
+
+```bash
+tx-diff --collapse-rules collapse.yaml --blueprint plutus.json tx-a.cbor tx-b.cbor
+```
+
+### YAML Fields
+
+- `version`: required schema version. Version `1` is the only supported value.
+- `views.raw`: optional raw-list policy. `show` is the default; `hide`
+  suppresses the raw branch only where named views exist.
+- `collapse`: optional list of named overlay rules.
+- `collapse[*].name`: required rendered view name, for example `swapOrders`.
+- `collapse[*].at`: required absolute path to an array/list node, for example
+  `body.outputs`.
+- `collapse[*].match.required`: non-empty list of relative paths inside each
+  changed list item.
+
+### Path Syntax
+
+Paths are dot-separated object keys and numeric list indexes. They are written
+against the open transaction diff tree after blueprint decoding.
+
+- `at` is absolute from the diff root, for example `body.outputs`.
+- `match.required` is relative to one item under that list, for example `coin`
+  or `datum.fields.4.fields.0.2`.
+- The rule file has no wildcards, predicates, formulas, sums, deltas, or
+  semigroup aggregation.
+
+### Matching Semantics
+
+A rule applies at its `at` path when that path is a changed list. For each
+changed list item, the item is selected when all `match.required` paths exist
+as changed leaves inside that item.
+
+Selected leaves are transposed so the list index moves down to the changed
+leaf. Exact equal A/B leaf pairs are grouped and rendered as index ranges.
+
+Rules are overlays, not partitions. If two rules match the same list item, both
+named views render their own projection.
+
+### Raw View Policy
+
+With `views.raw: show`, the original list diff remains available under a `raw`
+branch when named views exist at that list path.
+
+With `views.raw: hide`, the raw branch is omitted, but unrepresented diffs are
+not dropped. Changed leaves, insertions, and deletions not represented by a
+named view render directly under their original numeric indexes.
+
+## Tutorial: Swap Order Review
+
+This example groups repeated output differences under a semantic `swapOrders`
+view while keeping unmatched outputs visible by their numeric index.
+
+`collapse.yaml`:
+
+```yaml
+version: 1
+views:
+  raw: hide
+collapse:
+  - name: swapOrders
+    at: body.outputs
+    match:
+      required:
+        - coin
+        - datum.fields.4.fields.0.2
+        - datum.fields.4.fields.1.2
+```
+
+Command:
+
+```bash
+tx-diff --collapse-rules collapse.yaml --blueprint plutus.json swap.cbor.hex bash.tx.json
+```
+
+Output shape:
+
+```text
+body
++- fee
+|  +- A: 1.038522 ADA (1038522 lovelace)
+|  `- B: 1.042614 ADA (1042614 lovelace)
++- outputs
+|  +- swapOrders
+|  |  +- coin
+|  |  |  +- 0..4
+|  |  |  |  +- A: 12371.863798 ADA (12371863798 lovelace)
+|  |  |  |  `- B: 12503.280000 ADA (12503280000 lovelace)
+|  |  |  `- 32
+|  |  |     +- A: 12371.863797 ADA (12371863797 lovelace)
+|  |  |     `- B:   8166.545306 ADA (8166545306 lovelace)
+|  |  `- datum
+|  |     `- fields
+|  |        `- 4
+|  |           `- fields
+|  |              `- 0
+|  |                 `- 2
+|  |                    `- 0..4
+|  |                       +- A: 12368583798
+|  |                       `- B: 12500000000
+|  +- 33
+|  |  `- coin
+|  |     +- A: 1041728.494694 ADA (1041728494694 lovelace)
+|  |     `- B: 1041836.734694 ADA (1041836734694 lovelace)
+|  `- 34
+|     `- coin
+|        +- A: 50006.200754 ADA (50006200754 lovelace)
+|        `- B: 49897.956662 ADA (49897956662 lovelace)
+`- totalCollateral
+   +- A: 1.557783 ADA (1557783 lovelace)
+   `- B: 1.563921 ADA (1563921 lovelace)
+```
+
+How to read it:
+
+- `swapOrders` is the named rule result.
+- `0..4` and `32` are original list indexes grouped at the changed leaf.
+- `33` and `34` are unmatched output diffs that remain visible because the raw
+  view is hidden but differences must not disappear.
+- A and B are separate child rows, right-aligned per changed leaf.
+- ADA amounts are shown in ADA and lovelace where the field is known to be a
+  coin value.
+
+The fixture output used while developing this feature is available in the
+gist: <https://gist.github.com/paolino/0097174c0fd21c2c1e99c5c6b7e341b5>.
+
+## Troubleshooting
+
+`tx-diff: failed to decode input`
+: Check that both transaction files are CBOR hex, raw CBOR, or cardano-cli JSON
+  envelopes.
+
+`tx-diff: failed to decode blueprint`
+: The blueprint file is not valid JSON or is not in the supported Plutus
+  blueprint shape.
+
+`tx-diff: failed to decode collapse rules`
+: The YAML is invalid, the version is unsupported, `views.raw` is not `show` or
+  `hide`, or a rule is missing required fields.
+
+The collapse view does not decode datum fields
+: Pass the matching `--blueprint` file. Collapse paths are written against the
+  decoded open tree when decoding succeeds, and against raw Plutus data when it
+  does not.
+
+The collapse view hides something I expected to see
+: `views.raw: hide` only hides the raw branch where named views exist. Diffs
+  not represented by a named view still render under numeric indexes. Use
+  `views.raw: show` when you also want the full original per-index list view.
+
+## Roadmap
+
+The current release compares the two transaction bodies provided on disk. Two
+follow-up capabilities are planned:
+
+- **WASM support**: make the tx-diff engine available in browser and other
+  WebAssembly environments.
+- **Input resolution through cardano-node N2C**: connect to a local
+  cardano-node socket to resolve transaction inputs while diffing, so the
+  output can include context that is not present in the signed transaction
+  bytes alone.
+
+These are not required for the release artifacts above. They are listed here
+so users know where the executable is heading.
+
+## Specification Contract
+
+The main user manual is this page. The lower-level Spec Kit contract for the
+collapse-rule file lives in
+[`specs/142-tx-diff-collapse-views/contracts/collapse-rules.yaml.md`](https://github.com/lambdasistemi/cardano-node-clients/blob/main/specs/142-tx-diff-collapse-views/contracts/collapse-rules.yaml.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ Cardano node:
 - **Submitter** -- submit signed transactions
 - **Balance** -- exact-fee balancing and fee-dependent output convergence
 - **TxBuild** -- Conway-era transaction builder DSL with `Peek` fixpoints and pluggable `Ctx` queries
+- **TxDiff** -- structural transaction diffing with blueprint-aware datum/redeemer decoding ([architecture](modules/tx-diff.md))
 - **Validity** -- pick an `invalid-hereafter` slot inside the chain's plutus-translation horizon ([details](modules/validity.md))
 
 `Balance` and `TxBuild` are implemented by the public
@@ -26,6 +27,14 @@ protocol supplies its own constructor:
 |----------|----------|-----------|
 | N2C (Unix socket) | `mkN2CProvider` | `mkN2CSubmitter` |
 | N2N (TCP) | planned | planned |
+
+## Executables
+
+- **tx-diff** -- compare two Conway transactions, optionally decode Plutus
+  datum/redeemer data with blueprints, and group repeated list diffs with YAML
+  collapse rules ([manual](executables/tx-diff.md)). Install released builds
+  from the GitHub Release assets on Linux or with
+  `brew tap lambdasistemi/tap && brew install tx-diff` on macOS.
 
 ## Current TxBuild status
 

--- a/docs/modules/tx-diff.md
+++ b/docs/modules/tx-diff.md
@@ -1,0 +1,105 @@
+# TxDiff
+
+`Cardano.Node.Client.TxDiff` is the structural comparison engine behind the
+[`tx-diff` executable](../executables/tx-diff.md).
+
+The module has two jobs:
+
+- turn Conway transactions into an open diff tree that can include
+  application-level datum and redeemer values
+- render that tree in human-oriented forms without losing the original
+  transaction structure
+
+## Architecture
+
+The comparison pipeline is deliberately split into three layers:
+
+1. Decode each transaction input into a Conway transaction.
+2. Project the transaction into an open value tree.
+3. Traverse both trees in parallel and stop descending when equality proves a
+   subtree is identical.
+
+That last point matters. Equality is the guardrail that prevents the renderer
+from drowning the user in unchanged structure. Only changed, inserted, and
+deleted branches survive into the `DiffNode` tree.
+
+## Open Values
+
+The renderer does not try to preserve the full Haskell type of every ledger
+field. It uses an open value shape:
+
+- objects for named fields
+- arrays for ordered ledger lists
+- scalars for numbers, text, hashes, summaries, and rendered ledger values
+
+This is intentional. Transaction users reason about the transaction shape, but
+application-level datum and redeemer schemas are open-ended. A Plutus blueprint
+can decode part of that world into named fields, and the diff tree can embed
+those fields without needing a new Haskell type for each contract.
+
+## Blueprint Boundary
+
+Blueprint decoding happens before rendering. If a datum or redeemer can be
+decoded unambiguously by the provided blueprints, raw Plutus data is replaced
+with the decoded open value. If decoding fails or is ambiguous, the value stays
+raw.
+
+This keeps the invariant simple: rendering always consumes one open diff tree.
+It does not special-case contract data after the diff has already been built.
+
+## Collapse Rules
+
+Collapse rules are a render-time overlay for list diffs. They do not alter the
+core comparison.
+
+For each rule:
+
+1. Find the changed list at `collapse[*].at`.
+2. Select changed list items where all `match.required` paths exist.
+3. Keep only those required changed leaves.
+4. Move the original list indexes down to each leaf.
+5. Group exact equal A/B leaf pairs into index ranges.
+6. Insert the result under the rule name.
+
+The raw list can still be rendered under `raw`, or hidden with
+`views.raw: hide`. Hiding raw does not hide unrepresented diffs; they remain
+under their original numeric indexes.
+
+Rules are overlays rather than partitions. Two rules may match the same item
+because each name represents a semantic view, not ownership of a diff.
+
+## Rendering
+
+Tree rendering inserts changed leaves as path nodes with separate `A:` and
+`B:` child rows. The values are right-aligned per changed leaf:
+
+```text
+fee
++- A:  1
+`- B: 20
+```
+
+The executable defaults to ASCII tree art. Unicode tree art is available for
+terminals and renderers that preserve it.
+
+## Planned Boundaries
+
+Two planned extensions keep the same architectural shape:
+
+- **WASM support** should reuse the open diff tree and renderer contracts while
+  replacing the executable boundary with a WebAssembly-callable API.
+- **Input resolution through cardano-node N2C** should add an optional
+  context-acquisition layer before rendering. The diff core should still
+  compare explicit transactions; N2C resolution enriches what the renderer can
+  explain about inputs that are only referenced by `TxIn`.
+
+Keeping these as boundaries around the open diff tree avoids mixing network IO,
+ledger lookup, or browser packaging concerns into the structural comparison
+logic.
+
+## User Manual
+
+Use the executable manual for CLI flags, collapse-rule YAML, tutorials, and
+troubleshooting:
+
+- [`tx-diff` executable manual](../executables/tx-diff.md)

--- a/lib/Cardano/Node/Client/TxDiff.hs
+++ b/lib/Cardano/Node/Client/TxDiff.hs
@@ -9,6 +9,9 @@ diff feature. The central rule is equality first: paired values are compared
 before any child projection is requested.
 -}
 module Cardano.Node.Client.TxDiff (
+    CollapseRawView (..),
+    CollapseRule (..),
+    CollapseRules (..),
     DiffChange (..),
     DiffNode (..),
     DiffPlan (..),
@@ -33,15 +36,18 @@ module Cardano.Node.Client.TxDiff (
     diffNodeHasChanges,
     diffOpenValue,
     diffWith,
+    parseCollapseRulesYaml,
     renderConwayTxInputDiff,
     renderDiffNodeHuman,
     renderDiffNodeHumanWith,
 ) where
 
-import Data.Aeson ((.:), (.=))
+import Control.Monad (when)
+import Data.Aeson (FromJSON (..), (.:), (.:?), (.=))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Key
 import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Aeson.Types ((.!=))
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
@@ -59,6 +65,7 @@ import Data.Text qualified as Text
 import Data.Text.Encoding qualified as TextEncoding
 import Data.Tree qualified as Tree
 import Data.Tree.View qualified as TreeView
+import Data.Yaml qualified as Yaml
 import Lens.Micro ((^.))
 import Text.Read (readMaybe)
 
@@ -142,7 +149,7 @@ import Cardano.Slotting.Slot (SlotNo (..))
 import PlutusCore.Data qualified as PLC
 
 newtype DiffPath = DiffPath [Text]
-    deriving stock (Eq, Show)
+    deriving stock (Eq, Ord, Show)
 
 data DiffNode = DiffNode DiffPath DiffChange
     deriving stock (Eq, Show)
@@ -234,6 +241,7 @@ data TreeArt
 data HumanRenderOptions = HumanRenderOptions
     { humanRenderShape :: RenderShape
     , humanTreeArt :: TreeArt
+    , humanCollapseRules :: Maybe CollapseRules
     }
     deriving stock (Eq, Show)
 
@@ -243,7 +251,92 @@ defaultHumanRenderOptions =
     HumanRenderOptions
         { humanRenderShape = RenderTree
         , humanTreeArt = TreeArtAscii
+        , humanCollapseRules = Nothing
         }
+
+data CollapseRawView
+    = CollapseRawShow
+    | CollapseRawHide
+    deriving stock (Eq, Show)
+
+data CollapseRules = CollapseRules
+    { collapseRawView :: CollapseRawView
+    , collapseRules :: [CollapseRule]
+    }
+    deriving stock (Eq, Show)
+
+data CollapseRule = CollapseRule
+    { collapseRuleName :: Text
+    , collapseRuleAt :: DiffPath
+    , collapseRuleRequired :: [DiffPath]
+    }
+    deriving stock (Eq, Show)
+
+newtype CollapseRuleMatch = CollapseRuleMatch [DiffPath]
+
+newtype CollapseViews = CollapseViews CollapseRawView
+
+parseCollapseRulesYaml :: BS.ByteString -> Either String CollapseRules
+parseCollapseRulesYaml input =
+    case Yaml.decodeEither' input of
+        Left err ->
+            Left (Yaml.prettyPrintParseException err)
+        Right rules ->
+            Right rules
+
+instance FromJSON CollapseRules where
+    parseJSON =
+        Aeson.withObject "CollapseRules" $ \value -> do
+            version <- value .:? "version" .!= (1 :: Int)
+            when (version /= 1) $
+                fail ("unsupported collapse rules version: " <> show version)
+            CollapseViews rawView <- value .:? "views" .!= CollapseViews CollapseRawShow
+            rules <- value .:? "collapse" .!= []
+            pure
+                CollapseRules
+                    { collapseRawView = rawView
+                    , collapseRules = rules
+                    }
+
+instance FromJSON CollapseViews where
+    parseJSON =
+        Aeson.withObject "CollapseViews" $ \value ->
+            CollapseViews <$> value .:? "raw" .!= CollapseRawShow
+
+instance FromJSON CollapseRawView where
+    parseJSON =
+        Aeson.withText "CollapseRawView" $ \value ->
+            case value of
+                "show" ->
+                    pure CollapseRawShow
+                "hide" ->
+                    pure CollapseRawHide
+                _ ->
+                    fail ("unsupported raw collapse view: " <> Text.unpack value)
+
+instance FromJSON CollapseRule where
+    parseJSON =
+        Aeson.withObject "CollapseRule" $ \value -> do
+            name <- value .: "name"
+            at <- value .: "at"
+            CollapseRuleMatch required <- value .: "match"
+            when (null required) $
+                fail "collapse rule match.required must not be empty"
+            pure
+                CollapseRule
+                    { collapseRuleName = name
+                    , collapseRuleAt = at
+                    , collapseRuleRequired = required
+                    }
+
+instance FromJSON CollapseRuleMatch where
+    parseJSON =
+        Aeson.withObject "CollapseRuleMatch" $ \value ->
+            CollapseRuleMatch <$> value .: "required"
+
+instance FromJSON DiffPath where
+    parseJSON =
+        Aeson.withText "DiffPath" (pure . textDiffPath)
 
 data ConwayDiffValue
     = ConwayTxValue ConwayTx
@@ -505,7 +598,7 @@ renderDiffNodeHumanWith options diff =
         RenderPaths ->
             Text.unlines (renderDiffNodeLines diff)
         RenderTree ->
-            renderDiffNodeTree (humanTreeArt options) diff
+            renderDiffNodeTree options diff
 
 data RenderTrie = RenderTrie
     { renderTrieLeaves :: [Tree.Tree Text]
@@ -513,9 +606,12 @@ data RenderTrie = RenderTrie
     }
 
 data RenderSegmentSortKey
-    = RenderSegmentNumber Integer Text
-    | RenderSegmentText Text
+    = RenderSegmentText Text
+    | RenderSegmentNumber Integer Text
     deriving stock (Eq, Ord, Show)
+
+data LeafDiff = LeafDiff Aeson.Value Aeson.Value
+    deriving stock (Eq, Show)
 
 emptyRenderTrie :: RenderTrie
 emptyRenderTrie =
@@ -524,28 +620,35 @@ emptyRenderTrie =
         , renderTrieChildren = Map.empty
         }
 
-renderDiffNodeTree :: TreeArt -> DiffNode -> Text
-renderDiffNodeTree treeArt diff@(DiffNode _ change) =
+renderDiffNodeTree :: HumanRenderOptions -> DiffNode -> Text
+renderDiffNodeTree options diff@(DiffNode _ change) =
     case change of
         DiffSame _ ->
             Text.unlines (renderDiffNodeLines diff)
         _ ->
-            renderForest treeArt $
-                renderTrieForest (collectDiffTree emptyRenderTrie diff)
+            renderForest (humanTreeArt options) $
+                renderTrieForest $
+                    collectDiffTree
+                        (humanCollapseRules options)
+                        emptyRenderTrie
+                        diff
 
-collectDiffTree :: RenderTrie -> DiffNode -> RenderTrie
-collectDiffTree trie (DiffNode path change) =
+collectDiffTree :: Maybe CollapseRules -> RenderTrie -> DiffNode -> RenderTrie
+collectDiffTree collapseRules trie node@(DiffNode path change) =
     case change of
         DiffSame _ ->
             trie
         DiffChanged left right ->
             insertPath
-                (renderChangedPathSegments path left right)
-                []
+                (renderChangedPathSegments path)
+                (renderChangedValueLeaves left right)
                 trie
         DiffObject _ changed onlyA onlyB ->
             let withChanged =
-                    foldl' collectDiffTree trie (Map.elems changed)
+                    foldl'
+                        (collectDiffTree collapseRules)
+                        trie
+                        (Map.elems changed)
                 withOnlyA =
                     foldl'
                         (insertObjectOnly "-" path)
@@ -555,10 +658,64 @@ collectDiffTree trie (DiffNode path change) =
                     (insertObjectOnly "+" path)
                     withOnlyA
                     (Map.toAscList onlyB)
+        DiffArray common changed onlyA onlyB ->
+            collectDiffArray collapseRules trie node path common changed onlyA onlyB
+
+collectDiffArray ::
+    Maybe CollapseRules ->
+    RenderTrie ->
+    DiffNode ->
+    DiffPath ->
+    [(Int, Maybe Aeson.Value)] ->
+    [(Int, DiffNode)] ->
+    [(Int, Aeson.Value)] ->
+    [(Int, Aeson.Value)] ->
+    RenderTrie
+collectDiffArray collapseConfig trie node path common changed onlyA onlyB =
+    let matchingRules =
+            collapseRulesAt collapseConfig path
+        (withViews, hasView) =
+            foldl'
+                (insertCollapseView path changed)
+                (trie, False)
+                matchingRules
+        coveredLeaves =
+            collapseCoveredLeafPaths matchingRules changed
+        remainderChanged =
+            [ (index, remainderItem)
+            | (index, item) <- changed
+            , Just remainderItem <-
+                [ pruneCoveredLeaves
+                    (Map.findWithDefault Set.empty index coveredLeaves)
+                    item
+                ]
+            ]
+        remainderNode =
+            DiffNode path (DiffArray common remainderChanged onlyA onlyB)
+     in case (hasView, collapseRawViewEnabled collapseConfig) of
+            (False, _) ->
+                collectRawDiffArray collapseConfig trie node
+            (True, CollapseRawShow) ->
+                collectRawDiffArray
+                    collapseConfig
+                    withViews
+                    (rebaseDiffNode path (path </> "raw") node)
+            (True, CollapseRawHide)
+                | diffNodeHasChanges remainderNode ->
+                    collectRawDiffArray
+                        collapseConfig
+                        withViews
+                        remainderNode
+                | otherwise ->
+                    withViews
+
+collectRawDiffArray :: Maybe CollapseRules -> RenderTrie -> DiffNode -> RenderTrie
+collectRawDiffArray collapseRules trie (DiffNode path change) =
+    case change of
         DiffArray _ changed onlyA onlyB ->
             let withChanged =
                     foldl'
-                        collectDiffTree
+                        (collectDiffTree collapseRules)
                         trie
                         (map snd changed)
                 withOnlyA =
@@ -570,6 +727,240 @@ collectDiffTree trie (DiffNode path change) =
                     (insertArrayOnly "+" path)
                     withOnlyA
                     onlyB
+        _ ->
+            collectDiffTree collapseRules trie (DiffNode path change)
+
+collapseRulesAt :: Maybe CollapseRules -> DiffPath -> [CollapseRule]
+collapseRulesAt Nothing _ =
+    []
+collapseRulesAt (Just rules) path =
+    [ rule
+    | rule <- collapseRules rules
+    , collapseRuleAt rule == path
+    ]
+
+collapseRawViewEnabled :: Maybe CollapseRules -> CollapseRawView
+collapseRawViewEnabled Nothing =
+    CollapseRawShow
+collapseRawViewEnabled (Just rules) =
+    collapseRawView rules
+
+collapseCoveredLeafPaths ::
+    [CollapseRule] ->
+    [(Int, DiffNode)] ->
+    Map Int (Set.Set DiffPath)
+collapseCoveredLeafPaths rules changed =
+    foldl' coverRule Map.empty rules
+  where
+    coverRule covered rule =
+        foldl' (coverItem rule) covered changed
+    coverItem rule covered (index, item)
+        | ruleMatchesItem rule item =
+            Map.insertWith
+                Set.union
+                index
+                (Set.fromList (collapseRuleRequired rule))
+                covered
+        | otherwise =
+            covered
+
+pruneCoveredLeaves :: Set.Set DiffPath -> DiffNode -> Maybe DiffNode
+pruneCoveredLeaves covered node@(DiffNode rootPath _) =
+    prune node
+  where
+    prune current@(DiffNode path change) =
+        case change of
+            DiffSame _ ->
+                Nothing
+            DiffChanged _ _
+                | leafCovered path ->
+                    Nothing
+                | otherwise ->
+                    Just current
+            DiffObject common changed onlyA onlyB ->
+                keepIfChanged $
+                    DiffNode
+                        path
+                        ( DiffObject
+                            common
+                            (Map.mapMaybe prune changed)
+                            onlyA
+                            onlyB
+                        )
+            DiffArray common changed onlyA onlyB ->
+                keepIfChanged $
+                    DiffNode
+                        path
+                        ( DiffArray
+                            common
+                            [ (index, pruned)
+                            | (index, item) <- changed
+                            , Just pruned <- [prune item]
+                            ]
+                            onlyA
+                            onlyB
+                        )
+    keepIfChanged pruned
+        | diffNodeHasChanges pruned =
+            Just pruned
+        | otherwise =
+            Nothing
+    leafCovered path =
+        case stripDiffPathPrefix rootPath path of
+            Just relativePath ->
+                relativePath `Set.member` covered
+            Nothing ->
+                False
+
+insertCollapseView ::
+    DiffPath ->
+    [(Int, DiffNode)] ->
+    (RenderTrie, Bool) ->
+    CollapseRule ->
+    (RenderTrie, Bool)
+insertCollapseView listPath changed (trie, hasView) rule =
+    case matchingItems of
+        [] ->
+            (trie, hasView)
+        _ ->
+            ( foldl'
+                insertRequiredPath
+                trie
+                (collapseRuleRequired rule)
+            , True
+            )
+  where
+    matchingItems =
+        [ (index, item, changedLeavesFromItem item)
+        | (index, item) <- changed
+        , ruleMatchesItem rule item
+        ]
+    viewPath =
+        listPath </> collapseRuleName rule
+    insertRequiredPath currentTrie requiredPath =
+        let grouped =
+                groupLeafDiffs
+                    [ (index, leaf)
+                    | (index, _, leaves) <- matchingItems
+                    , Just leaf <- [lookup requiredPath leaves]
+                    ]
+         in foldl'
+                (insertLeafGroup requiredPath)
+                currentTrie
+                grouped
+    insertLeafGroup requiredPath currentTrie (indices, LeafDiff left right) =
+        insertPath
+            ( diffPathSegments (viewPath </!> requiredPath)
+                <> [renderIndexRanges indices]
+            )
+            (renderChangedValueLeaves left right)
+            currentTrie
+
+ruleMatchesItem :: CollapseRule -> DiffNode -> Bool
+ruleMatchesItem rule item =
+    all
+        (`elem` map fst leaves)
+        (collapseRuleRequired rule)
+  where
+    leaves =
+        changedLeavesFromItem item
+
+changedLeavesFromItem :: DiffNode -> [(DiffPath, LeafDiff)]
+changedLeavesFromItem item@(DiffNode rootPath _) =
+    [ (relativePath, leaf)
+    | (absolutePath, leaf) <- changedLeaves item
+    , Just relativePath <- [stripDiffPathPrefix rootPath absolutePath]
+    ]
+
+changedLeaves :: DiffNode -> [(DiffPath, LeafDiff)]
+changedLeaves (DiffNode path change) =
+    case change of
+        DiffSame _ ->
+            []
+        DiffChanged left right ->
+            [(path, LeafDiff left right)]
+        DiffObject _ changed _ _ ->
+            concatMap changedLeaves (Map.elems changed)
+        DiffArray _ changed _ _ ->
+            concatMap (changedLeaves . snd) changed
+
+groupLeafDiffs :: [(Int, LeafDiff)] -> [([Int], LeafDiff)]
+groupLeafDiffs =
+    foldl' addLeafDiffGroup []
+  where
+    addLeafDiffGroup [] (index, leaf) =
+        [([index], leaf)]
+    addLeafDiffGroup ((indices, leaf) : rest) (index, newLeaf)
+        | leaf == newLeaf =
+            (indices <> [index], leaf) : rest
+    addLeafDiffGroup (group : rest) indexedLeaf =
+        group : addLeafDiffGroup rest indexedLeaf
+
+renderIndexRanges :: [Int] -> Text
+renderIndexRanges indices =
+    Text.intercalate "," $
+        map renderRange $
+            contiguousRanges (List.sort indices)
+  where
+    renderRange (start, end)
+        | start == end =
+            Text.pack (show start)
+        | otherwise =
+            Text.pack (show start) <> ".." <> Text.pack (show end)
+
+contiguousRanges :: [Int] -> [(Int, Int)]
+contiguousRanges [] =
+    []
+contiguousRanges (firstIndex : rest) =
+    reverse (foldl' step [(firstIndex, firstIndex)] rest)
+  where
+    step [] index =
+        [(index, index)]
+    step ((start, end) : ranges) index
+        | index == end + 1 =
+            (start, index) : ranges
+        | otherwise =
+            (index, index) : (start, end) : ranges
+
+rebaseDiffNode :: DiffPath -> DiffPath -> DiffNode -> DiffNode
+rebaseDiffNode oldPath newPath (DiffNode path change) =
+    DiffNode (replaceDiffPathPrefix oldPath newPath path) $
+        case change of
+            DiffSame value ->
+                DiffSame value
+            DiffChanged left right ->
+                DiffChanged left right
+            DiffObject common changed onlyA onlyB ->
+                DiffObject
+                    common
+                    (Map.map (rebaseDiffNode oldPath newPath) changed)
+                    onlyA
+                    onlyB
+            DiffArray common changed onlyA onlyB ->
+                DiffArray
+                    common
+                    [ ( index
+                      , rebaseDiffNode oldPath newPath child
+                      )
+                    | (index, child) <- changed
+                    ]
+                    onlyA
+                    onlyB
+
+stripDiffPathPrefix :: DiffPath -> DiffPath -> Maybe DiffPath
+stripDiffPathPrefix (DiffPath prefix) (DiffPath path)
+    | prefix `List.isPrefixOf` path =
+        Just (DiffPath (drop (length prefix) path))
+    | otherwise =
+        Nothing
+
+replaceDiffPathPrefix :: DiffPath -> DiffPath -> DiffPath -> DiffPath
+replaceDiffPathPrefix oldPath newPath path =
+    case stripDiffPathPrefix oldPath path of
+        Just relativePath ->
+            newPath </!> relativePath
+        Nothing ->
+            path
 
 insertObjectOnly ::
     Text ->
@@ -666,33 +1057,44 @@ renderAsciiChildren prefix children =
                 if isLast then "   " else "|  "
         ]
 
-renderChangedPathSegments :: DiffPath -> Aeson.Value -> Aeson.Value -> [Text]
-renderChangedPathSegments path left right =
+renderChangedPathSegments :: DiffPath -> [Text]
+renderChangedPathSegments path =
     case reverse (renderedPathSegments path) of
         [] ->
-            [changedLabel "<root>" left right]
+            ["<root>"]
         key : parentSegments ->
-            reverse parentSegments <> [changedLabel key left right]
+            reverse parentSegments <> [key]
 
-changedLabel :: Text -> Aeson.Value -> Aeson.Value -> Text
-changedLabel key left right =
-    key
-        <> ": A: "
-        <> renderJsonValue left
-        <> " | B: "
-        <> renderJsonValue right
+renderChangedValueLeaves :: Aeson.Value -> Aeson.Value -> [Tree.Tree Text]
+renderChangedValueLeaves left right =
+    [ Tree.Node ("A: " <> rightAlignRenderedValue width leftText) []
+    , Tree.Node ("B: " <> rightAlignRenderedValue width rightText) []
+    ]
+  where
+    leftText =
+        renderJsonValue left
+    rightText =
+        renderJsonValue right
+    width =
+        max (Text.length leftText) (Text.length rightText)
+
+rightAlignRenderedValue :: Int -> Text -> Text
+rightAlignRenderedValue width value =
+    Text.replicate (width - Text.length value) " " <> value
 
 renderSegmentSortKey :: Text -> RenderSegmentSortKey
 renderSegmentSortKey label =
-    case readMaybe (Text.unpack sortText) of
+    case readMaybe (Text.unpack numericSortPrefix) of
         Just number
-            | not (Text.null sortText) && Text.all isDigit sortText ->
+            | not (Text.null numericSortPrefix) ->
                 RenderSegmentNumber number label
         _ ->
             RenderSegmentText label
   where
     sortText =
         Text.takeWhile (/= ':') label
+    numericSortPrefix =
+        Text.takeWhile isDigit sortText
 
 renderDiffNodeLines :: DiffNode -> [Text]
 renderDiffNodeLines (DiffNode path change) =
@@ -824,6 +1226,20 @@ renderLovelace lovelace =
 (</>) :: DiffPath -> Text -> DiffPath
 DiffPath segments </> segment =
     DiffPath (segments <> [segment])
+
+(</!>) :: DiffPath -> DiffPath -> DiffPath
+DiffPath left </!> DiffPath right =
+    DiffPath (left <> right)
+
+diffPathSegments :: DiffPath -> [Text]
+diffPathSegments (DiffPath segments) =
+    segments
+
+textDiffPath :: Text -> DiffPath
+textDiffPath text =
+    DiffPath $
+        filter (not . Text.null) $
+            Text.splitOn "." text
 
 openValuePlan :: DiffPlan OpenValue
 openValuePlan =

--- a/lib/Cardano/Node/Client/TxDiff/Cli.hs
+++ b/lib/Cardano/Node/Client/TxDiff/Cli.hs
@@ -23,6 +23,7 @@ import Cardano.Node.Client.TxDiff (
 
 data TxDiffCliOptions = TxDiffCliOptions
     { txDiffCliBlueprintPaths :: [FilePath]
+    , txDiffCliCollapseRulesPath :: Maybe FilePath
     , txDiffCliHumanRenderOptions :: HumanRenderOptions
     , txDiffCliLeftPath :: FilePath
     , txDiffCliRightPath :: FilePath
@@ -34,43 +35,50 @@ newtype TxDiffCliError = TxDiffCliUsageError String
 
 parseTxDiffCliArgs :: [String] -> Either TxDiffCliError TxDiffCliOptions
 parseTxDiffCliArgs =
-    go [] defaultHumanRenderOptions
+    go [] Nothing defaultHumanRenderOptions
   where
-    go blueprintPaths renderOptions ("--blueprint" : blueprintPath : rest) =
-        go (blueprintPath : blueprintPaths) renderOptions rest
-    go _ _ ["--blueprint"] =
+    go blueprintPaths collapseRulesPath renderOptions ("--blueprint" : blueprintPath : rest) =
+        go (blueprintPath : blueprintPaths) collapseRulesPath renderOptions rest
+    go _ _ _ ["--blueprint"] =
         Left (TxDiffCliUsageError "missing value for --blueprint")
-    go blueprintPaths renderOptions ("--render" : value : rest) =
+    go blueprintPaths _ renderOptions ("--collapse-rules" : collapseRulesPath : rest) =
+        go blueprintPaths (Just collapseRulesPath) renderOptions rest
+    go _ _ _ ["--collapse-rules"] =
+        Left (TxDiffCliUsageError "missing value for --collapse-rules")
+    go blueprintPaths collapseRulesPath renderOptions ("--render" : value : rest) =
         case parseRenderShape value of
             Left err ->
                 Left err
             Right renderShape ->
                 go
                     blueprintPaths
+                    collapseRulesPath
                     renderOptions{humanRenderShape = renderShape}
                     rest
-    go _ _ ["--render"] =
+    go _ _ _ ["--render"] =
         Left (TxDiffCliUsageError "missing value for --render")
-    go blueprintPaths renderOptions ("--tree-art" : value : rest) =
+    go blueprintPaths collapseRulesPath renderOptions ("--tree-art" : value : rest) =
         case parseTreeArt value of
             Left err ->
                 Left err
             Right treeArt ->
                 go
                     blueprintPaths
+                    collapseRulesPath
                     renderOptions{humanTreeArt = treeArt}
                     rest
-    go _ _ ["--tree-art"] =
+    go _ _ _ ["--tree-art"] =
         Left (TxDiffCliUsageError "missing value for --tree-art")
-    go blueprintPaths renderOptions [leftPath, rightPath] =
+    go blueprintPaths collapseRulesPath renderOptions [leftPath, rightPath] =
         Right
             TxDiffCliOptions
                 { txDiffCliBlueprintPaths = reverse blueprintPaths
+                , txDiffCliCollapseRulesPath = collapseRulesPath
                 , txDiffCliHumanRenderOptions = renderOptions
                 , txDiffCliLeftPath = leftPath
                 , txDiffCliRightPath = rightPath
                 }
-    go _ _ _ =
+    go _ _ _ _ =
         Left (TxDiffCliUsageError "expected TX_A TX_B")
 
 parseRenderShape :: String -> Either TxDiffCliError RenderShape
@@ -94,4 +102,5 @@ txDiffCliUsage prog =
     "Usage: "
         <> prog
         <> " [--render tree|paths] [--tree-art ascii|unicode]"
+        <> " [--collapse-rules FILE]"
         <> " [--blueprint FILE ...] TX_A TX_B"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,5 +39,8 @@ nav:
       - Submitter: modules/submitter.md
       - Balance: modules/balance.md
       - TxBuild: modules/txbuild.md
+      - TxDiff: modules/tx-diff.md
       - N2C: modules/n2c.md
       - Validity: modules/validity.md
+  - Executables:
+      - tx-diff: executables/tx-diff.md

--- a/specs/142-tx-diff-collapse-views/contracts/collapse-rules.yaml.md
+++ b/specs/142-tx-diff-collapse-views/contracts/collapse-rules.yaml.md
@@ -1,0 +1,104 @@
+# Collapse Rules YAML Contract
+
+## Version 1
+
+```yaml
+version: 1
+
+views:
+  raw: show   # show | hide; optional, defaults to show
+
+collapse:
+  - name: swapOrders
+    at: body.outputs
+    match:
+      required:
+        - coin
+        - datum.fields.4.fields.0.2
+        - datum.fields.4.fields.1.2
+```
+
+## Fields
+
+- `version`: required schema version. Version `1` is the only supported value.
+- `views.raw`: optional raw-list rendering policy. `show` is the default;
+  `hide` suppresses the raw branch only where a named view exists.
+- `collapse`: optional list of named overlay rules.
+- `collapse[*].name`: required rendered semantic view name, for example
+  `swapOrders`.
+- `collapse[*].at`: required absolute diff path to an array/list node, for
+  example `body.outputs`.
+- `collapse[*].match.required`: non-empty list of required relative paths
+  inside each changed list item.
+
+## Path Syntax
+
+Paths are dot-separated object keys and numeric list indexes. They are written
+against the open transaction diff tree after any blueprint decoding has
+substituted datum or redeemer data.
+
+- `at` paths are absolute from the diff root, for example `body.outputs`.
+- `match.required` paths are relative to one item under the `at` list, for
+  example `coin` or `datum.fields.4.fields.0.2`.
+- The first slice has no wildcard, predicate, arithmetic, or schema language in
+  the rule file.
+
+## Matching And Grouping
+
+A rule applies at its `at` path when that path is a changed list. For each
+changed list item, the item is selected when all `match.required` paths exist
+as changed leaves inside that item.
+
+Selected leaves are transposed so the list index moves down to the changed
+leaf. Exact equal A/B leaf pairs are grouped and rendered as index ranges:
+
+```text
+outputs
+`- swapOrders
+   `- coin
+      +- 0..4
+      |  +- A: 12371.863798 ADA (12371863798 lovelace)
+      |  `- B: 12503.280000 ADA (12503280000 lovelace)
+      `- 32
+         +- A: 12371.863797 ADA (12371863797 lovelace)
+         `- B:   8166.545306 ADA (8166545306 lovelace)
+```
+
+Rules are independent overlays. Matching an item in one rule does not remove it
+from any other rule, so semantic views may intersect.
+
+## Raw View Policy
+
+With `views.raw: show`, the original list diff remains available under a `raw`
+branch when named views exist at that list path.
+
+With `views.raw: hide`, the raw branch is omitted, but unrepresented diffs are
+not dropped. Changed leaves, insertions, and deletions not represented by a
+named view render directly under their original numeric indexes.
+
+## Rendering Contract
+
+Tree-mode changed leaves render A and B as separate child lines. Values are
+right-aligned against each other within that changed leaf.
+
+This contract has no formula, sum, delta, or semigroup fields. Aggregation is
+tracked separately.
+
+## Render Shape
+
+With `views.raw: hide`, named views render before numeric remainder indexes.
+Each changed leaf keeps the transaction values as aligned children:
+
+```text
+body
+`- outputs
+   +- swapOrders
+   |  `- coin
+   |     `- 0..4
+   |        +- A: 12371.863798 ADA (12371863798 lovelace)
+   |        `- B: 12503.280000 ADA (12503280000 lovelace)
+   `- 33
+      `- coin
+         +- A: 1041728.494694 ADA (1041728494694 lovelace)
+         `- B: 1041836.734694 ADA (1041836734694 lovelace)
+```

--- a/specs/142-tx-diff-collapse-views/data-model.md
+++ b/specs/142-tx-diff-collapse-views/data-model.md
@@ -1,0 +1,45 @@
+# Data Model: Tx Diff Named Collapse Views
+
+## CollapseRules
+
+Top-level YAML configuration.
+
+- `version`: schema version, currently `1`.
+- `views.raw`: `show` or `hide`; defaults to `show`.
+- `collapse`: ordered list of named overlay rules.
+
+## CollapseRule
+
+Named semantic view over one list path.
+
+- `name`: rendered child name, for example `swapOrders`.
+- `at`: absolute diff path to a list, for example `body.outputs`.
+- `match.required`: relative paths that must exist as changed leaves inside a
+  list item for that item to be included in the view.
+
+## Collapsed Leaf Group
+
+Rendered leaf entry created from exact A/B equality.
+
+- `indices`: one or more original list indexes, rendered as ranges when
+  contiguous.
+- `left`: rendered A value.
+- `right`: rendered B value.
+
+## Transformation
+
+```text
+List<Indexed DiffTree>
+  -- select per named rule -->
+List<Indexed MatchingDiffTree>
+  -- keep required leaves -->
+DiffTree<List<Indexed DiffLeaf>>
+  -- group exact leaf equality -->
+DiffTree<List<IndexRange DiffLeaf>>
+```
+
+The original list remains renderable as raw output.
+
+When raw output is hidden, changed list items and tail insertions/deletions
+that are not represented by any named rule remain renderable under their
+original numeric indexes.

--- a/specs/142-tx-diff-collapse-views/plan.md
+++ b/specs/142-tx-diff-collapse-views/plan.md
@@ -1,0 +1,82 @@
+# Implementation Plan: Tx Diff Named Collapse Views
+
+**Branch**: `feat/tx-diff-named-yaml-collapse-views-for-list-diffs` | **Date**: 2026-05-14 | **Spec**: `specs/142-tx-diff-collapse-views/spec.md`  
+**Input**: Feature specification from `specs/142-tx-diff-collapse-views/spec.md`
+
+## Summary
+
+Add an optional YAML-driven collapse pass to the existing tx-diff human tree
+renderer. The exact structural diff remains unchanged. When a list path has
+named collapse rules, each rule independently selects matching changed list
+items, transposes configured relative diff leaves into a named view, and
+groups equal A/B leaves by index ranges. Raw per-index rendering remains
+available and defaults to visible; when raw is hidden, uncovered list diffs
+remain visible under their original numeric indexes. Tree-mode changed leaves
+render A and B on separate right-aligned lines.
+
+## Technical Context
+
+**Language/Version**: Haskell, GHC 9.12.3  
+**Primary Dependencies**: `aeson`, `containers`, `text`, `tree-view`, new
+`yaml` dependency for YAML config parsing  
+**Storage**: N/A  
+**Testing**: Hspec + QuickCheck via `just unit` and full `just ci`  
+**Target Platform**: Linux/macOS CLI  
+**Project Type**: Haskell library + CLI executable  
+**Performance Goals**: Linear in rendered changed list items and configured
+required paths for normal tx-diff sizes  
+**Constraints**: Preserve existing output without rules; no arithmetic
+aggregation in this ticket  
+**Scale/Scope**: Human rendering for Conway transaction diffs
+
+## Constitution Check
+
+- Use existing tx-diff core and renderer patterns.
+- Add tests before production behavior.
+- Keep release-surface changes narrow: one CLI flag and a parser.
+- Do not introduce semigroup/formula semantics in this slice.
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/142-tx-diff-collapse-views/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── collapse-rules.yaml.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+lib/Cardano/Node/Client/TxDiff.hs
+lib/Cardano/Node/Client/TxDiff/Cli.hs
+app/tx-diff/Main.hs
+test/Cardano/Node/Client/TxDiff/CoreSpec.hs
+test/Cardano/Node/Client/TxDiff/CliSpec.hs
+cardano-node-clients.cabal
+```
+
+**Structure Decision**: Keep the collapse data model and renderer integration
+inside `Cardano.Node.Client.TxDiff` for the first slice because the feature is
+render-only and operates on `DiffNode`.
+
+## Status
+
+**Completed**: Ticket #142 and follow-up ticket #143 created. Spec artifacts
+written. Collapse rules parser, CLI flag, named overlay rendering, hidden-raw
+preservation, and unit coverage implemented. Initial `just format`,
+`just unit`, and `just ci` passed. Review refinement for hidden-raw remainder
+rendering and A/B tree alignment completed.
+**Current**: Ready for external review.
+**Blockers**: None.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/142-tx-diff-collapse-views/quickstart.md
+++ b/specs/142-tx-diff-collapse-views/quickstart.md
@@ -1,0 +1,52 @@
+# Quickstart: Tx Diff Named Collapse Views
+
+Create `collapse.yaml`:
+
+```yaml
+version: 1
+views:
+  raw: hide
+collapse:
+  - name: swapOrders
+    at: body.outputs
+    match:
+      required:
+        - coin
+        - datum.fields.4.fields.0.2
+        - datum.fields.4.fields.1.2
+```
+
+Run tx-diff:
+
+```sh
+tx-diff --collapse-rules collapse.yaml --blueprint plutus.json tx-a.cbor tx-b.cbor
+```
+
+Expected shape:
+
+```text
+body
+`- outputs
+   +- swapOrders
+   |  +- coin
+   |  |  `- 0..4
+   |  |     +- A: 12371.863798 ADA (12371863798 lovelace)
+   |  |     `- B: 12503.280000 ADA (12503280000 lovelace)
+   |  `- datum
+   |     `- fields
+   |        `- 4
+   |           `- fields
+   |              `- 0
+   |                 `- 2
+   |                    `- 0..4
+   |                       +- A: 12368583798
+   |                       `- B: 12500000000
+   `- 33
+      `- coin
+         +- A: 1041728.494694 ADA (1041728494694 lovelace)
+         `- B: 1041836.734694 ADA (1041836734694 lovelace)
+```
+
+Use `views.raw: show` to keep the original list under a `raw` branch as an
+audit view. With `views.raw: hide`, unmatched list diffs still render directly
+under their original numeric indexes.

--- a/specs/142-tx-diff-collapse-views/research.md
+++ b/specs/142-tx-diff-collapse-views/research.md
@@ -1,0 +1,45 @@
+# Research: Tx Diff Named Collapse Views
+
+## Findings
+
+- The existing renderer already builds a trie from `DiffNode` paths. Collapse
+  can be implemented as a pre-render insertion strategy without changing the
+  diff engine.
+- The correct model is overlay projection, not partitioning. A rule does not
+  consume list items; each rule independently selects matching items.
+- The user clarified that the list dimension moves to the differences. In
+  implementation terms, a rule transforms selected changed list children from
+  `[(index, DiffTree)]` into a named tree of required relative paths, where
+  each leaf contains grouped indexed A/B diffs.
+- Existing raw rendering must remain available for auditability. When rules
+  exist at a list path, raw output can be shown under a `raw` child or hidden
+  by config.
+- YAML is the right user-facing format for the rule file. The codebase already
+  uses `aeson`; the Haskell `yaml` package can parse YAML into `FromJSON`
+  instances with minimal custom code.
+
+## Decision
+
+Use this minimal YAML shape:
+
+```yaml
+version: 1
+views:
+  raw: show
+collapse:
+  - name: swapOrders
+    at: body.outputs
+    match:
+      required:
+        - coin
+        - datum.fields.4.fields.0.2
+        - datum.fields.4.fields.1.2
+```
+
+## Alternatives Considered
+
+- **Branch-level grouping by whole diff-tree equality**: rejected because the
+  user wants the list moved down to diff leaves, not a group around repeated
+  whole branches.
+- **Rules as partitions**: rejected because semantic views may intersect.
+- **Semigroup aggregation in the same ticket**: rejected and tracked in #143.

--- a/specs/142-tx-diff-collapse-views/spec.md
+++ b/specs/142-tx-diff-collapse-views/spec.md
@@ -1,0 +1,141 @@
+# Feature Specification: Tx Diff Named Collapse Views
+
+**Feature Branch**: `feat/tx-diff-named-yaml-collapse-views-for-list-diffs`  
+**Created**: 2026-05-14  
+**Status**: Draft  
+**Input**: GitHub issue #142 and user discussion on collapsing repeated list
+diffs by named semantic overlays.
+
+## User Scenarios & Testing
+
+### User Story 1 - Collapse Repeated List Diffs (Priority: P1)
+
+A tx-diff user can provide a YAML rule named `swapOrders` for
+`body.outputs` so repeated output-item diffs are shown once as a named view,
+with the output index dimension moved down to the changed leaves.
+
+**Why this priority**: This is the readability problem observed in the swap
+transaction: every output repeats `coin` and the same nested datum paths.
+
+**Independent Test**: Diff two open values with an `outputs` list whose items
+share `coin` and nested datum-field changes. Render with a `swapOrders` rule
+and verify the tree shows `outputs.swapOrders.coin` and
+`outputs.swapOrders.datum...`, with indexed leaf lists.
+
+**Acceptance Scenarios**:
+
+1. **Given** a list diff with items `0`, `1`, and `2` all containing `coin`
+   and `datum.fields.4.fields.0.2`, **When** the `swapOrders` rule requires
+   those paths, **Then** the named view contains those paths once and lists
+   indexed A/B changes under each leaf.
+2. **Given** two items have the same A/B leaf change and one item differs,
+   **When** the named view is rendered, **Then** equal leaf changes are grouped
+   by index ranges without arithmetic aggregation.
+
+### User Story 2 - Keep Rule Overlays Independent (Priority: P2)
+
+A tx-diff user can define multiple named rules at the same list path, and the
+same list item may appear in more than one rule when it matches both.
+
+**Why this priority**: The user described groupings as semantic views, not
+partitions. Rules must not steal matches from each other.
+
+**Independent Test**: Render a list with `swapOrders` requiring `coin` plus a
+datum path and `coinChanges` requiring only `coin`. Verify index `0` appears
+in both named views.
+
+**Acceptance Scenarios**:
+
+1. **Given** intersecting rules at `body.outputs`, **When** an item matches
+   both rules, **Then** both named views include that item.
+2. **Given** raw rendering is enabled, **When** named views are rendered,
+   **Then** the original per-index diff remains visible under `raw`.
+
+### User Story 3 - Hide Raw View When Requested (Priority: P3)
+
+A tx-diff user can choose to hide the raw per-index list rendering when named
+views are enough.
+
+**Why this priority**: The raw view is useful for verification, but users need
+a compact mode for large repeated lists.
+
+**Independent Test**: Render the same list with `views.raw: hide` and verify
+the named view remains while the `raw` section is absent.
+
+**Acceptance Scenarios**:
+
+1. **Given** `views.raw: hide`, **When** a collapse rule applies to a list,
+   **Then** that list renders only named views.
+2. **Given** no rule applies to a list, **When** raw is hidden, **Then** the
+   list still renders normally so unrelated diffs are not lost.
+3. **Given** a rule represents only some diffs inside a list, **When** raw is
+   hidden, **Then** unrepresented list diffs remain visible under their
+   original numeric indexes so the renderer does not lose actionable
+   differences or invent an extra semantic bucket.
+
+### Edge Cases
+
+- A rule whose required paths match no item renders no named view.
+- A rule can require nested numeric path segments such as
+  `datum.fields.4.fields.0.2`.
+- Rules do not invent semantic names inside datum paths; they only name the
+  view itself.
+- Inserted or deleted list items are not collapsed in the first slice; raw or
+  original numeric-index rendering remains the source of truth for them.
+- Hiding the raw view never hides diffs that are not represented by at least
+  one named collapse view; those diffs render under their original numeric
+  indexes.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The CLI MUST accept one YAML collapse-rules file.
+- **FR-002**: A collapse rule MUST have a name, an absolute list path, and one
+  or more required relative diff paths.
+- **FR-003**: Collapse rules MUST be independent overlays; intersecting rules
+  may include the same list item.
+- **FR-004**: For a matching rule, the renderer MUST transpose
+  `List<Indexed DiffTree>` into `DiffTree<List<Indexed DiffLeaf>>`.
+- **FR-005**: Equal A/B diff leaves inside a named view MUST be grouped by
+  exact equality and rendered with compact index ranges.
+- **FR-006**: The YAML config MUST support `views.raw: show|hide`.
+- **FR-007**: Without a collapse-rules file, existing tree and path render
+  behavior MUST remain unchanged.
+- **FR-008**: This feature MUST NOT perform semigroup aggregation, arithmetic
+  folding, sums, or computed deltas.
+- **FR-009**: With `views.raw: hide`, the renderer MUST still show changed
+  list-item leaves, insertions, and deletions under their original numeric
+  indexes when no named collapse view represents them.
+- **FR-010**: Tree-mode changed leaves MUST render A and B on separate child
+  lines with the values right-aligned against each other.
+
+### Key Entities
+
+- **Collapse Rules File**: YAML input describing raw-view settings and named
+  collapse rules.
+- **Collapse Rule**: A named semantic overlay at one list path, selecting list
+  items by required relative diff paths.
+- **Collapsed View**: Rendered named tree where the list index dimension is
+  attached to changed leaves.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A three-item repeated output diff renders each repeated datum
+  path once under the named view, not once per output item.
+- **SC-002**: An item matching two rules appears in both rendered named views.
+- **SC-003**: Running tx-diff without a collapse-rules file produces byte-for-
+  byte identical output for existing unit examples.
+- **SC-004**: The first implementation adds no arithmetic aggregation behavior.
+- **SC-005**: `views.raw: hide` never makes the rendered output report fewer
+  underlying differences than the selected named views cover.
+
+## Assumptions
+
+- YAML path syntax is dot-separated text with numeric list indexes represented
+  as path segments.
+- The first implementation targets human tree output; explicit path rendering
+  remains unchanged.
+- Raw view defaults to `show`.

--- a/specs/142-tx-diff-collapse-views/tasks.md
+++ b/specs/142-tx-diff-collapse-views/tasks.md
@@ -1,0 +1,62 @@
+# Tasks: Tx Diff Named Collapse Views
+
+**Input**: `specs/142-tx-diff-collapse-views/`  
+**Prerequisites**: `spec.md`, `plan.md`, `research.md`,
+`data-model.md`, `contracts/collapse-rules.yaml.md`
+
+## Phase 1: Specification
+
+- [x] T001 Create GitHub issue #142 for named YAML collapse views.
+- [x] T002 Create follow-up GitHub issue #143 for semigroup/formula aggregation.
+- [x] T003 Write Spec Kit artifacts under `specs/142-tx-diff-collapse-views/`.
+
+## Phase 2: Tests First
+
+- [x] T004 [P] Add core renderer tests for one named collapse view moving
+  `outputs` indexes down to `coin` and nested datum leaves in
+  `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
+- [x] T005 [P] Add core renderer tests showing intersecting rules are overlays
+  in `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
+- [x] T006 [P] Add core renderer tests for `views.raw: hide` in
+  `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
+- [x] T007 [P] Add CLI parser tests for `--collapse-rules FILE` in
+  `test/Cardano/Node/Client/TxDiff/CliSpec.hs`.
+- [x] T008 [P] Add a regression test that `views.raw: hide` still renders
+  list diffs not represented by any named collapse view under original numeric indexes in
+  `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
+
+## Phase 3: Implementation
+
+- [x] T009 Add collapse rules data types and YAML parser to
+  `lib/Cardano/Node/Client/TxDiff.hs`.
+- [x] T010 Add collapse rule fields to `HumanRenderOptions` and thread options
+  through tree rendering in `lib/Cardano/Node/Client/TxDiff.hs`.
+- [x] T011 Implement named overlay selection, required-path extraction, leaf
+  transposition, and exact leaf grouping in `lib/Cardano/Node/Client/TxDiff.hs`.
+- [x] T012 Preserve unrepresented list diffs, insertions, and deletions under
+  original numeric indexes when `views.raw: hide` suppresses only the fully represented raw view in
+  `lib/Cardano/Node/Client/TxDiff.hs`.
+- [x] T013 Add `--collapse-rules FILE` parsing to
+  `lib/Cardano/Node/Client/TxDiff/Cli.hs`.
+- [x] T014 Load the YAML rules file in `app/tx-diff/Main.hs`.
+- [x] T015 Add `yaml` dependency in `cardano-node-clients.cabal`.
+
+## Phase 4: Verification
+
+- [x] T016 Run `nix develop --quiet -c just format`.
+- [x] T017 Run `nix develop --quiet -c just unit`.
+- [x] T018 Run `nix develop --quiet -c just ci`.
+
+## Phase 5: Review Refinement
+
+- [x] T019 [P] Add RED tests for flattened numeric remainder rendering and
+  vertical right-aligned A/B tree values in
+  `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
+- [x] T020 Flatten hidden-raw remainder rendering to original numeric children
+  in `lib/Cardano/Node/Client/TxDiff.hs`.
+- [x] T021 Render tree-mode A/B values as right-aligned child lines in
+  `lib/Cardano/Node/Client/TxDiff.hs`.
+- [x] T022 Regenerate the gist collapse outputs.
+- [x] T023 Re-run `nix develop --quiet -c just format`.
+- [x] T024 Re-run `nix develop --quiet -c just unit`.
+- [x] T025 Re-run `nix develop --quiet -c just ci`.

--- a/test/Cardano/Node/Client/TxDiff/CliSpec.hs
+++ b/test/Cardano/Node/Client/TxDiff/CliSpec.hs
@@ -22,6 +22,7 @@ spec =
                 `shouldBe` Right
                     TxDiffCliOptions
                         { txDiffCliBlueprintPaths = []
+                        , txDiffCliCollapseRulesPath = Nothing
                         , txDiffCliHumanRenderOptions = defaultHumanRenderOptions
                         , txDiffCliLeftPath = "tx-a.cbor"
                         , txDiffCliRightPath = "tx-b.cbor"
@@ -32,6 +33,7 @@ spec =
                 `shouldBe` Right
                     TxDiffCliOptions
                         { txDiffCliBlueprintPaths = []
+                        , txDiffCliCollapseRulesPath = Nothing
                         , txDiffCliHumanRenderOptions =
                             defaultHumanRenderOptions
                                 { humanRenderShape = RenderPaths
@@ -45,6 +47,7 @@ spec =
                 `shouldBe` Right
                     TxDiffCliOptions
                         { txDiffCliBlueprintPaths = []
+                        , txDiffCliCollapseRulesPath = Nothing
                         , txDiffCliHumanRenderOptions =
                             defaultHumanRenderOptions
                                 { humanTreeArt = TreeArtUnicode
@@ -65,6 +68,23 @@ spec =
                 `shouldBe` Right
                     TxDiffCliOptions
                         { txDiffCliBlueprintPaths = ["one.json", "two.json"]
+                        , txDiffCliCollapseRulesPath = Nothing
+                        , txDiffCliHumanRenderOptions = defaultHumanRenderOptions
+                        , txDiffCliLeftPath = "tx-a.cbor"
+                        , txDiffCliRightPath = "tx-b.cbor"
+                        }
+
+        it "accepts a collapse rules path" $
+            parseTxDiffCliArgs
+                [ "--collapse-rules"
+                , "collapse.yaml"
+                , "tx-a.cbor"
+                , "tx-b.cbor"
+                ]
+                `shouldBe` Right
+                    TxDiffCliOptions
+                        { txDiffCliBlueprintPaths = []
+                        , txDiffCliCollapseRulesPath = Just "collapse.yaml"
                         , txDiffCliHumanRenderOptions = defaultHumanRenderOptions
                         , txDiffCliLeftPath = "tx-a.cbor"
                         , txDiffCliRightPath = "tx-b.cbor"
@@ -79,3 +99,8 @@ spec =
             parseTxDiffCliArgs ["--tree-art", "emoji", "missing-a", "missing-b"]
                 `shouldBe` Left
                     (TxDiffCliUsageError "unsupported --tree-art value: emoji")
+
+        it "rejects a missing collapse rules path before inputs are read" $
+            parseTxDiffCliArgs ["--collapse-rules"]
+                `shouldBe` Left
+                    (TxDiffCliUsageError "missing value for --collapse-rules")

--- a/test/Cardano/Node/Client/TxDiff/ConwaySpec.hs
+++ b/test/Cardano/Node/Client/TxDiff/ConwaySpec.hs
@@ -176,9 +176,8 @@ spec =
                     expectationFailure ("failed to render tx diff: " <> show err)
                 Right output -> do
                     output `shouldSatisfy` Text.isInfixOf "`- fee"
-                    output
-                        `shouldSatisfy` Text.isInfixOf
-                            "B: 0.000042 ADA (42 lovelace)"
+                    output `shouldSatisfy` Text.isInfixOf "B:"
+                    output `shouldSatisfy` Text.isInfixOf "0.000042 ADA (42 lovelace)"
 
         it "reports a Conway fee change at body.fee" $ do
             tx <- loadFixture sampleHash
@@ -1094,8 +1093,9 @@ spec =
                                 }
                         output = renderDiffNodeHuman (diffConwayTxWith options txA txB)
                     output
-                        `shouldSatisfy` Text.isInfixOf
-                            "amount: A: 42 | B: 43"
+                        `shouldSatisfy` Text.isInfixOf "amount"
+                    output `shouldSatisfy` Text.isInfixOf "A: 42"
+                    output `shouldSatisfy` Text.isInfixOf "B: 43"
 
         it "descends into inline output datum as raw Plutus data without a matching blueprint" $ do
             tx <- loadFixture sampleHash
@@ -1131,7 +1131,9 @@ spec =
                                 (diffConwayTxWith defaultTxDiffOptions txA txB)
                     output `shouldSatisfy` Text.isInfixOf "`- datum"
                     output `shouldSatisfy` Text.isInfixOf "`- fields"
-                    output `shouldSatisfy` Text.isInfixOf "0: A: 42 | B: 43"
+                    output `shouldSatisfy` Text.isInfixOf "0"
+                    output `shouldSatisfy` Text.isInfixOf "A: 42"
+                    output `shouldSatisfy` Text.isInfixOf "B: 43"
                     output `shouldNotSatisfy` Text.isInfixOf "cbor:"
 
         it "uses a matched blueprint decoder to descend into redeemer data fields" $ do
@@ -1160,8 +1162,9 @@ spec =
                         }
                 output = renderDiffNodeHuman (diffConwayTxWith options txA txB)
             output
-                `shouldSatisfy` Text.isInfixOf
-                    "amount: A: 42 | B: 43"
+                `shouldSatisfy` Text.isInfixOf "amount"
+            output `shouldSatisfy` Text.isInfixOf "A: 42"
+            output `shouldSatisfy` Text.isInfixOf "B: 43"
             output
                 `shouldNotSatisfy` Text.isInfixOf "cbor:"
 

--- a/test/Cardano/Node/Client/TxDiff/CoreSpec.hs
+++ b/test/Cardano/Node/Client/TxDiff/CoreSpec.hs
@@ -5,6 +5,7 @@ module Cardano.Node.Client.TxDiff.CoreSpec (spec) where
 import Data.Aeson ((.=))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Key
+import Data.ByteString.Char8 qualified as BS8
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text (Text)
@@ -27,6 +28,9 @@ import Test.QuickCheck (
  )
 
 import Cardano.Node.Client.TxDiff (
+    CollapseRawView (..),
+    CollapseRule (..),
+    CollapseRules (..),
     DiffChange (..),
     DiffNode (..),
     DiffPath (..),
@@ -38,6 +42,7 @@ import Cardano.Node.Client.TxDiff (
     defaultHumanRenderOptions,
     diffOpenValue,
     diffWith,
+    parseCollapseRulesYaml,
     renderDiffNodeHuman,
     renderDiffNodeHumanWith,
  )
@@ -204,7 +209,7 @@ spec =
                         [
                             ( "body"
                             , OpenObject
-                                [ ("fee", OpenInteger 2)
+                                [ ("fee", OpenInteger 20)
                                 , ("ttl", OpenInteger 11)
                                 , ("same", OpenText "keep")
                                 ]
@@ -213,8 +218,12 @@ spec =
             renderDiffNodeHuman (diffOpenValue left right)
                 `shouldBe` Text.unlines
                     [ "body"
-                    , "+- fee: A: 1 | B: 2"
-                    , "`- ttl: A: 10 | B: 11"
+                    , "+- fee"
+                    , "|  +- A:  1"
+                    , "|  `- B: 20"
+                    , "`- ttl"
+                    , "   +- A: 10"
+                    , "   `- B: 11"
                     ]
 
         it "renders collected diff tree as explicit path lines" $ do
@@ -283,7 +292,7 @@ spec =
                         [
                             ( "body"
                             , OpenObject
-                                [ ("fee", OpenInteger 2)
+                                [ ("fee", OpenInteger 20)
                                 , ("ttl", OpenInteger 11)
                                 ]
                             )
@@ -295,8 +304,12 @@ spec =
             renderDiffNodeHumanWith options (diffOpenValue left right)
                 `shouldBe` Text.unlines
                     [ "body"
-                    , " ├╴fee: A: 1 | B: 2"
-                    , " └╴ttl: A: 10 | B: 11"
+                    , " ├╴fee"
+                    , " │  ├╴A:  1"
+                    , " │  └╴B: 20"
+                    , " └╴ttl"
+                    , "    ├╴A: 10"
+                    , "    └╴B: 11"
                     ]
 
         it "orders numeric tree path segments numerically" $ do
@@ -341,8 +354,269 @@ spec =
             renderDiffNodeHuman (diffOpenValue left right)
                 `shouldBe` Text.unlines
                     [ "outputs"
-                    , "+- 2: A: 2 | B: 20"
-                    , "`- 10: A: 10 | B: 100"
+                    , "+- 2"
+                    , "|  +- A:  2"
+                    , "|  `- B: 20"
+                    , "`- 10"
+                    , "   +- A:  10"
+                    , "   `- B: 100"
+                    ]
+
+        it "parses YAML collapse rules as named overlays" $ do
+            parseCollapseRulesYaml
+                ( BS8.pack
+                    "version: 1\n\
+                    \views:\n\
+                    \  raw: hide\n\
+                    \collapse:\n\
+                    \  - name: swapOrders\n\
+                    \    at: outputs\n\
+                    \    match:\n\
+                    \      required:\n\
+                    \        - coin\n\
+                    \        - datum.fields.4.fields.0.2\n"
+                )
+                `shouldBe` Right
+                    CollapseRules
+                        { collapseRawView = CollapseRawHide
+                        , collapseRules =
+                            [ CollapseRule
+                                { collapseRuleName = "swapOrders"
+                                , collapseRuleAt = DiffPath ["outputs"]
+                                , collapseRuleRequired =
+                                    [ DiffPath ["coin"]
+                                    , DiffPath
+                                        [ "datum"
+                                        , "fields"
+                                        , "4"
+                                        , "fields"
+                                        , "0"
+                                        , "2"
+                                        ]
+                                    ]
+                                }
+                            ]
+                        }
+
+        it "moves list indexes down to named collapse view leaves" $ do
+            let options =
+                    defaultHumanRenderOptions
+                        { humanCollapseRules =
+                            Just
+                                CollapseRules
+                                    { collapseRawView = CollapseRawHide
+                                    , collapseRules =
+                                        [ CollapseRule
+                                            { collapseRuleName = "swapOrders"
+                                            , collapseRuleAt = DiffPath ["outputs"]
+                                            , collapseRuleRequired =
+                                                [ DiffPath ["coin"]
+                                                , DiffPath
+                                                    [ "datum"
+                                                    , "fields"
+                                                    , "4"
+                                                    , "fields"
+                                                    , "0"
+                                                    , "2"
+                                                    ]
+                                                , DiffPath
+                                                    [ "datum"
+                                                    , "fields"
+                                                    , "4"
+                                                    , "fields"
+                                                    , "1"
+                                                    , "2"
+                                                    ]
+                                                ]
+                                            }
+                                        ]
+                                    }
+                        }
+                output =
+                    renderDiffNodeHumanWith
+                        options
+                        (diffOpenValue collapsedLeft collapsedRight)
+            output
+                `shouldBe` Text.unlines
+                    [ "outputs"
+                    , "`- swapOrders"
+                    , "   +- coin"
+                    , "   |  +- 0..1"
+                    , "   |  |  +- A: 10"
+                    , "   |  |  `- B: 20"
+                    , "   |  `- 2"
+                    , "   |     +- A: 11"
+                    , "   |     `- B: 21"
+                    , "   `- datum"
+                    , "      `- fields"
+                    , "         `- 4"
+                    , "            `- fields"
+                    , "               +- 0"
+                    , "               |  `- 2"
+                    , "               |     +- 0..1"
+                    , "               |     |  +- A: 100"
+                    , "               |     |  `- B: 200"
+                    , "               |     `- 2"
+                    , "               |        +- A: 101"
+                    , "               |        `- B: 201"
+                    , "               `- 1"
+                    , "                  `- 2"
+                    , "                     `- 0..2"
+                    , "                        +- A: 300"
+                    , "                        `- B: 400"
+                    ]
+
+        it "renders intersecting collapse rules as independent named overlays" $ do
+            let options =
+                    defaultHumanRenderOptions
+                        { humanCollapseRules =
+                            Just
+                                CollapseRules
+                                    { collapseRawView = CollapseRawHide
+                                    , collapseRules =
+                                        [ CollapseRule
+                                            { collapseRuleName = "swapOrders"
+                                            , collapseRuleAt = DiffPath ["outputs"]
+                                            , collapseRuleRequired =
+                                                [ DiffPath ["coin"]
+                                                , DiffPath
+                                                    [ "datum"
+                                                    , "fields"
+                                                    , "4"
+                                                    , "fields"
+                                                    , "0"
+                                                    , "2"
+                                                    ]
+                                                ]
+                                            }
+                                        , CollapseRule
+                                            { collapseRuleName = "coinChanges"
+                                            , collapseRuleAt = DiffPath ["outputs"]
+                                            , collapseRuleRequired =
+                                                [DiffPath ["coin"]]
+                                            }
+                                        ]
+                                    }
+                        }
+                output =
+                    renderDiffNodeHumanWith
+                        options
+                        (diffOpenValue collapsedLeft collapsedRight)
+            output `shouldSatisfy` Text.isInfixOf "coinChanges"
+            output `shouldSatisfy` Text.isInfixOf "swapOrders"
+            output `shouldSatisfy` Text.isInfixOf "0..1"
+            output `shouldSatisfy` Text.isInfixOf "A: 10"
+            output `shouldSatisfy` Text.isInfixOf "B: 20"
+
+        it "keeps raw list rendering visible unless collapse rules hide it" $ do
+            let rules rawView =
+                    CollapseRules
+                        { collapseRawView = rawView
+                        , collapseRules =
+                            [ CollapseRule
+                                { collapseRuleName = "coinChanges"
+                                , collapseRuleAt = DiffPath ["outputs"]
+                                , collapseRuleRequired = [DiffPath ["coin"]]
+                                }
+                            ]
+                        }
+                renderWith rawView =
+                    renderDiffNodeHumanWith
+                        defaultHumanRenderOptions
+                            { humanCollapseRules = Just (rules rawView)
+                            }
+                        (diffOpenValue collapsedLeft collapsedRight)
+                rawOutput =
+                    renderWith CollapseRawShow
+                hiddenOutput =
+                    renderWith CollapseRawHide
+            rawOutput `shouldSatisfy` Text.isInfixOf "`- raw"
+            hiddenOutput `shouldNotSatisfy` Text.isInfixOf "raw"
+
+        it "keeps numeric list item diffs visible when raw view is hidden" $ do
+            let options =
+                    defaultHumanRenderOptions
+                        { humanCollapseRules =
+                            Just
+                                CollapseRules
+                                    { collapseRawView = CollapseRawHide
+                                    , collapseRules =
+                                        [ CollapseRule
+                                            { collapseRuleName = "swapOrders"
+                                            , collapseRuleAt = DiffPath ["outputs"]
+                                            , collapseRuleRequired =
+                                                [ DiffPath ["coin"]
+                                                , DiffPath
+                                                    [ "datum"
+                                                    , "fields"
+                                                    , "4"
+                                                    , "fields"
+                                                    , "0"
+                                                    , "2"
+                                                    ]
+                                                ]
+                                            }
+                                        ]
+                                    }
+                        }
+                output =
+                    renderDiffNodeHumanWith
+                        options
+                        (diffOpenValue remainderLeft remainderRight)
+            output
+                `shouldBe` Text.unlines
+                    [ "outputs"
+                    , "+- swapOrders"
+                    , "|  +- coin"
+                    , "|  |  +- 0..1"
+                    , "|  |  |  +- A: 10"
+                    , "|  |  |  `- B: 20"
+                    , "|  |  `- 2"
+                    , "|  |     +- A: 11"
+                    , "|  |     `- B: 21"
+                    , "|  `- datum"
+                    , "|     `- fields"
+                    , "|        `- 4"
+                    , "|           `- fields"
+                    , "|              `- 0"
+                    , "|                 `- 2"
+                    , "|                    +- 0..1"
+                    , "|                    |  +- A: 100"
+                    , "|                    |  `- B: 200"
+                    , "|                    `- 2"
+                    , "|                       +- A: 101"
+                    , "|                       `- B: 201"
+                    , "+- 0"
+                    , "|  `- datum"
+                    , "|     `- fields"
+                    , "|        `- 4"
+                    , "|           `- fields"
+                    , "|              `- 1"
+                    , "|                 `- 2"
+                    , "|                    +- A: 300"
+                    , "|                    `- B: 400"
+                    , "+- 1"
+                    , "|  `- datum"
+                    , "|     `- fields"
+                    , "|        `- 4"
+                    , "|           `- fields"
+                    , "|              `- 1"
+                    , "|                 `- 2"
+                    , "|                    +- A: 300"
+                    , "|                    `- B: 400"
+                    , "+- 2"
+                    , "|  `- datum"
+                    , "|     `- fields"
+                    , "|        `- 4"
+                    , "|           `- fields"
+                    , "|              `- 1"
+                    , "|                 `- 2"
+                    , "|                    +- A: 300"
+                    , "|                    `- B: 400"
+                    , "`- 3"
+                    , "   `- coin"
+                    , "      +- A: 12"
+                    , "      `- B: 22"
                     ]
 
         it "renders known coin values with exact ADA and lovelace units" $ do
@@ -356,7 +630,9 @@ spec =
             renderDiffNodeHuman diff
                 `shouldBe` Text.unlines
                     [ "body"
-                    , "`- fee: A: 1.000000 ADA (1000000 lovelace) | B: 1.500000 ADA (1500000 lovelace)"
+                    , "`- fee"
+                    , "   +- A: 1.000000 ADA (1000000 lovelace)"
+                    , "   `- B: 1.500000 ADA (1500000 lovelace)"
                     ]
 
         it "summarizes raw CBOR payloads in human-readable output" $ do
@@ -372,7 +648,9 @@ spec =
                     [ "body"
                     , "`- outputs"
                     , "   `- 0"
-                    , "      `- datum: A: cbor:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa... (40 bytes) | B: cbor:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb... (40 bytes)"
+                    , "      `- datum"
+                    , "         +- A: cbor:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa... (40 bytes)"
+                    , "         `- B: cbor:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb... (40 bytes)"
                     ]
 
         it "reports any equal generated value as same at the root" $
@@ -465,6 +743,98 @@ spec =
 rootPath :: DiffPath
 rootPath =
     DiffPath []
+
+collapsedLeft :: OpenValue
+collapsedLeft =
+    OpenObject
+        [
+            ( "outputs"
+            , OpenArray
+                [ outputValue 10 100 300
+                , outputValue 10 100 300
+                , outputValue 11 101 300
+                ]
+            )
+        ]
+
+collapsedRight :: OpenValue
+collapsedRight =
+    OpenObject
+        [
+            ( "outputs"
+            , OpenArray
+                [ outputValue 20 200 400
+                , outputValue 20 200 400
+                , outputValue 21 201 400
+                ]
+            )
+        ]
+
+remainderLeft :: OpenValue
+remainderLeft =
+    OpenObject
+        [
+            ( "outputs"
+            , OpenArray
+                [ outputValue 10 100 300
+                , outputValue 10 100 300
+                , outputValue 11 101 300
+                , OpenObject [("coin", OpenInteger 12)]
+                ]
+            )
+        ]
+
+remainderRight :: OpenValue
+remainderRight =
+    OpenObject
+        [
+            ( "outputs"
+            , OpenArray
+                [ outputValue 20 200 400
+                , outputValue 20 200 400
+                , outputValue 21 201 400
+                , OpenObject [("coin", OpenInteger 22)]
+                ]
+            )
+        ]
+
+outputValue :: Integer -> Integer -> Integer -> OpenValue
+outputValue coin datumIn datumOut =
+    OpenObject
+        [ ("coin", OpenInteger coin)
+        ,
+            ( "datum"
+            , OpenObject
+                [
+                    ( "fields"
+                    , OpenObject
+                        [
+                            ( "4"
+                            , OpenObject
+                                [
+                                    ( "fields"
+                                    , OpenObject
+                                        [
+                                            ( "0"
+                                            , OpenObject
+                                                [ ("2", OpenInteger datumIn)
+                                                ]
+                                            )
+                                        ,
+                                            ( "1"
+                                            , OpenObject
+                                                [ ("2", OpenInteger datumOut)
+                                                ]
+                                            )
+                                        ]
+                                    )
+                                ]
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
 
 openBytesJson :: Aeson.Value -> Aeson.Value
 openBytesJson bytes =


### PR DESCRIPTION
## Summary
- Add Spec Kit artifacts for #142 and leave semigroup/formula aggregation to follow-up #143.
- Add `--collapse-rules FILE` with YAML parsing for named list-diff overlay views and `views.raw: show|hide`.
- Render collapsed list leaves with index ranges while preserving unrepresented diffs under their original numeric indexes when raw output is hidden.
- Render changed tree leaves as right-aligned `A:` / `B:` child rows.
- Add public tx-diff documentation: executable manual/tutorial, release installation via Linux AppImage/DEB/RPM and macOS Homebrew, app README, MkDocs navigation entry, TxDiff architecture page, and roadmap notes for WASM plus N2C input resolution.

## TDD / Verification
- RED observed for flattened numeric remainder rendering and vertical right-aligned A/B tree values.
- GREEN observed with focused Hspec matches for grouped and numeric rendering.
- `nix develop --quiet -c mkdocs build --strict`
- `nix develop --quiet -c just format`
- `nix develop --quiet -c just unit`
- `nix develop --quiet -c just ci`

Closes #142.