### PR TITLE
fix(release): avoid duplicate AppImage assets

### DIFF
--- a/nix/linux-artifact-smoke.nix
+++ b/nix/linux-artifact-smoke.nix
@@ -86,6 +86,14 @@ pkgs.writeShellApplication {
       smoke_cli "$bin"
     }
 
+    reject_duplicate_appimage() {
+      duplicate="$artifacts_dir/$executable_name.AppImage"
+      if [ -e "$duplicate" ]; then
+        echo "unexpected duplicate AppImage asset: $duplicate" >&2
+        exit 1
+      fi
+    }
+
     smoke_deb() {
       deb="$artifacts_dir/$executable_name-$artifact_version-$system_suffix.deb"
       test -f "$deb"
@@ -109,6 +117,7 @@ pkgs.writeShellApplication {
       smoke_cli "$bin"
     }
 
+    reject_duplicate_appimage
     smoke_appimage
     smoke_deb
     smoke_rpm

--- a/nix/linux-release.nix
+++ b/nix/linux-release.nix
@@ -23,7 +23,6 @@ pkgs.runCommand
   mkdir -p "$out"
 
   cp -L ${appImage} "$out/${executableName}-${artifactVersion}-${system}.AppImage"
-  cp -L ${appImage} "$out/${executableName}.AppImage"
 
   deb_file="$(find ${deb} -maxdepth 1 -type f -name '*.deb' | head -1)"
   rpm_file="$(find ${rpm} -maxdepth 1 -type f -name '*.rpm' | head -1)"


### PR DESCRIPTION
Closes #147

## Summary

- publish only the versioned Linux AppImage from `linux-release-artifacts`
- make `linux-artifact-smoke` reject an unversioned `tx-diff.AppImage` before release upload

## Verification

- RED: `linux-artifact-smoke` failed against the old `linux-release-artifacts` output with `unexpected duplicate AppImage asset: .../tx-diff.AppImage`
- GREEN: `nix build .#linux-release-artifacts` plus `nix run .#linux-artifact-smoke -- --artifacts-dir "$artifact_dir" --artifact-version "$version"`
- `nix develop --quiet -c just ci`