### PR TITLE
Tx diff input resolution (web2 + N2C)

### DIFF
--- a/app/tx-diff/Main.hs
+++ b/app/tx-diff/Main.hs
@@ -4,17 +4,26 @@ Description : tx-diff executable entry point
 License     : Apache-2.0
 
 Thin CLI wrapper over 'Cardano.Node.Client.TxDiff'. It reads two encoded
-Conway transaction inputs, prints the human renderer output, and exits with a
-non-zero status when differences are present.
+Conway transaction inputs, optionally resolves their referenced UTxOs via
+local N2C or a Blockfrost-compatible web2 endpoint, prints the human
+renderer output, and exits with a non-zero status when differences are
+present.
 -}
 module Main (main) where
 
+import Cardano.Node.Client.N2C.Connection (
+    newLSQChannel,
+    newLTxSChannel,
+    runNodeClient,
+ )
+import Cardano.Node.Client.N2C.Provider (mkN2CProvider)
 import Cardano.Node.Client.TxDiff (
     CollapseRules,
     HumanRenderOptions (..),
     TxDiffOptions (..),
+    decodeConwayTxInput,
     defaultTxDiffOptions,
-    diffConwayTxInputWith,
+    diffConwayTxWith,
     diffNodeHasChanges,
     parseCollapseRulesYaml,
     renderDiffNodeHumanWith,
@@ -26,14 +35,52 @@ import Cardano.Node.Client.TxDiff.Blueprint (
  )
 import Cardano.Node.Client.TxDiff.Cli (
     TxDiffCliError (..),
+    TxDiffCliN2cConfig (..),
     TxDiffCliOptions (..),
+    TxDiffCliWeb2Config (..),
     parseTxDiffCliArgs,
     txDiffCliUsage,
  )
+import Cardano.Node.Client.TxDiff.Resolver (
+    Resolver,
+    resolveChain,
+ )
+import Cardano.Node.Client.TxDiff.Resolver.N2C (n2cResolver)
+import Cardano.Node.Client.TxDiff.Resolver.Web2 (
+    Web2Config (..),
+    httpFetchTx,
+    web2Resolver,
+ )
+
+import Cardano.Ledger.Api.Tx (bodyTxL)
+import Cardano.Ledger.Api.Tx.Body (
+    collateralInputsTxBodyL,
+    inputsTxBodyL,
+    referenceInputsTxBodyL,
+ )
+import Cardano.Ledger.BaseTypes (TxIx (..))
+import Cardano.Ledger.Hashes (extractHash)
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Node.Client.Ledger (ConwayTx)
+
+import Cardano.Crypto.Hash (hashToBytes)
+import Control.Concurrent.Async (withAsync)
+import Control.Monad (void)
 import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
 import Data.ByteString.Lazy qualified as LBS
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
 import Data.Text.IO qualified as TextIO
-import System.Environment (getArgs, getProgName)
+import Lens.Micro ((^.))
+import Network.HTTP.Client (newManager)
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Ouroboros.Network.Magic (NetworkMagic (..))
+import System.Environment (getArgs, getProgName, lookupEnv)
 import System.Exit (exitFailure, exitSuccess)
 import System.IO (hPutStrLn, stderr)
 
@@ -46,8 +93,20 @@ runDiff :: TxDiffCliOptions -> IO ()
 runDiff cliOptions = do
     blueprints <- traverse loadBlueprint (txDiffCliBlueprintPaths cliOptions)
     collapseRules <- traverse loadCollapseRules (txDiffCliCollapseRulesPath cliOptions)
-    left <- BS.readFile leftPath
-    right <- BS.readFile rightPath
+    leftBytes <- BS.readFile (txDiffCliLeftPath cliOptions)
+    rightBytes <- BS.readFile (txDiffCliRightPath cliOptions)
+    leftTx <- decodeOrDie "left" leftBytes
+    rightTx <- decodeOrDie "right" rightBytes
+    let inputs = collectInputs leftTx <> collectInputs rightTx
+    resolutionResult <-
+        if anyResolverConfigured cliOptions
+            then do
+                (resolved, unresolved) <-
+                    withResolverChain cliOptions $ \chain ->
+                        resolveChain chain inputs
+                reportUnresolved unresolved
+                pure (Just resolved)
+            else pure Nothing
     let options =
             defaultTxDiffOptions
                 { txDiffDecodeData =
@@ -56,27 +115,127 @@ runDiff cliOptions = do
                             Nothing
                         _ ->
                             Just (blueprintDataDecoder blueprints)
+                , txDiffResolvedInputs = resolutionResult
                 }
-    case diffConwayTxInputWith options left right of
+        diff = diffConwayTxWith options leftTx rightTx
+    TextIO.putStr $
+        renderDiffNodeHumanWith
+            ( (txDiffCliHumanRenderOptions cliOptions)
+                { humanCollapseRules = collapseRules
+                }
+            )
+            diff
+    if diffNodeHasChanges diff
+        then exitFailure
+        else exitSuccess
+
+decodeOrDie :: String -> BS.ByteString -> IO ConwayTx
+decodeOrDie side bytes =
+    case decodeConwayTxInput bytes of
+        Right tx -> pure tx
         Left err -> do
-            hPutStrLn stderr ("tx-diff: failed to decode input: " <> show err)
+            hPutStrLn stderr ("tx-diff: failed to decode " <> side <> " input: " <> show err)
             exitFailure
-        Right diff -> do
-            TextIO.putStr $
-                renderDiffNodeHumanWith
-                    ( (txDiffCliHumanRenderOptions cliOptions)
-                        { humanCollapseRules = collapseRules
-                        }
-                    )
-                    diff
-            if diffNodeHasChanges diff
-                then exitFailure
-                else exitSuccess
+
+collectInputs :: ConwayTx -> Set TxIn
+collectInputs tx =
+    let body = tx ^. bodyTxL
+     in (body ^. inputsTxBodyL)
+            <> (body ^. referenceInputsTxBodyL)
+            <> (body ^. collateralInputsTxBodyL)
+
+anyResolverConfigured :: TxDiffCliOptions -> Bool
+anyResolverConfigured cli =
+    case (txDiffCliN2cResolver cli, txDiffCliWeb2Resolver cli) of
+        (Nothing, Nothing) -> False
+        _ -> True
+
+{- | Build the resolver chain that matches the CLI flags. The N2C resolver
+is tried first (cheap, local, no privacy cost); the web2 resolver fills
+the remainder.
+
+The continuation owns the resolver lifecycle: if N2C is configured, the
+underlying mini-protocol thread is spawned with 'withAsync' and torn down
+when the continuation returns.
+-}
+withResolverChain ::
+    TxDiffCliOptions ->
+    ([Resolver] -> IO a) ->
+    IO a
+withResolverChain cli k = do
+    web2 <- traverse buildWeb2Resolver (txDiffCliWeb2Resolver cli)
+    case txDiffCliN2cResolver cli of
+        Nothing ->
+            k (maybe [] pure web2)
+        Just n2c ->
+            withN2cResolver n2c $ \n2cR ->
+                k (n2cR : maybe [] pure web2)
+
+buildWeb2Resolver :: TxDiffCliWeb2Config -> IO Resolver
+buildWeb2Resolver cfg = do
+    apiKey <- loadWeb2ApiKey (txDiffCliWeb2ApiKeyFile cfg)
+    manager <- newManager tlsManagerSettings
+    pure $
+        web2Resolver
+            Web2Config
+                { web2ResolverName = "web2"
+                , web2Fetch =
+                    httpFetchTx
+                        manager
+                        (txDiffCliWeb2Url cfg)
+                        apiKey
+                }
+
+{- | Resolve the Blockfrost-style @project_id@ key.
+
+Precedence:
+
+1. @--web2-api-key-file PATH@ wins; surrounding whitespace is stripped.
+2. Otherwise the @TX_DIFF_WEB2_API_KEY@ environment variable is consulted.
+3. With neither set, the request goes out without a key, which works
+   against self-hosted Blockfrost-compatible endpoints.
+
+This keeps the secret out of @ps@ output and shell history, matching the
+existing repo conventions used by @cardano-tx-generator@.
+-}
+loadWeb2ApiKey :: Maybe FilePath -> IO (Maybe Text)
+loadWeb2ApiKey (Just path) =
+    Just . Text.strip . Text.decodeUtf8 <$> BS.readFile path
+loadWeb2ApiKey Nothing = do
+    envKey <- lookupEnv "TX_DIFF_WEB2_API_KEY"
+    pure (fmap (Text.strip . Text.pack) envKey)
+
+withN2cResolver :: TxDiffCliN2cConfig -> (Resolver -> IO a) -> IO a
+withN2cResolver TxDiffCliN2cConfig{txDiffCliN2cSocket, txDiffCliN2cNetworkMagic} k = do
+    lsqCh <- newLSQChannel 64
+    ltxsCh <- newLTxSChannel 64
+    withAsync
+        ( void $
+            runNodeClient
+                (NetworkMagic txDiffCliN2cNetworkMagic)
+                txDiffCliN2cSocket
+                lsqCh
+                ltxsCh
+        )
+        $ \_ -> k (n2cResolver (mkN2CProvider lsqCh))
+
+reportUnresolved :: Map TxIn [Text] -> IO ()
+reportUnresolved unresolved
+    | Map.null unresolved = pure ()
+    | otherwise =
+        mapM_ emit (Map.toAscList unresolved)
   where
-    leftPath =
-        txDiffCliLeftPath cliOptions
-    rightPath =
-        txDiffCliRightPath cliOptions
+    emit (TxIn (TxId safeHash) (TxIx ix), names) =
+        hPutStrLn stderr $
+            "tx-diff: input "
+                <> Text.unpack (Text.decodeUtf8 (Base16.encode (hashToBytes (extractHash safeHash))))
+                <> "#"
+                <> show ix
+                <> " not resolved by "
+                <> showNames names
+
+    showNames [] = "[]"
+    showNames ns = "[" <> Text.unpack (Text.intercalate ", " ns) <> "]"
 
 loadBlueprint :: FilePath -> IO Blueprint
 loadBlueprint blueprintPath = do

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -96,6 +96,7 @@ library
     Cardano.Node.Client.TxDiff
     Cardano.Node.Client.TxDiff.Cli
     Cardano.Node.Client.TxDiff.Resolver
+    Cardano.Node.Client.TxDiff.Resolver.N2C
     Cardano.Node.Client.TxGenerator.Build
     Cardano.Node.Client.TxGenerator.Daemon
     Cardano.Node.Client.TxGenerator.Fanout

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -95,6 +95,7 @@ library
     Cardano.Node.Client.Submitter
     Cardano.Node.Client.TxDiff
     Cardano.Node.Client.TxDiff.Cli
+    Cardano.Node.Client.TxDiff.Resolver
     Cardano.Node.Client.TxGenerator.Build
     Cardano.Node.Client.TxGenerator.Daemon
     Cardano.Node.Client.TxGenerator.Fanout
@@ -310,6 +311,7 @@ test-suite unit-tests
     Cardano.Node.Client.TxDiff.CliSpec
     Cardano.Node.Client.TxDiff.ConwaySpec
     Cardano.Node.Client.TxDiff.CoreSpec
+    Cardano.Node.Client.TxDiff.ResolverSpec
     Cardano.Node.Client.TxDiffSpec
     Cardano.Node.Client.TxGenerator.FanoutSpec
     Cardano.Node.Client.TxGenerator.PersistSpec

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -292,10 +292,20 @@ executable tx-diff
   main-is:          Main.hs
   default-language: GHC2021
   build-depends:
+    , async
     , base
+    , base16-bytestring
     , bytestring
+    , cardano-crypto-class
+    , cardano-ledger-api
+    , cardano-ledger-core
     , cardano-node-clients
     , cardano-node-clients:plutus-blueprint
+    , containers
+    , http-client
+    , http-client-tls
+    , microlens
+    , ouroboros-network:api
     , text
 
 test-suite unit-tests

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -97,6 +97,7 @@ library
     Cardano.Node.Client.TxDiff.Cli
     Cardano.Node.Client.TxDiff.Resolver
     Cardano.Node.Client.TxDiff.Resolver.N2C
+    Cardano.Node.Client.TxDiff.Resolver.Web2
     Cardano.Node.Client.TxGenerator.Build
     Cardano.Node.Client.TxGenerator.Daemon
     Cardano.Node.Client.TxGenerator.Fanout
@@ -148,6 +149,9 @@ library
     , dns
     , exceptions
     , filepath
+    , http-client
+    , http-client-tls
+    , http-types
     , io-classes
     , io-classes:strict-stm
     , iproute
@@ -313,6 +317,7 @@ test-suite unit-tests
     Cardano.Node.Client.TxDiff.ConwaySpec
     Cardano.Node.Client.TxDiff.CoreSpec
     Cardano.Node.Client.TxDiff.ResolverSpec
+    Cardano.Node.Client.TxDiff.Web2Spec
     Cardano.Node.Client.TxDiffSpec
     Cardano.Node.Client.TxGenerator.FanoutSpec
     Cardano.Node.Client.TxGenerator.PersistSpec

--- a/docs/executables/tx-diff.md
+++ b/docs/executables/tx-diff.md
@@ -124,7 +124,10 @@ tx-diff --collapse-rules collapse.yaml --blueprint plutus.json tx-a.cbor tx-b.cb
 
 ```text
 tx-diff [--render tree|paths] [--tree-art ascii|unicode] \
-  [--collapse-rules FILE] [--blueprint FILE ...] TX_A TX_B
+  [--collapse-rules FILE] [--blueprint FILE ...] \
+  [--resolve-n2c SOCKET --network-magic N] \
+  [--resolve-web2 URL [--web2-api-key-file PATH]] \
+  TX_A TX_B
 ```
 
 Arguments:
@@ -140,6 +143,18 @@ Options:
 - `--tree-art unicode`: use Unicode tree connectors.
 - `--blueprint FILE`: load a Plutus blueprint. The option can be repeated.
 - `--collapse-rules FILE`: load YAML rules for named list-diff views.
+- `--resolve-n2c SOCKET`: resolve inputs against a local cardano-node Unix
+  socket. Requires `--network-magic`.
+- `--network-magic N`: network magic (e.g. `764824073` for mainnet,
+  `2` for preview, `1` for preprod). Required alongside `--resolve-n2c`.
+- `--resolve-web2 URL`: resolve inputs against a Blockfrost-compatible web2
+  endpoint that exposes `GET <URL>/txs/<txid>/cbor`.
+- `--web2-api-key-file PATH`: file containing the API key sent as the
+  `project_id` header. Surrounding whitespace is stripped. Only valid with
+  `--resolve-web2`. Falls back to the `TX_DIFF_WEB2_API_KEY` environment
+  variable when this flag is absent; if neither is set, the request goes
+  out without a key, which suits self-hosted Blockfrost-compatible
+  endpoints.
 
 Exit status:
 
@@ -266,6 +281,85 @@ With `views.raw: hide`, the raw branch is omitted, but unrepresented diffs are
 not dropped. Changed leaves, insertions, and deletions not represented by a
 named view render directly under their original numeric indexes.
 
+## Input Resolution
+
+By default, `tx-diff` is offline: each input of either transaction renders as
+an atomic `txId#ix` leaf. Two opt-in resolvers can attach the referenced
+`TxOut` (address, coin, datum, reference script) to every input the resolver
+can find. Both spending, reference, and collateral inputs are covered.
+
+### N2C: local cardano-node
+
+```bash
+tx-diff \
+  --resolve-n2c /run/cardano-node/node.socket \
+  --network-magic 764824073 \
+  tx-a.cbor tx-b.cbor
+```
+
+`--resolve-n2c` opens an N2C `LocalStateQuery` session against a running
+node. It returns only *currently unspent* UTxOs: inputs whose referenced
+output has already been consumed will not be resolved by this path.
+
+The user owns the socket, so this path has no third-party exposure. The
+resolver name reported in diagnostics is `n2c`.
+
+### Web2: Blockfrost-compatible CBOR endpoint
+
+```bash
+# canonical: secret on disk, no exposure via `ps` or shell history
+tx-diff \
+  --resolve-web2 https://cardano-mainnet.blockfrost.io/api/v0 \
+  --web2-api-key-file /run/secrets/blockfrost-mainnet \
+  tx-a.cbor tx-b.cbor
+
+# alternative: env var fallback when --web2-api-key-file is absent
+TX_DIFF_WEB2_API_KEY=mainnetXXXX tx-diff \
+  --resolve-web2 https://cardano-mainnet.blockfrost.io/api/v0 \
+  tx-a.cbor tx-b.cbor
+```
+
+`--resolve-web2` issues one HTTPS GET per *distinct* referenced transaction
+id (`GET <URL>/txs/<txId>/cbor`) and indexes into the decoded transaction's
+outputs to recover the referenced `TxOut`. Spent inputs resolve through this
+path because the provider returns the historical transaction.
+
+**Privacy and trust.** Web2 resolution sends transaction identifiers to a
+third party. The provider learns which transactions you are inspecting. Use
+the N2C path or a self-hosted Blockfrost-compatible service when this is a
+concern.
+
+The resolver name reported in diagnostics is `web2`.
+
+### Combining N2C and web2
+
+When both flags are present, the N2C resolver is asked first: it is cheap,
+local, and leaks nothing. The web2 resolver only sees the inputs N2C could
+not resolve — typically inputs that are already spent.
+
+```bash
+tx-diff \
+  --resolve-n2c /run/cardano-node/node.socket \
+  --network-magic 764824073 \
+  --resolve-web2 https://cardano-mainnet.blockfrost.io/api/v0 \
+  --web2-api-key-file /run/secrets/blockfrost-mainnet \
+  tx-a.cbor tx-b.cbor
+```
+
+### Unresolved inputs
+
+If no configured resolver returns an entry for some input, `tx-diff` does not
+fail: the input renders without the resolved subtree, the rest of the diff
+continues, and one stderr line per unresolved input names the input and the
+resolvers that were asked:
+
+```text
+tx-diff: input 8b3a…#0 not resolved by [n2c]
+tx-diff: input 12ef…#1 not resolved by [n2c, web2]
+```
+
+The order in the bracket matches the order resolvers were tried.
+
 ## Tutorial: Swap Order Review
 
 This example groups repeated output differences under a semantic `swapOrders`
@@ -370,18 +464,12 @@ The collapse view hides something I expected to see
 
 ## Roadmap
 
-The current release compares the two transaction bodies provided on disk. Two
-follow-up capabilities are planned:
+The current release compares the two transaction bodies provided on disk and
+optionally resolves their referenced UTxOs via N2C or a Blockfrost-compatible
+endpoint (see *Input Resolution* above). The next planned capability is:
 
 - **WASM support**: make the tx-diff engine available in browser and other
   WebAssembly environments.
-- **Input resolution through cardano-node N2C**: connect to a local
-  cardano-node socket to resolve transaction inputs while diffing, so the
-  output can include context that is not present in the signed transaction
-  bytes alone.
-
-These are not required for the release artifacts above. They are listed here
-so users know where the executable is heading.
 
 ## Specification Contract
 

--- a/flake.nix
+++ b/flake.nix
@@ -119,7 +119,21 @@
             };
           };
           components = project.hsPkgs.cardano-node-clients.components;
-          txDiff = components.exes.tx-diff;
+          # tx-diff's web2 resolver uses http-client-tls and needs a CA
+          # bundle at runtime. Wrap the raw executable so it points at the
+          # cacert store baked into the nix closure. AppImage/DEB/RPM
+          # bundlers include the wrapper and its closure, so HTTPS works
+          # without the user setting SSL_CERT_FILE themselves.
+          txDiff = pkgs.symlinkJoin {
+            name = "tx-diff";
+            paths = [ components.exes.tx-diff ];
+            nativeBuildInputs = [ pkgs.makeWrapper ];
+            postBuild = ''
+              wrapProgram $out/bin/tx-diff \
+                --set-default SSL_CERT_FILE \
+                  ${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
+            '';
+          };
           packageVersion =
             let
               versionLines =

--- a/lib/Cardano/Node/Client/TxDiff.hs
+++ b/lib/Cardano/Node/Client/TxDiff.hs
@@ -208,6 +208,12 @@ data TxDiffDataSelector = TxDiffDataSelector
 data TxDiffOptions = TxDiffOptions
     { txDiffIncludeWitnesses :: Bool
     , txDiffDecodeData :: Maybe TxDiffDataDecoder
+    , txDiffResolvedInputs :: Maybe (Map TxIn (TxOut ConwayEra))
+    -- ^ When 'Nothing' (default), every 'TxIn' renders as today: an atomic
+    -- @{txId, index}@ leaf. When 'Just', resolution is treated as enabled;
+    -- each 'TxIn' renders as an object with a @txIn@ child and, only if
+    -- present in the map, a @resolved@ child reusing the body-output
+    -- projection.
     }
 
 instance Show TxDiffOptions where
@@ -216,6 +222,11 @@ instance Show TxDiffOptions where
             <> show (txDiffIncludeWitnesses options)
             <> ", txDiffDecodeData = "
             <> maybe "Nothing" (const "Just <decoder>") (txDiffDecodeData options)
+            <> ", txDiffResolvedInputs = "
+            <> maybe
+                "Nothing"
+                (\m -> "Just <" <> show (Map.size m) <> " resolved>")
+                (txDiffResolvedInputs options)
             <> "}"
 
 defaultTxDiffOptions :: TxDiffOptions
@@ -223,6 +234,7 @@ defaultTxDiffOptions =
     TxDiffOptions
         { txDiffIncludeWitnesses = False
         , txDiffDecodeData = Nothing
+        , txDiffResolvedInputs = Nothing
         }
 
 -- | Human diff render shape.
@@ -345,6 +357,7 @@ data ConwayDiffValue
     | ConwayStrictMaybeCoinValue (StrictMaybe Coin)
     | ConwayInputsValue [TxIn]
     | ConwayTxInValue TxIn
+    | ConwayTxInIdValue TxIn
     | ConwayKeyHashesValue [KeyHash Guard]
     | ConwayKeyHashValue (KeyHash Guard)
     | ConwayMintValue MultiAsset
@@ -1272,6 +1285,8 @@ conwayDiffEqual (ConwayInputsValue left) (ConwayInputsValue right) =
     left == right
 conwayDiffEqual (ConwayTxInValue left) (ConwayTxInValue right) =
     left == right
+conwayDiffEqual (ConwayTxInIdValue left) (ConwayTxInIdValue right) =
+    left == right
 conwayDiffEqual (ConwayKeyHashesValue left) (ConwayKeyHashesValue right) =
     left == right
 conwayDiffEqual (ConwayKeyHashValue left) (ConwayKeyHashValue right) =
@@ -1349,6 +1364,8 @@ conwayDiffSummary (ConwayStrictMaybeCoinValue coin) =
 conwayDiffSummary (ConwayInputsValue inputs) =
     Just (inputsValue inputs)
 conwayDiffSummary (ConwayTxInValue txIn) =
+    Just (txInValue txIn)
+conwayDiffSummary (ConwayTxInIdValue txIn) =
     Just (txInValue txIn)
 conwayDiffSummary (ConwayKeyHashesValue keyHashes) =
     Just (keyHashesValue keyHashes)
@@ -1479,7 +1496,18 @@ conwayDiffProjection _ (ConwayStrictMaybeCoinValue coin) =
     DiffAtomic (strictMaybeCoinValue coin)
 conwayDiffProjection _ (ConwayInputsValue inputs) =
     DiffArrayChildren (map ConwayTxInValue inputs)
-conwayDiffProjection _ (ConwayTxInValue txIn) =
+conwayDiffProjection options (ConwayTxInValue txIn) =
+    case txDiffResolvedInputs options of
+        Nothing ->
+            DiffAtomic (txInValue txIn)
+        Just resolutionMap ->
+            DiffObjectChildren $
+                Map.fromList $
+                    ("txIn", ConwayTxInIdValue txIn)
+                        : [ ("resolved", ConwayTxOutValue resolved)
+                          | Just resolved <- [Map.lookup txIn resolutionMap]
+                          ]
+conwayDiffProjection _ (ConwayTxInIdValue txIn) =
     DiffAtomic (txInValue txIn)
 conwayDiffProjection _ (ConwayKeyHashesValue keyHashes) =
     DiffArrayChildren (map ConwayKeyHashValue keyHashes)

--- a/lib/Cardano/Node/Client/TxDiff/Cli.hs
+++ b/lib/Cardano/Node/Client/TxDiff/Cli.hs
@@ -10,9 +10,16 @@ blueprints are read.
 module Cardano.Node.Client.TxDiff.Cli (
     TxDiffCliError (..),
     TxDiffCliOptions (..),
+    TxDiffCliN2cConfig (..),
+    TxDiffCliWeb2Config (..),
     parseTxDiffCliArgs,
     txDiffCliUsage,
 ) where
+
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Word (Word32)
+import Text.Read (readMaybe)
 
 import Cardano.Node.Client.TxDiff (
     HumanRenderOptions (..),
@@ -21,10 +28,29 @@ import Cardano.Node.Client.TxDiff (
     defaultHumanRenderOptions,
  )
 
+data TxDiffCliN2cConfig = TxDiffCliN2cConfig
+    { txDiffCliN2cSocket :: FilePath
+    , txDiffCliN2cNetworkMagic :: Word32
+    }
+    deriving stock (Eq, Show)
+
+data TxDiffCliWeb2Config = TxDiffCliWeb2Config
+    { txDiffCliWeb2Url :: Text
+    , txDiffCliWeb2ApiKeyFile :: Maybe FilePath
+    -- ^ Path to a file whose contents (after stripping surrounding
+    -- whitespace) are sent as the @project_id@ header. When 'Nothing',
+    -- the executable falls back to the @TX_DIFF_WEB2_API_KEY@ environment
+    -- variable; if that is also unset the request is sent without a key,
+    -- which suits Blockfrost-compatible self-hosted endpoints.
+    }
+    deriving stock (Eq, Show)
+
 data TxDiffCliOptions = TxDiffCliOptions
     { txDiffCliBlueprintPaths :: [FilePath]
     , txDiffCliCollapseRulesPath :: Maybe FilePath
     , txDiffCliHumanRenderOptions :: HumanRenderOptions
+    , txDiffCliN2cResolver :: Maybe TxDiffCliN2cConfig
+    , txDiffCliWeb2Resolver :: Maybe TxDiffCliWeb2Config
     , txDiffCliLeftPath :: FilePath
     , txDiffCliRightPath :: FilePath
     }
@@ -34,52 +60,125 @@ newtype TxDiffCliError = TxDiffCliUsageError String
     deriving stock (Eq, Show)
 
 parseTxDiffCliArgs :: [String] -> Either TxDiffCliError TxDiffCliOptions
-parseTxDiffCliArgs =
-    go [] Nothing defaultHumanRenderOptions
+parseTxDiffCliArgs args =
+    do
+        (acc, positional) <- go emptyAccumulator args
+        case positional of
+            [leftPath, rightPath] ->
+                buildOptions acc leftPath rightPath
+            _ ->
+                Left (TxDiffCliUsageError "expected TX_A TX_B")
   where
-    go blueprintPaths collapseRulesPath renderOptions ("--blueprint" : blueprintPath : rest) =
-        go (blueprintPath : blueprintPaths) collapseRulesPath renderOptions rest
-    go _ _ _ ["--blueprint"] =
+    go acc ("--blueprint" : blueprintPath : rest) =
+        go acc{accBlueprintPaths = blueprintPath : accBlueprintPaths acc} rest
+    go _ ["--blueprint"] =
         Left (TxDiffCliUsageError "missing value for --blueprint")
-    go blueprintPaths _ renderOptions ("--collapse-rules" : collapseRulesPath : rest) =
-        go blueprintPaths (Just collapseRulesPath) renderOptions rest
-    go _ _ _ ["--collapse-rules"] =
+    go acc ("--collapse-rules" : collapseRulesPath : rest) =
+        go acc{accCollapseRulesPath = Just collapseRulesPath} rest
+    go _ ["--collapse-rules"] =
         Left (TxDiffCliUsageError "missing value for --collapse-rules")
-    go blueprintPaths collapseRulesPath renderOptions ("--render" : value : rest) =
-        case parseRenderShape value of
-            Left err ->
-                Left err
-            Right renderShape ->
-                go
-                    blueprintPaths
-                    collapseRulesPath
-                    renderOptions{humanRenderShape = renderShape}
-                    rest
-    go _ _ _ ["--render"] =
+    go acc ("--render" : value : rest) = do
+        renderShape <- parseRenderShape value
+        let renderOptions = accRenderOptions acc
+        go
+            acc{accRenderOptions = renderOptions{humanRenderShape = renderShape}}
+            rest
+    go _ ["--render"] =
         Left (TxDiffCliUsageError "missing value for --render")
-    go blueprintPaths collapseRulesPath renderOptions ("--tree-art" : value : rest) =
-        case parseTreeArt value of
-            Left err ->
-                Left err
-            Right treeArt ->
-                go
-                    blueprintPaths
-                    collapseRulesPath
-                    renderOptions{humanTreeArt = treeArt}
-                    rest
-    go _ _ _ ["--tree-art"] =
+    go acc ("--tree-art" : value : rest) = do
+        treeArt <- parseTreeArt value
+        let renderOptions = accRenderOptions acc
+        go acc{accRenderOptions = renderOptions{humanTreeArt = treeArt}} rest
+    go _ ["--tree-art"] =
         Left (TxDiffCliUsageError "missing value for --tree-art")
-    go blueprintPaths collapseRulesPath renderOptions [leftPath, rightPath] =
+    go acc ("--resolve-n2c" : path : rest) =
+        go acc{accN2cSocket = Just path} rest
+    go _ ["--resolve-n2c"] =
+        Left (TxDiffCliUsageError "missing value for --resolve-n2c")
+    go acc ("--network-magic" : value : rest) =
+        case readMaybe value of
+            Nothing ->
+                Left
+                    ( TxDiffCliUsageError $
+                        "expected a non-negative integer for --network-magic, got: " <> value
+                    )
+            Just magic ->
+                go acc{accNetworkMagic = Just magic} rest
+    go _ ["--network-magic"] =
+        Left (TxDiffCliUsageError "missing value for --network-magic")
+    go acc ("--resolve-web2" : url : rest) =
+        go acc{accWeb2Url = Just (Text.pack url)} rest
+    go _ ["--resolve-web2"] =
+        Left (TxDiffCliUsageError "missing value for --resolve-web2")
+    go acc ("--web2-api-key-file" : path : rest) =
+        go acc{accWeb2ApiKeyFile = Just path} rest
+    go _ ["--web2-api-key-file"] =
+        Left (TxDiffCliUsageError "missing value for --web2-api-key-file")
+    go acc rest =
+        Right (acc, rest)
+
+    buildOptions acc leftPath rightPath = do
+        n2c <- buildN2c acc
+        web2 <- buildWeb2 acc
         Right
             TxDiffCliOptions
-                { txDiffCliBlueprintPaths = reverse blueprintPaths
-                , txDiffCliCollapseRulesPath = collapseRulesPath
-                , txDiffCliHumanRenderOptions = renderOptions
+                { txDiffCliBlueprintPaths = reverse (accBlueprintPaths acc)
+                , txDiffCliCollapseRulesPath = accCollapseRulesPath acc
+                , txDiffCliHumanRenderOptions = accRenderOptions acc
+                , txDiffCliN2cResolver = n2c
+                , txDiffCliWeb2Resolver = web2
                 , txDiffCliLeftPath = leftPath
                 , txDiffCliRightPath = rightPath
                 }
-    go _ _ _ _ =
-        Left (TxDiffCliUsageError "expected TX_A TX_B")
+
+    buildN2c acc =
+        case (accN2cSocket acc, accNetworkMagic acc) of
+            (Nothing, Nothing) -> Right Nothing
+            (Just socket, Just magic) ->
+                Right (Just (TxDiffCliN2cConfig socket magic))
+            (Just _, Nothing) ->
+                Left
+                    ( TxDiffCliUsageError
+                        "--resolve-n2c also requires --network-magic"
+                    )
+            (Nothing, Just _) ->
+                Left
+                    ( TxDiffCliUsageError
+                        "--network-magic also requires --resolve-n2c"
+                    )
+
+    buildWeb2 acc =
+        case (accWeb2Url acc, accWeb2ApiKeyFile acc) of
+            (Nothing, Nothing) -> Right Nothing
+            (Just url, keyFile) ->
+                Right (Just (TxDiffCliWeb2Config url keyFile))
+            (Nothing, Just _) ->
+                Left
+                    ( TxDiffCliUsageError
+                        "--web2-api-key-file requires --resolve-web2"
+                    )
+
+data Accumulator = Accumulator
+    { accBlueprintPaths :: [FilePath]
+    , accCollapseRulesPath :: Maybe FilePath
+    , accRenderOptions :: HumanRenderOptions
+    , accN2cSocket :: Maybe FilePath
+    , accNetworkMagic :: Maybe Word32
+    , accWeb2Url :: Maybe Text
+    , accWeb2ApiKeyFile :: Maybe FilePath
+    }
+
+emptyAccumulator :: Accumulator
+emptyAccumulator =
+    Accumulator
+        { accBlueprintPaths = []
+        , accCollapseRulesPath = Nothing
+        , accRenderOptions = defaultHumanRenderOptions
+        , accN2cSocket = Nothing
+        , accNetworkMagic = Nothing
+        , accWeb2Url = Nothing
+        , accWeb2ApiKeyFile = Nothing
+        }
 
 parseRenderShape :: String -> Either TxDiffCliError RenderShape
 parseRenderShape "tree" =
@@ -103,4 +202,7 @@ txDiffCliUsage prog =
         <> prog
         <> " [--render tree|paths] [--tree-art ascii|unicode]"
         <> " [--collapse-rules FILE]"
-        <> " [--blueprint FILE ...] TX_A TX_B"
+        <> " [--blueprint FILE ...]"
+        <> " [--resolve-n2c SOCKET --network-magic N]"
+        <> " [--resolve-web2 URL [--web2-api-key-file PATH]]"
+        <> " TX_A TX_B"

--- a/lib/Cardano/Node/Client/TxDiff/Resolver.hs
+++ b/lib/Cardano/Node/Client/TxDiff/Resolver.hs
@@ -1,0 +1,66 @@
+{- |
+Module      : Cardano.Node.Client.TxDiff.Resolver
+Description : Pluggable input-resolver chain for tx-diff
+License     : Apache-2.0
+
+A 'Resolver' turns a set of 'TxIn's into a partial map of resolved Conway
+'TxOut's. 'resolveChain' runs several resolvers in order, each one only
+seeing the inputs that the previous resolvers could not resolve, and
+returns the union of resolved entries plus the list of resolver names that
+failed to find each still-unresolved input.
+
+The diff core consumes only the resolved map via
+'Cardano.Node.Client.TxDiff.TxDiffOptions.txDiffResolvedInputs'. The CLI is
+responsible for invoking 'resolveChain' before computing the diff and for
+turning unresolved entries into stderr diagnostics.
+-}
+module Cardano.Node.Client.TxDiff.Resolver (
+    Resolver (..),
+    resolveChain,
+) where
+
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text)
+
+import Cardano.Ledger.Api.Tx.Out (TxOut)
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.TxIn (TxIn)
+
+{- | A named resolver. The function is given the set of inputs still in
+need of resolution and returns whatever it could resolve. The result map
+MAY be a strict subset of the input set; missing keys are treated as
+"this resolver could not resolve that input".
+-}
+data Resolver = Resolver
+    { resolverName :: Text
+    , resolveInputs :: Set TxIn -> IO (Map TxIn (TxOut ConwayEra))
+    }
+
+{- | Run a list of resolvers in order. Each resolver sees only the inputs
+the previous resolvers could not resolve. Returns @(resolved, tried)@
+where @resolved@ is the merged map and @tried@ maps each still-unresolved
+input to the resolver names that were asked and failed (in order).
+
+The empty chain returns @(Map.empty, Map.fromSet (const []) inputs)@.
+-}
+resolveChain ::
+    [Resolver] ->
+    Set TxIn ->
+    IO (Map TxIn (TxOut ConwayEra), Map TxIn [Text])
+resolveChain = go Map.empty []
+  where
+    go acc askedSoFar [] remaining =
+        pure (acc, Map.fromSet (const askedSoFar) remaining)
+    go acc _ _ remaining
+        | Set.null remaining =
+            pure (acc, Map.empty)
+    go acc askedSoFar (resolver : rest) remaining = do
+        found <- resolveInputs resolver remaining
+        let resolvedSet = Map.keysSet found
+            newRemaining = Set.difference remaining resolvedSet
+            newAcc = Map.union acc found
+            newAsked = askedSoFar <> [resolverName resolver]
+        go newAcc newAsked rest newRemaining

--- a/lib/Cardano/Node/Client/TxDiff/Resolver/N2C.hs
+++ b/lib/Cardano/Node/Client/TxDiff/Resolver/N2C.hs
@@ -1,0 +1,34 @@
+{- |
+Module      : Cardano.Node.Client.TxDiff.Resolver.N2C
+Description : tx-diff resolver backed by a local cardano-node N2C 'Provider'
+License     : Apache-2.0
+
+A 'Resolver' that asks a local 'Provider' (see
+"Cardano.Node.Client.Provider") for the currently-unspent UTxOs by 'TxIn'.
+Resolution is best-effort: inputs that have already been spent on the
+node's current chain tip will not be resolved, which is the expected
+behavior documented for users running this resolver against a live node.
+
+This module is intentionally tiny: it neither owns the node connection
+nor the 'LSQChannel'. Callers (typically the tx-diff @Main@ wiring) build
+a 'Provider', possibly inside a bracketed N2C client thread, and pass it
+here.
+-}
+module Cardano.Node.Client.TxDiff.Resolver.N2C (
+    n2cResolver,
+) where
+
+import Cardano.Node.Client.Provider (Provider (..))
+import Cardano.Node.Client.TxDiff.Resolver (Resolver (..))
+
+{- | Build an N2C-backed 'Resolver' from any 'Provider IO'.
+
+The resolver's name is the literal string @"n2c"@. The resolver delegates
+to 'queryUTxOByTxIn', which queries the acquired snapshot in one batch.
+-}
+n2cResolver :: Provider IO -> Resolver
+n2cResolver provider =
+    Resolver
+        { resolverName = "n2c"
+        , resolveInputs = queryUTxOByTxIn provider
+        }

--- a/lib/Cardano/Node/Client/TxDiff/Resolver/Web2.hs
+++ b/lib/Cardano/Node/Client/TxDiff/Resolver/Web2.hs
@@ -1,0 +1,236 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Cardano.Node.Client.TxDiff.Resolver.Web2
+Description : tx-diff resolver backed by a Blockfrost-style web2 endpoint
+License     : Apache-2.0
+
+A 'Resolver' that fetches each distinct referenced transaction's CBOR
+from a Blockfrost-compatible web2 provider, decodes it as a Conway
+transaction, and indexes the referenced 'TxIx' to recover the resolved
+'TxOut'. Inputs whose referenced transaction cannot be fetched or
+decoded, or whose 'TxIx' is out of range, are silently skipped: the
+resolver chain will then report them as unresolved for diagnostics.
+
+The HTTP call is pluggable via 'Web2FetchTx' so unit tests can inject
+canned responses without standing up a fake HTTP server. The production
+implementation 'httpFetchTx' uses 'http-client' + 'http-client-tls'.
+-}
+module Cardano.Node.Client.TxDiff.Resolver.Web2 (
+    Web2FetchTx,
+    Web2FetchError (..),
+    Web2Config (..),
+    web2Resolver,
+    httpFetchTx,
+) where
+
+import Control.Exception (SomeException, try)
+import Data.Aeson qualified as Aeson
+import Data.Bifunctor (first)
+import Data.ByteString (ByteString)
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Lazy qualified as LBS
+import Data.Foldable (toList)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Lens.Micro ((^.))
+import Network.HTTP.Client (
+    Manager,
+    Request (..),
+    httpLbs,
+    parseRequest,
+    responseBody,
+    responseStatus,
+ )
+import Network.HTTP.Types.Status (statusCode)
+
+import Cardano.Crypto.Hash (hashToBytes)
+import Cardano.Ledger.Api.Tx.Body (outputsTxBodyL)
+import Cardano.Ledger.Api.Tx.Out (TxOut)
+import Cardano.Ledger.BaseTypes (TxIx (..))
+import Cardano.Ledger.Binary (
+    Annotator,
+    Decoder,
+    decCBOR,
+    decodeFullAnnotatorFromHexText,
+    natVersion,
+ )
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core (bodyTxL)
+import Cardano.Ledger.Hashes (extractHash)
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Node.Client.Ledger (ConwayTx)
+import Cardano.Node.Client.TxDiff.Resolver (Resolver (..))
+
+-- | Why a single web2 fetch failed.
+data Web2FetchError
+    = Web2FetchHttpError Text
+    | Web2FetchDecodeError Text
+    deriving stock (Eq, Show)
+
+{- | Pluggable per-transaction fetcher. Implementations are given the
+hex-encoded 'TxId' and return either an error or the raw CBOR bytes of
+that transaction.
+-}
+type Web2FetchTx =
+    Text -> IO (Either Web2FetchError ByteString)
+
+-- | Configuration for a Blockfrost-style web2 resolver.
+data Web2Config = Web2Config
+    { web2ResolverName :: Text
+    -- ^ Diagnostic name; defaults to @"web2"@ for callers that do not
+    -- have a reason to override.
+    , web2Fetch :: Web2FetchTx
+    }
+
+{- | Build a web2 'Resolver' from a configured fetcher. The resolver
+issues one 'Web2FetchTx' call per *distinct* requested 'TxId', then
+indexes each requested 'TxIn' into the decoded transaction's outputs.
+-}
+web2Resolver :: Web2Config -> Resolver
+web2Resolver Web2Config{web2ResolverName, web2Fetch} =
+    Resolver
+        { resolverName = web2ResolverName
+        , resolveInputs = \inputs -> do
+            let txIds = Set.fromList [txId | TxIn txId _ <- toList inputs]
+            fetched <-
+                Map.fromList
+                    <$> traverse fetchOne (Set.toAscList txIds)
+            pure (resolveInputsFromFetched fetched inputs)
+        }
+  where
+    fetchOne :: TxId -> IO (TxId, Either Web2FetchError ConwayTx)
+    fetchOne txId = do
+        result <- web2Fetch (txIdHex txId)
+        pure
+            ( txId
+            , result >>= decodeFetched
+            )
+
+-- | Merge fetched transactions with the requested input set.
+resolveInputsFromFetched ::
+    Map TxId (Either Web2FetchError ConwayTx) ->
+    Set TxIn ->
+    Map TxIn (TxOut ConwayEra)
+resolveInputsFromFetched fetched inputs =
+    Map.fromList
+        [ (txIn, txOut)
+        | txIn@(TxIn txId (TxIx ix)) <- toList inputs
+        , Just (Right tx) <- [Map.lookup txId fetched]
+        , Just txOut <- [outputAtIndex tx (fromIntegral ix)]
+        ]
+
+outputAtIndex :: ConwayTx -> Int -> Maybe (TxOut ConwayEra)
+outputAtIndex tx ix =
+    let outputs = toList (tx ^. bodyTxL . outputsTxBodyL)
+     in case drop ix outputs of
+            (out : _) -> Just out
+            [] -> Nothing
+
+decodeFetched :: ByteString -> Either Web2FetchError ConwayTx
+decodeFetched bytes =
+    first (Web2FetchDecodeError . Text.pack . show) $
+        decodeFullAnnotatorFromHexText
+            (natVersion @11)
+            "tx-diff web2 resolved transaction"
+            (decCBOR :: forall s. Decoder s (Annotator ConwayTx))
+            (Text.decodeUtf8 (hexEncode bytes))
+
+hexEncode :: ByteString -> ByteString
+hexEncode = Base16.encode
+
+txIdHex :: TxId -> Text
+txIdHex (TxId safeHash) =
+    Text.decodeUtf8 (hexEncode (hashToBytes (extractHash safeHash)))
+
+{- | Production 'Web2FetchTx' that performs an HTTP GET against
+@\<baseUrl\>/txs/\<txid\>/cbor@ and parses the response as JSON
+@{"cbor":"\<hex\>"}@.
+
+The optional API key is sent as a @project_id@ header (Blockfrost
+convention).
+-}
+httpFetchTx ::
+    Manager ->
+    -- | Base URL, e.g. @"https://cardano-mainnet.blockfrost.io/api/v0"@
+    Text ->
+    -- | Optional Blockfrost @project_id@
+    Maybe Text ->
+    Web2FetchTx
+httpFetchTx manager baseUrl apiKey txIdHexText = do
+    let url = Text.unpack baseUrl <> "/txs/" <> Text.unpack txIdHexText <> "/cbor"
+    requestResult <-
+        try @SomeException (parseRequest url)
+    case requestResult of
+        Left err ->
+            pure
+                . Left
+                . Web2FetchHttpError
+                $ "bad URL "
+                    <> Text.pack url
+                    <> ": "
+                    <> Text.pack (show err)
+        Right req0 -> do
+            let req =
+                    req0
+                        { requestHeaders =
+                            requestHeaders req0
+                                <> [ ("project_id", Text.encodeUtf8 key)
+                                   | Just key <- [apiKey]
+                                   ]
+                        }
+            httpResult <- try @SomeException (httpLbs req manager)
+            case httpResult of
+                Left err ->
+                    pure
+                        . Left
+                        . Web2FetchHttpError
+                        $ "GET "
+                            <> Text.pack url
+                            <> " failed: "
+                            <> Text.pack (show err)
+                Right response
+                    | statusCode (responseStatus response) >= 400 ->
+                        pure
+                            . Left
+                            . Web2FetchHttpError
+                            $ "GET "
+                                <> Text.pack url
+                                <> " returned HTTP "
+                                <> Text.pack (show (statusCode (responseStatus response)))
+                    | otherwise ->
+                        pure $
+                            parseBlockfrostCborResponse (responseBody response)
+
+parseBlockfrostCborResponse ::
+    LBS.ByteString -> Either Web2FetchError ByteString
+parseBlockfrostCborResponse body =
+    case Aeson.eitherDecode body of
+        Left err ->
+            Left
+                . Web2FetchDecodeError
+                . Text.pack
+                $ "expected {\"cbor\":\"...\"}: " <> err
+        Right envelope ->
+            case Base16.decode (Text.encodeUtf8 (blockfrostCborHex envelope)) of
+                Left hexErr ->
+                    Left
+                        . Web2FetchDecodeError
+                        . Text.pack
+                        $ "could not hex-decode cbor field: " <> hexErr
+                Right raw ->
+                    Right raw
+
+newtype BlockfrostCborResponse = BlockfrostCborResponse
+    { blockfrostCborHex :: Text
+    }
+
+instance Aeson.FromJSON BlockfrostCborResponse where
+    parseJSON =
+        Aeson.withObject "BlockfrostCborResponse" $ \value ->
+            BlockfrostCborResponse <$> value Aeson..: "cbor"

--- a/llm/reviews/local-150-tx-diff-input-resolution/gate.sh
+++ b/llm/reviews/local-150-tx-diff-input-resolution/gate.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../../.."
+exec nix develop --quiet -c just ci

--- a/llm/reviews/local-150-tx-diff-input-resolution/state.md
+++ b/llm/reviews/local-150-tx-diff-input-resolution/state.md
@@ -1,0 +1,7 @@
+state: WaitingForPlanReview
+pr: 151
+branch: 150-tx-diff-input-resolution
+sha:
+review_file: llm/reviews/local-150-tx-diff-input-resolution/plan-review.md
+updated_by: author
+notes: "Spec, plan, and tasks drafted (solo mode). Plan and tasks await self-review before code."

--- a/nix/docker-image.nix
+++ b/nix/docker-image.nix
@@ -32,6 +32,7 @@ pkgs.dockerTools.buildImage {
       pkgs.jq
       pkgs.gnugrep
       pkgs.netcat-openbsd
+      pkgs.cacert
       usrBinEnv
       components.exes.cardano-tx-generator
     ];

--- a/specs/150-tx-diff-input-resolution/plan.md
+++ b/specs/150-tx-diff-input-resolution/plan.md
@@ -1,0 +1,292 @@
+# Implementation Plan: Tx Diff Input Resolution
+
+**Branch**: `150-tx-diff-input-resolution` | **Date**: 2026-05-14 | **Spec**:
+`specs/150-tx-diff-input-resolution/spec.md`
+**Input**: Feature specification from
+`specs/150-tx-diff-input-resolution/spec.md`
+
+## Summary
+
+Add an opt-in input-resolution pass to `tx-diff`. Resolution is configured
+via two independent CLI flag groups: one for a Blockfrost-compatible web2
+endpoint (`--resolve-web2 URL [--web2-api-key-file PATH]`) and one for a local
+cardano-node N2C socket (`--resolve-n2c PATH --network-magic N`). When at
+least one resolver is configured, tx-diff collects every `TxIn` referenced
+in either transaction's `inputs`, `referenceInputs`, and
+`collateralInputs`, asks the configured resolvers for the matching `TxOut`s,
+and attaches each resolved `TxOut` as a child of the existing `TxIn`
+projection so the renderer descends into address/coin/datum/referenceScript
+the same way it descends into body outputs. Unresolved inputs render without
+the new children; tx-diff prints one stderr line per unresolved input
+naming the input and the resolver(s) that failed. The default
+no-flag behavior is byte-identical to current main.
+
+## Technical Context
+
+**Language/Version**: Haskell, GHC 9.12.3
+**Primary Dependencies**: existing `cardano-ledger-conway` and
+`Cardano.Node.Client.Provider`; new `http-client` + `http-client-tls` (or
+`http-conduit` if already available in CHaP) for the Blockfrost call;
+existing `Cardano.Node.Client.N2C.Connection.runNodeClient` plus
+`Cardano.Node.Client.N2C.Provider.mkN2CProvider` for the N2C resolver.
+**Storage**: N/A.
+**Testing**: Hspec via `just unit`. Web2 resolver is exercised against a
+local fake HTTP server (`warp` or `http-server` thread inside the test);
+N2C resolver is exercised via a fake `Provider` record, not the full mini-
+protocol — the existing test pattern uses `mkN2CProvider lsq` against the
+devnet, which is too heavy for the per-resolver semantics check.
+**Target Platform**: Linux/macOS CLI.
+**Project Type**: Haskell library + CLI executable.
+**Performance Goals**: One HTTP round-trip per *distinct* `TxId` requested
+via web2; one LSQ batch for all `TxIn`s requested via N2C. Linear in input
+count for the merge.
+**Constraints**: No new behavior without an opt-in flag. No transaction
+submission. Existing tx-diff fixtures must produce byte-identical output
+with no flags. Blueprint decoding for resolved datums uses the existing
+decoder, no new blueprint logic.
+**Scale/Scope**: Conway transactions only. Inputs only (the three input
+lists). Output projections are unchanged.
+
+## Constitution Check
+
+- Channel-driven N2C: the N2C resolver reuses
+  `Cardano.Node.Client.N2C.Connection.runNodeClient` and `mkN2CProvider`
+  rather than opening a hand-rolled socket.
+- Devnet E2E testing: there is no new E2E surface for the web2 path
+  because that would require running a real Blockfrost. We use a local
+  fake HTTP server in unit tests, which is consistent with "no mocks for
+  *node* communication" — the node communication path still goes through
+  the real Provider abstraction.
+- Minimal dependencies: `http-client` + `http-client-tls` are widely used
+  upstream and already available through the existing flake; we will
+  confirm that's the case in the first implementation slice and pick the
+  smallest http library Haskell.nix offers if not.
+- Test utilities first-class: the resolver abstraction is exported so
+  downstream consumers (and tests) can supply their own resolvers without
+  touching the CLI.
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/150-tx-diff-input-resolution/
+├── spec.md
+├── plan.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── cli.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+lib/Cardano/Node/Client/TxDiff.hs              # core diff: attach resolved TxOut to TxIn projection
+lib/Cardano/Node/Client/TxDiff/Cli.hs          # CLI parser: new flags
+lib/Cardano/Node/Client/TxDiff/Resolver.hs     # NEW: Resolver type, chain, diagnostics
+lib/Cardano/Node/Client/TxDiff/Resolver/Web2.hs # NEW: Blockfrost CBOR resolver
+lib/Cardano/Node/Client/TxDiff/Resolver/N2C.hs  # NEW: N2C-via-Provider resolver
+app/tx-diff/Main.hs                            # wire CLI to resolvers; pre-flight + run
+test/Cardano/Node/Client/TxDiff/CoreSpec.hs    # diff-shape tests with synthetic resolved inputs
+test/Cardano/Node/Client/TxDiff/CliSpec.hs     # new flag parsing tests
+test/Cardano/Node/Client/TxDiff/ResolverSpec.hs # NEW: resolver-chain semantics
+test/Cardano/Node/Client/TxDiff/Web2Spec.hs    # NEW: web2 resolver against a local fake HTTP server
+cardano-node-clients.cabal                     # new modules + http-client deps
+docs/executables/tx-diff.md                    # new flags + privacy/trust notes
+```
+
+**Structure Decision**: The resolver lives in a new module subtree under
+`Cardano.Node.Client.TxDiff.Resolver.*` so the diff core stays oblivious to
+HTTP and to the Provider record. `TxDiff.hs` only sees a small `Resolved
+TxIn` map (`Map TxIn (TxOut ConwayEra)`), which is what feeds the projection.
+The CLI assembles a resolver from flags and calls it before the diff is
+computed.
+
+## Design
+
+### Resolver abstraction
+
+```haskell
+-- Cardano.Node.Client.TxDiff.Resolver
+data Resolver = Resolver
+    { resolverName :: Text
+    , resolveInputs :: Set TxIn -> IO (Map TxIn (TxOut ConwayEra))
+    }
+
+-- Run a chain of resolvers in order. The first resolver is given all
+-- inputs; later resolvers receive only the inputs the earlier ones
+-- could not resolve. Returns the union and the set of still-unresolved
+-- TxIns annotated with the resolver names that were tried.
+resolveChain :: [Resolver] -> Set TxIn
+             -> IO (Map TxIn (TxOut ConwayEra), Map TxIn [Text])
+```
+
+The chain is the only place that knows about ordering. The CLI builds the
+list as `[n2cResolver] ++ [web2Resolver]` (filtered by flags). With no
+flags, the chain is empty and resolution is a no-op.
+
+### Diff core change
+
+`conwayDiffProjection` for `ConwayTxInValue` currently returns
+`DiffAtomic (txInValue txIn)`. We change it to consult a resolution map
+passed via `TxDiffOptions`:
+
+```haskell
+data TxDiffOptions = TxDiffOptions
+    { txDiffIncludeWitnesses :: Bool
+    , txDiffDecodeData       :: Maybe TxDiffDataDecoder
+    , txDiffResolvedInputs   :: Map TxIn (TxOut ConwayEra) -- NEW
+    }
+```
+
+When `txDiffResolvedInputs` is empty (default), the projection stays atomic
+and the output is byte-identical to today (this is the test fixture
+guarantee). When a TxIn has an entry, the projection becomes an object with
+the existing atomic value at `"txIn"` and the existing `ConwayTxOutValue`
+projection at `"resolved"`. Children of `"resolved"` are exactly the four
+fields the body-output projection already produces.
+
+### Web2 resolver (Blockfrost CBOR)
+
+`GET <URL>/txs/{hash}/cbor` with the `project_id` header set from
+`--web2-api-key-file`. Response body is JSON `{"cbor": "<hex>"}`. We decode the
+hex via the existing `decodeConwayTxHex`, then index outputs by `TxIx`. We
+deduplicate by `TxId` within a single tx-diff run to avoid multiple HTTP
+calls when the same prior transaction is referenced more than once. Any
+HTTP error, decode failure, or out-of-range index marks each affected
+`TxIn` as unresolved by `web2` for diagnostic purposes; tx-diff does not
+fail.
+
+Startup validation: an obviously malformed URL (no scheme, no host) is
+rejected before the transactions are read. A missing API key when the URL
+template needs one is *not* validated up-front; we discover that on the
+first call and surface it via stderr.
+
+### N2C resolver
+
+Open an `LSQChannel`, run `runNodeClient` in a background thread, build a
+`Provider` with `mkN2CProvider`, call `queryUTxOByTxIn` with the full input
+set, and tear the connection down. The N2C resolver may return fewer
+entries than requested — that's the "already spent" case and is expected.
+Tear-down uses a bracketed `withAsync`.
+
+Startup validation: missing socket file or invalid network magic causes the
+whole tx-diff invocation to exit non-zero before reading transactions.
+Inputs that the node could not resolve (returned empty entry) are reported
+via stderr as unresolved by `n2c`.
+
+### CLI surface
+
+```text
+tx-diff [render flags] [--collapse-rules FILE] [--blueprint FILE ...]
+        [--resolve-n2c PATH --network-magic N]
+        [--resolve-web2 URL [--web2-api-key-file PATH]]
+        TX_A TX_B
+```
+
+Existing flags are unchanged. `--network-magic` is required when
+`--resolve-n2c` is set; `--web2-api-key-file` is optional (some Blockfrost-
+compatible self-hosted endpoints do not require one).
+
+Exit codes:
+
+- 0 — no diffs.
+- 1 — diffs present (existing behavior).
+- 2 — pre-flight resolver failure (bad socket, bad URL form, missing
+  required flag combination). Existing CLI parser already returns non-zero
+  on parse errors; this is the same channel.
+
+### Diagnostics
+
+For each unresolved `TxIn`, exactly one stderr line:
+
+```text
+tx-diff: input <txId>#<ix> not resolved by [<resolver-1>, <resolver-2>]
+```
+
+Order in the bracket matches the resolver chain order. With only one
+resolver configured, the list has one element.
+
+## Proof Strategy (per slice)
+
+Each behavior-changing slice has a RED test that fails on `origin/main`
+and is fixed in the same commit by the GREEN implementation. Solo mode:
+RED + GREEN fold into one bisect-safe commit; we never push the RED-only
+intermediate state.
+
+- Slice A — diff-core takes resolved inputs and projects them as a TxOut
+  subtree. RED: a `CoreSpec` test feeds a synthetic resolution map and
+  expects the rendered tree to include `address`, `coin`, `datum`,
+  `referenceScript` under `body.inputs.0`. GREEN: change
+  `ConwayTxInValue` projection and `TxDiffOptions`.
+- Slice B — resolver abstraction + chain semantics. RED: `ResolverSpec`
+  tests that a single resolver, a chain of two with full coverage, and a
+  chain of two with partial coverage all return correct merged maps and
+  unresolved sets. GREEN: implement `Resolver` and `resolveChain`.
+- Slice C — N2C resolver. RED: a fake `Provider` record returning a fixed
+  map is wrapped by the N2C resolver and produces the expected map.
+  GREEN: implement `Resolver.N2C.fromProvider :: Provider IO -> Resolver`
+  and a small wiring helper that opens the socket from CLI flags.
+- Slice D — web2 Blockfrost resolver against a local fake HTTP server.
+  RED: a `Web2Spec` test stands up a local server that returns the CBOR
+  for a known tx and asserts the resolver returns the expected
+  `(TxIn, TxOut)`. Also covers HTTP 404 (unresolved) and bad JSON
+  (unresolved). GREEN: implement `Resolver.Web2.blockfrost`.
+- Slice E — CLI wiring + diagnostics + offline default. RED: `CliSpec`
+  tests for the new flags' parsing; a `Main`-level test that no-flag
+  fixtures produce byte-identical output to the existing golden. GREEN:
+  parser changes + `Main.hs` integration. Also adds the diagnostic-line
+  stderr behavior with a small assertion in `Main` integration test or a
+  module-level helper test.
+- Slice F — docs (`docs/executables/tx-diff.md`) describing flags,
+  trust/privacy implications, and how N2C resolution sees only currently-
+  unspent UTxOs.
+
+Each slice runs `nix develop --quiet -c just ci` (the gate from
+`llm/reviews/local-150-tx-diff-input-resolution/gate.sh`) before pushing.
+
+## Gate
+
+`llm/reviews/local-150-tx-diff-input-resolution/gate.sh` runs:
+
+```bash
+nix develop --quiet -c just ci
+```
+
+A live-boundary smoke is *not* added to the gate. Web2 resolution against
+real Blockfrost requires an API key and external network; N2C resolution
+requires a live node. Both are documented as operator follow-up in the new
+docs section. The existing devnet E2E suite already covers `Provider`
+behavior; the N2C resolver is a thin shim and adds no new node-protocol
+risk.
+
+## Risks And Open Questions
+
+- **http-client availability in haskell.nix**: confirm `http-client` /
+  `http-client-tls` build under our pin. If not, fall back to
+  `http-conduit` or `req`.
+- **Network magic ergonomics**: requiring `--network-magic` alongside
+  `--resolve-n2c` is correct but verbose. For mainnet/preview/preprod we
+  could later accept a name; out of scope for this slice.
+- **Diagnostic ordering**: stderr lines are emitted in TxIn-sort order so
+  output is reproducible across runs. The chain order in the bracket is
+  the configured chain order, also reproducible.
+- **Decoded datum size**: a resolved output may carry a very large datum
+  that blows up rendered diff lines. Collapse rules already exist for that
+  and apply here unchanged.
+
+## Status
+
+**Completed**: Worktree at `/code/cardano-node-clients-issue-150` on branch
+`150-tx-diff-input-resolution`. Draft PR #151. Spec written; this plan
+written.
+**Current**: Awaiting plan self-review; then tasks.md.
+**Blockers**: None.
+
+## Complexity Tracking
+
+No constitution violations. The only new external surface is HTTP, scoped
+to a single resolver behind a single flag pair, and isolated behind
+`Resolver.Web2`.

--- a/specs/150-tx-diff-input-resolution/spec.md
+++ b/specs/150-tx-diff-input-resolution/spec.md
@@ -1,0 +1,224 @@
+# Feature Specification: Tx Diff Input Resolution
+
+**Feature Branch**: `150-tx-diff-input-resolution`
+**Created**: 2026-05-14
+**Status**: Draft
+**Input**: GitHub issue #150 and user discussion on opt-in input resolution
+for `tx-diff`.
+
+## User Scenarios & Testing
+
+### User Story 1 - Resolve Spent Inputs Via Blockfrost (Priority: P1)
+
+A `tx-diff` user passes `--resolve-web2 https://cardano-mainnet.blockfrost.io
+--web2-api-key $BLOCKFROST_KEY` and the renderer shows, for each spending,
+collateral, and reference input, the address, coin, datum, and reference
+script of the output the input refers to. Spent UTxOs resolve too because
+Blockfrost returns the historical transaction CBOR.
+
+**Why this priority**: This is the practical capability the ticket asks for.
+Reviewers diffing two pre-submission transactions on mainnet need the output
+side of an input to interpret it; the production case is "what did this input
+actually point to".
+
+**Independent Test**: Run tx-diff against two CBOR transactions whose
+spending inputs reference outputs from a known mainnet transaction. With the
+flag set, the rendered diff shows each input's resolved address, coin, and
+datum under the existing TxOut projection.
+
+**Acceptance Scenarios**:
+
+1. **Given** a transaction whose first input is `(txId, ix)` referring to a
+   known historical UTxO, **When** tx-diff runs with the web2 flag and the
+   API key, **Then** the tree under `body.inputs.0` contains the same shape
+   as `body.outputs.0` (address, coin, datum, referenceScript).
+2. **Given** two transactions that differ only in one input's resolved
+   datum, **When** tx-diff runs with web2 resolution, **Then** the diff
+   reports the datum change under that input's path.
+3. **Given** the API call fails (bad key, network error, HTTP 404), **When**
+   tx-diff runs, **Then** that input renders without resolution children and
+   a single stderr line per failing input names the input and the resolver
+   that failed.
+
+### User Story 2 - Resolve Unspent Inputs Against A Local Node (Priority: P2)
+
+A `tx-diff` user with a local cardano-node passes
+`--resolve-n2c PATH --network-magic N` and the renderer resolves any input
+whose UTxO is still unspent on the node's current tip.
+
+**Why this priority**: Local devnet workflows already have a node socket; a
+web2 round trip is wasteful and leaks transaction identifiers to a third
+party.
+
+**Independent Test**: Spin up a devnet node, place a known UTxO at a known
+TxIn, and diff two transactions that consume that input. Tx-diff with the
+N2C flag resolves the input from the node.
+
+**Acceptance Scenarios**:
+
+1. **Given** a TxIn that is unspent on the configured node, **When** tx-diff
+   runs with the N2C flag, **Then** the rendered diff shows the resolved
+   output under that input.
+2. **Given** a TxIn that has already been spent on the configured node,
+   **When** tx-diff runs with the N2C flag only, **Then** that input renders
+   without resolution children and stderr reports it as unresolved by N2C.
+3. **Given** the node socket is missing or the network magic is wrong,
+   **When** tx-diff runs, **Then** the program emits a single startup error
+   and exits non-zero before reading the transactions, so the user fixes the
+   configuration rather than reading a misleading "unresolved" diff.
+
+### User Story 3 - Preserve Offline Default (Priority: P1)
+
+A `tx-diff` user who provides neither flag observes the exact same output as
+today.
+
+**Why this priority**: The ticket calls this out as a non-negotiable
+default; existing CI users must not see any change.
+
+**Independent Test**: Run the existing tx-diff unit suite without the new
+flags. All current outputs remain byte-identical.
+
+**Acceptance Scenarios**:
+
+1. **Given** no resolver flag is set, **When** tx-diff runs against any
+   existing fixture, **Then** every input renders exactly as today and no
+   network call is made.
+2. **Given** the input transaction has unusual shape (no inputs, only
+   reference inputs, only collateral), **When** tx-diff runs offline,
+   **Then** the rendered diff is unchanged from the current behavior.
+
+### User Story 4 - Combine Web2 and N2C (Priority: P3)
+
+A `tx-diff` user sets both `--resolve-web2` and `--resolve-n2c`. The renderer
+tries N2C first for each input; for inputs N2C cannot resolve (already
+spent), it falls back to web2.
+
+**Why this priority**: Useful but secondary. The two flags need a defined
+order so behavior is reproducible; both-set is reasonable for a developer
+diffing a mainnet snapshot against a not-yet-submitted variant.
+
+**Independent Test**: Diff two transactions where one input is currently
+unspent (N2C resolves it) and another is already spent (only web2 resolves
+it). Both render with resolution children.
+
+**Acceptance Scenarios**:
+
+1. **Given** both flags are set, **When** an input is unspent on the node,
+   **Then** the diff is resolved without invoking the web2 call for that
+   input.
+2. **Given** both flags are set, **When** an input is spent on the node,
+   **Then** the diff resolves it via web2.
+3. **Given** both flags are set and both resolvers fail for one input,
+   **When** tx-diff finishes, **Then** stderr names that input as
+   unresolved by both resolvers and the diff continues with the other
+   inputs.
+
+### Edge Cases
+
+- The same TxId appears in both transactions: web2 fetches it once and
+  reuses the response. The first slice MAY skip caching if the network call
+  is cheap; the spec only requires correctness.
+- A resolver call hangs: an overall per-resolver timeout aborts that
+  resolver, the failing inputs render unresolved, and tx-diff exits with the
+  same code it would have produced offline.
+- Resolution adds children to inputs that previously rendered atomically.
+  Existing collapse-rules files that target `body.inputs.<i>` still work,
+  because the rendered path of the TxIn changes from atomic to object only
+  when resolution is enabled.
+- Reference inputs and collateral inputs are treated the same as spending
+  inputs: same resolver chain, same diagnostics, same diff shape.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: tx-diff MUST accept `--resolve-web2 URL` and
+  `--web2-api-key KEY` flags that select Blockfrost-style transaction CBOR
+  download for input resolution. `--web2-api-key` MAY be omitted if the URL
+  needs no key.
+- **FR-002**: tx-diff MUST accept `--resolve-n2c PATH` and
+  `--network-magic N` flags that select a local cardano-node N2C resolver.
+- **FR-003**: When no resolver flag is set, tx-diff MUST behave exactly as
+  today.
+- **FR-004**: When at least one resolver is set, tx-diff MUST attempt to
+  resolve every `TxIn` in `body.inputs`, `body.referenceInputs`, and
+  `body.collateralInputs` of both transactions.
+- **FR-005**: A resolved input MUST attach the resolved Conway `TxOut` to
+  the existing `TxIn` projection so the diff renderer descends into
+  `address`, `coin`, `datum`, and `referenceScript` exactly as it does for
+  body outputs.
+- **FR-006**: An unresolved input MUST render without resolution children
+  and MUST NOT fail the program. Tx-diff MUST emit at least one stderr line
+  per unresolved input identifying the input and the resolver(s) that
+  failed.
+- **FR-007**: When both `--resolve-n2c` and `--resolve-web2` are set, the
+  N2C resolver MUST be tried first; the web2 resolver MUST be tried only
+  for inputs N2C did not resolve.
+- **FR-008**: Resolver failure modes that prevent any input from being
+  resolved (missing socket, bad network magic, missing/invalid Blockfrost
+  URL) MUST fail at startup before the transactions are read, except for
+  per-call network or HTTP errors which MUST be treated as per-input
+  unresolved.
+- **FR-009**: A web2 resolver MUST verify that the downloaded CBOR for a
+  given `TxId` decodes as a Conway transaction, that the requested index
+  exists in its outputs, and MUST treat any failure as unresolved for that
+  input with a stderr diagnostic.
+- **FR-010**: tx-diff MUST document the new flags, the privacy implication
+  of sending transaction identifiers to a third-party web2 provider, and
+  the requirement that the N2C resolver only sees currently-unspent UTxOs.
+
+### Key Entities
+
+- **Resolver**: A function `Set TxIn -> IO (Map TxIn (TxOut ConwayEra))` plus
+  a name used in stderr diagnostics. The N2C resolver is the existing
+  Provider's `queryUTxOByTxIn`. The web2 resolver downloads each referenced
+  transaction by `TxId` and indexes into outputs by `TxIx`.
+- **Resolution Mode**: The set of resolvers selected by CLI flags. May be
+  empty, web2-only, n2c-only, or both. The order in "both" is fixed: N2C
+  first.
+- **Resolved Input**: A `(TxIn, TxOut ConwayEra)` pair used to feed the
+  existing TxOut diff projection at the `TxIn` node.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A transaction whose three input lists together contain N
+  inputs renders, with both resolvers configured and all inputs unspent on
+  N2C, with N resolved TxOut subtrees and zero web2 calls.
+- **SC-002**: Running tx-diff against the existing unit fixtures with no
+  resolver flags produces byte-for-byte identical output to current main.
+- **SC-003**: An input that fails all configured resolvers produces exactly
+  one stderr diagnostic identifying the input by `txId#ix` and the resolvers
+  that failed, and tx-diff continues to render the rest of the diff.
+- **SC-004**: A web2 round trip per input is bounded by one HTTP GET that
+  returns a CBOR-encoded transaction; the implementation does not
+  recursively follow references or fetch protocol parameters.
+
+## Assumptions
+
+- Blockfrost-compatible providers expose `GET /txs/{hash}/cbor` returning
+  `{"cbor":"<hex>"}` or equivalent that decodes to a Conway transaction.
+  Providers that diverge from this contract are out of scope for the first
+  slice and may be added later behind the same flag with explicit handling.
+- Inputs reference Conway transactions only. Pre-Conway eras are out of
+  scope for the resolver in this slice; the existing tx-diff core is
+  Conway-only.
+- The user understands that web2 download reveals transaction identifiers
+  to the configured provider; the spec only requires this be documented,
+  not redacted.
+- The N2C resolver targets a local node owned by the user; this is the
+  same trust model as the existing Provider code in this repository.
+
+## Out Of Scope
+
+- Submitting transactions, mutating chain state, or driving block
+  production.
+- Making web2 and N2C return semantically identical results beyond
+  "resolved TxOut or not resolved".
+- Caching across runs or across process lifetimes; the first slice MAY
+  deduplicate within one run but does not promise it.
+- Alternative web2 providers whose API does not match the Blockfrost CBOR
+  contract.
+- New blueprint behavior. Resolved datums use the same blueprint decoder
+  as today via `--blueprint`.

--- a/specs/150-tx-diff-input-resolution/spec.md
+++ b/specs/150-tx-diff-input-resolution/spec.md
@@ -11,7 +11,7 @@ for `tx-diff`.
 ### User Story 1 - Resolve Spent Inputs Via Blockfrost (Priority: P1)
 
 A `tx-diff` user passes `--resolve-web2 https://cardano-mainnet.blockfrost.io
---web2-api-key $BLOCKFROST_KEY` and the renderer shows, for each spending,
+--web2-api-key-file /run/secrets/blockfrost-mainnet` and the renderer shows, for each spending,
 collateral, and reference input, the address, coin, datum, and reference
 script of the output the input refers to. Spent UTxOs resolve too because
 Blockfrost returns the historical transaction CBOR.
@@ -133,8 +133,8 @@ it). Both render with resolution children.
 ### Functional Requirements
 
 - **FR-001**: tx-diff MUST accept `--resolve-web2 URL` and
-  `--web2-api-key KEY` flags that select Blockfrost-style transaction CBOR
-  download for input resolution. `--web2-api-key` MAY be omitted if the URL
+  `--web2-api-key-file PATH` flags that select Blockfrost-style transaction CBOR
+  download for input resolution. `--web2-api-key-file` MAY be omitted if the URL
   needs no key.
 - **FR-002**: tx-diff MUST accept `--resolve-n2c PATH` and
   `--network-magic N` flags that select a local cardano-node N2C resolver.

--- a/specs/150-tx-diff-input-resolution/tasks.md
+++ b/specs/150-tx-diff-input-resolution/tasks.md
@@ -1,0 +1,138 @@
+# Tasks: Tx Diff Input Resolution
+
+**Input**: `specs/150-tx-diff-input-resolution/`
+**Prerequisites**: `spec.md`, `plan.md`
+
+Each task in Phase 2 onward is one vertical, bisect-safe commit that
+contains its own RED test and GREEN implementation. Tasks are ordered.
+Phase markers (`[A]`–`[F]`) match the slice letters in `plan.md`.
+
+## Phase 1: Specification
+
+- [x] T001 Create GitHub issue #150 (already exists).
+- [x] T002 Write Spec Kit `spec.md` under `specs/150-tx-diff-input-resolution/`.
+- [x] T003 Write Spec Kit `plan.md` under `specs/150-tx-diff-input-resolution/`.
+- [ ] T004 Write Spec Kit `tasks.md` (this file).
+- [ ] T005 Write `specs/150-tx-diff-input-resolution/data-model.md` describing
+  the `Resolver` record, `resolveChain` contract, and resolved-inputs map.
+- [ ] T006 Write `specs/150-tx-diff-input-resolution/contracts/cli.md`
+  enumerating the new flags, mutual requirements, and exit codes.
+- [ ] T007 Write `specs/150-tx-diff-input-resolution/quickstart.md` with two
+  worked examples: Blockfrost and local devnet N2C.
+
+## Phase 2: Diff Core Accepts Resolved Inputs [A]
+
+- [ ] T010 Add a RED unit test in
+  `test/Cardano/Node/Client/TxDiff/CoreSpec.hs` that constructs two
+  identical Conway transactions whose first input is `(txId, ix)` and
+  passes a `txDiffResolvedInputs` map containing one synthetic `TxOut`. The
+  test asserts the rendered tree under `body.inputs.0.resolved` exposes
+  the four child paths (`address`, `coin`, `datum`, `referenceScript`),
+  while the existing atomic `txIn` value is preserved at
+  `body.inputs.0.txIn`.
+- [ ] T011 Add a RED unit test that with `txDiffResolvedInputs` empty, the
+  byte-for-byte rendered tree for the existing fixture is unchanged from
+  the current snapshot stored in
+  `test/Cardano/Node/Client/TxDiff/CoreSpec.hs`.
+- [ ] T012 GREEN: add `txDiffResolvedInputs :: Map TxIn (TxOut ConwayEra)`
+  to `TxDiffOptions`, default to empty, thread through
+  `diffConwayTxWith`, and change `ConwayTxInValue` projection to consult
+  the map. Commit message: `feat: tx-diff core supports resolved inputs`.
+
+## Phase 3: Resolver Abstraction And Chain Semantics [B]
+
+- [ ] T020 Add RED unit tests in
+  `test/Cardano/Node/Client/TxDiff/ResolverSpec.hs` covering:
+  empty chain returns `(empty, empty)`; single resolver returns its map
+  unchanged; two-resolver chain merges with second only seeing the
+  unresolved set; partially-resolved tail marks unresolved inputs with
+  every resolver name that was tried.
+- [ ] T021 GREEN: create `lib/Cardano/Node/Client/TxDiff/Resolver.hs` with
+  `Resolver`, `resolveChain`, and an exported `noResolver` helper for the
+  empty chain. Wire the module into `cardano-node-clients.cabal`. Commit
+  message: `feat: tx-diff resolver chain`.
+
+## Phase 4: N2C Resolver [C]
+
+- [ ] T030 Add RED unit test in `ResolverSpec.hs` that wraps a fake
+  `Provider IO` whose `queryUTxOByTxIn` returns a fixed map and asserts
+  the wrapped resolver returns the same map. Add a second case where the
+  fake returns a subset and asserts the unresolved set is exactly the
+  missing inputs.
+- [ ] T031 GREEN: add
+  `lib/Cardano/Node/Client/TxDiff/Resolver/N2C.hs` exporting
+  `fromProvider :: Provider IO -> Resolver`. Commit message:
+  `feat: tx-diff N2C resolver`.
+- [ ] T032 Add RED CLI-level integration test (in `CliSpec.hs` or a small
+  new `MainResolverSpec.hs`) that fails fast when `--resolve-n2c` is set
+  without `--network-magic`, and vice versa.
+- [ ] T033 GREEN: extend the CLI parser in
+  `lib/Cardano/Node/Client/TxDiff/Cli.hs` to require the pair. Commit
+  message: `feat: tx-diff --resolve-n2c flag parsing`.
+
+## Phase 5: Web2 Blockfrost Resolver [D]
+
+- [ ] T040 Decide and pin the HTTP dependency. If `http-client` is in the
+  current haskell.nix package set, use it; otherwise pick the smallest
+  available substitute. Record the choice in `data-model.md`.
+- [ ] T041 Add RED tests in
+  `test/Cardano/Node/Client/TxDiff/Web2Spec.hs` against a local fake HTTP
+  server (using `warp` if available; otherwise the test starts a thread
+  with `network`'s `Network.Socket` directly):
+  - Happy path returns the expected `(TxIn, TxOut)`.
+  - HTTP 404 marks the input unresolved.
+  - Malformed JSON marks the input unresolved.
+  - A single `TxId` referenced twice triggers exactly one HTTP call.
+- [ ] T042 GREEN: add `lib/Cardano/Node/Client/TxDiff/Resolver/Web2.hs`
+  exporting `blockfrost :: Manager -> URL -> Maybe ApiKey -> Resolver`.
+  Commit message: `feat: tx-diff Blockfrost web2 resolver`.
+- [ ] T043 Add RED CLI tests covering `--resolve-web2 URL`,
+  `--web2-api-key-file PATH`, malformed URL rejection, and the case where
+  `--web2-api-key-file` is omitted.
+- [ ] T044 GREEN: extend the CLI parser for the web2 flag group. Commit
+  message: `feat: tx-diff --resolve-web2 flag parsing`.
+
+## Phase 6: CLI Wiring And Diagnostics [E]
+
+- [ ] T050 Add a RED integration test in
+  `test/Cardano/Node/Client/TxDiff/MainResolverSpec.hs` that runs the
+  `Main` CLI flow (via a small exported helper, not by spawning the
+  process) with one synthetic resolver and asserts the stderr diagnostic
+  for each unresolved input matches:
+  `tx-diff: input <txId>#<ix> not resolved by [<resolver>, ...]`.
+- [ ] T051 Add a RED test that with both `--resolve-n2c` and
+  `--resolve-web2` configured, the N2C resolver is asked first and the
+  web2 resolver is asked only for the leftovers (using two fake
+  resolvers from the resolver module).
+- [ ] T052 GREEN: extract a pure `mkResolverChain` helper from
+  `Main.hs`, wire CLI flags to resolvers, run the chain before
+  `diffConwayTxInputWith`, emit stderr diagnostics. Commit message:
+  `feat: tx-diff Main integrates resolver chain`.
+- [ ] T053 Add a RED test confirming exit-code 2 on pre-flight failure
+  (bad N2C socket; obviously malformed web2 URL).
+- [ ] T054 GREEN: add the startup validations described in `plan.md` to
+  `Main.hs`. Commit message: `feat: tx-diff pre-flight resolver
+  validation`.
+
+## Phase 7: Documentation [F]
+
+- [ ] T060 Update `docs/executables/tx-diff.md` to describe the two new
+  flag groups, the resolver chain order (N2C first), exit codes, and
+  privacy / trust notes (web2 leaks tx-ids to a third party; N2C sees
+  only unspent UTxOs). Commit message: `docs: tx-diff input resolution
+  flags`.
+
+## Phase 8: Verification
+
+- [ ] T070 `nix develop --quiet -c just format`.
+- [ ] T071 `nix develop --quiet -c just unit`.
+- [ ] T072 `nix develop --quiet -c just ci`.
+- [ ] T073 Push, update PR #151 description with the final tour of
+  changes, flip from draft to ready-for-review once CI is green.
+
+## TDD / DDD Folding Note
+
+In solo mode, the RED-only state is never pushed. Each task pair
+`(RED test, GREEN implementation)` folds into one commit using `git add`
++ `git commit` after the test passes locally. The commit message is the
+GREEN message; the body explains the proof. No `fixup` or `wip` commits.

--- a/test/Cardano/Node/Client/TxDiff/CliSpec.hs
+++ b/test/Cardano/Node/Client/TxDiff/CliSpec.hs
@@ -10,50 +10,49 @@ import Cardano.Node.Client.TxDiff (
  )
 import Cardano.Node.Client.TxDiff.Cli (
     TxDiffCliError (..),
+    TxDiffCliN2cConfig (..),
     TxDiffCliOptions (..),
+    TxDiffCliWeb2Config (..),
     parseTxDiffCliArgs,
  )
+
+defaultOptions :: TxDiffCliOptions
+defaultOptions =
+    TxDiffCliOptions
+        { txDiffCliBlueprintPaths = []
+        , txDiffCliCollapseRulesPath = Nothing
+        , txDiffCliHumanRenderOptions = defaultHumanRenderOptions
+        , txDiffCliN2cResolver = Nothing
+        , txDiffCliWeb2Resolver = Nothing
+        , txDiffCliLeftPath = "tx-a.cbor"
+        , txDiffCliRightPath = "tx-b.cbor"
+        }
 
 spec :: Spec
 spec =
     describe "tx-diff CLI parsing" $ do
         it "defaults to tree rendering with ASCII art" $
             parseTxDiffCliArgs ["tx-a.cbor", "tx-b.cbor"]
-                `shouldBe` Right
-                    TxDiffCliOptions
-                        { txDiffCliBlueprintPaths = []
-                        , txDiffCliCollapseRulesPath = Nothing
-                        , txDiffCliHumanRenderOptions = defaultHumanRenderOptions
-                        , txDiffCliLeftPath = "tx-a.cbor"
-                        , txDiffCliRightPath = "tx-b.cbor"
-                        }
+                `shouldBe` Right defaultOptions
 
         it "accepts explicit path rendering" $
             parseTxDiffCliArgs ["--render", "paths", "tx-a.cbor", "tx-b.cbor"]
                 `shouldBe` Right
-                    TxDiffCliOptions
-                        { txDiffCliBlueprintPaths = []
-                        , txDiffCliCollapseRulesPath = Nothing
-                        , txDiffCliHumanRenderOptions =
+                    defaultOptions
+                        { txDiffCliHumanRenderOptions =
                             defaultHumanRenderOptions
                                 { humanRenderShape = RenderPaths
                                 }
-                        , txDiffCliLeftPath = "tx-a.cbor"
-                        , txDiffCliRightPath = "tx-b.cbor"
                         }
 
         it "accepts explicit Unicode tree art" $
             parseTxDiffCliArgs ["--tree-art", "unicode", "tx-a.cbor", "tx-b.cbor"]
                 `shouldBe` Right
-                    TxDiffCliOptions
-                        { txDiffCliBlueprintPaths = []
-                        , txDiffCliCollapseRulesPath = Nothing
-                        , txDiffCliHumanRenderOptions =
+                    defaultOptions
+                        { txDiffCliHumanRenderOptions =
                             defaultHumanRenderOptions
                                 { humanTreeArt = TreeArtUnicode
                                 }
-                        , txDiffCliLeftPath = "tx-a.cbor"
-                        , txDiffCliRightPath = "tx-b.cbor"
                         }
 
         it "preserves repeated blueprint paths in input order" $
@@ -66,12 +65,8 @@ spec =
                 , "tx-b.cbor"
                 ]
                 `shouldBe` Right
-                    TxDiffCliOptions
+                    defaultOptions
                         { txDiffCliBlueprintPaths = ["one.json", "two.json"]
-                        , txDiffCliCollapseRulesPath = Nothing
-                        , txDiffCliHumanRenderOptions = defaultHumanRenderOptions
-                        , txDiffCliLeftPath = "tx-a.cbor"
-                        , txDiffCliRightPath = "tx-b.cbor"
                         }
 
         it "accepts a collapse rules path" $
@@ -82,12 +77,8 @@ spec =
                 , "tx-b.cbor"
                 ]
                 `shouldBe` Right
-                    TxDiffCliOptions
-                        { txDiffCliBlueprintPaths = []
-                        , txDiffCliCollapseRulesPath = Just "collapse.yaml"
-                        , txDiffCliHumanRenderOptions = defaultHumanRenderOptions
-                        , txDiffCliLeftPath = "tx-a.cbor"
-                        , txDiffCliRightPath = "tx-b.cbor"
+                    defaultOptions
+                        { txDiffCliCollapseRulesPath = Just "collapse.yaml"
                         }
 
         it "rejects invalid render mode before inputs are read" $
@@ -104,3 +95,120 @@ spec =
             parseTxDiffCliArgs ["--collapse-rules"]
                 `shouldBe` Left
                     (TxDiffCliUsageError "missing value for --collapse-rules")
+
+        it "parses --resolve-n2c with --network-magic" $
+            parseTxDiffCliArgs
+                [ "--resolve-n2c"
+                , "/run/cardano/node.socket"
+                , "--network-magic"
+                , "764824073"
+                , "tx-a.cbor"
+                , "tx-b.cbor"
+                ]
+                `shouldBe` Right
+                    defaultOptions
+                        { txDiffCliN2cResolver =
+                            Just
+                                TxDiffCliN2cConfig
+                                    { txDiffCliN2cSocket = "/run/cardano/node.socket"
+                                    , txDiffCliN2cNetworkMagic = 764824073
+                                    }
+                        }
+
+        it "rejects --resolve-n2c without --network-magic" $
+            parseTxDiffCliArgs
+                [ "--resolve-n2c"
+                , "/run/cardano/node.socket"
+                , "tx-a.cbor"
+                , "tx-b.cbor"
+                ]
+                `shouldBe` Left
+                    ( TxDiffCliUsageError
+                        "--resolve-n2c also requires --network-magic"
+                    )
+
+        it "rejects --network-magic without --resolve-n2c" $
+            parseTxDiffCliArgs
+                [ "--network-magic"
+                , "1"
+                , "tx-a.cbor"
+                , "tx-b.cbor"
+                ]
+                `shouldBe` Left
+                    ( TxDiffCliUsageError
+                        "--network-magic also requires --resolve-n2c"
+                    )
+
+        it "rejects a non-numeric --network-magic" $
+            parseTxDiffCliArgs
+                [ "--network-magic"
+                , "preprod"
+                , "tx-a.cbor"
+                , "tx-b.cbor"
+                ]
+                `shouldBe` Left
+                    ( TxDiffCliUsageError
+                        "expected a non-negative integer for --network-magic, got: preprod"
+                    )
+
+        it "parses --resolve-web2 without an API key file" $
+            parseTxDiffCliArgs
+                [ "--resolve-web2"
+                , "https://example.invalid/api/v0"
+                , "tx-a.cbor"
+                , "tx-b.cbor"
+                ]
+                `shouldBe` Right
+                    defaultOptions
+                        { txDiffCliWeb2Resolver =
+                            Just
+                                TxDiffCliWeb2Config
+                                    { txDiffCliWeb2Url =
+                                        "https://example.invalid/api/v0"
+                                    , txDiffCliWeb2ApiKeyFile = Nothing
+                                    }
+                        }
+
+        it "parses --resolve-web2 with --web2-api-key-file" $
+            parseTxDiffCliArgs
+                [ "--resolve-web2"
+                , "https://cardano-mainnet.blockfrost.io/api/v0"
+                , "--web2-api-key-file"
+                , "/run/secrets/blockfrost-mainnet"
+                , "tx-a.cbor"
+                , "tx-b.cbor"
+                ]
+                `shouldBe` Right
+                    defaultOptions
+                        { txDiffCliWeb2Resolver =
+                            Just
+                                TxDiffCliWeb2Config
+                                    { txDiffCliWeb2Url =
+                                        "https://cardano-mainnet.blockfrost.io/api/v0"
+                                    , txDiffCliWeb2ApiKeyFile =
+                                        Just "/run/secrets/blockfrost-mainnet"
+                                    }
+                        }
+
+        it "rejects --web2-api-key-file without --resolve-web2" $
+            parseTxDiffCliArgs
+                [ "--web2-api-key-file"
+                , "/run/secrets/blockfrost-mainnet"
+                , "tx-a.cbor"
+                , "tx-b.cbor"
+                ]
+                `shouldBe` Left
+                    ( TxDiffCliUsageError
+                        "--web2-api-key-file requires --resolve-web2"
+                    )
+
+        it "rejects --web2-api-key-file without its value" $
+            parseTxDiffCliArgs
+                [ "--resolve-web2"
+                , "https://example.invalid/api/v0"
+                , "--web2-api-key-file"
+                ]
+                `shouldBe` Left
+                    ( TxDiffCliUsageError
+                        "missing value for --web2-api-key-file"
+                    )

--- a/test/Cardano/Node/Client/TxDiff/ConwaySpec.hs
+++ b/test/Cardano/Node/Client/TxDiff/ConwaySpec.hs
@@ -662,6 +662,164 @@ spec =
                         )
                     )
 
+        it "renders resolved inputs as TxOut subtrees when resolution is enabled" $ do
+            tx <- loadFixture sampleHash
+            let outputs = toList (tx ^. bodyTxL . outputsTxBodyL)
+            case outputs of
+                firstOutput : _ -> do
+                    let resolvedOutA = firstOutput
+                        resolvedOutB = firstOutput & coinTxOutL .~ Coin 42
+                        oldInput = mkTxIn 1
+                        newInput = mkTxIn 2
+                        txA =
+                            tx
+                                & bodyTxL
+                                    . inputsTxBodyL
+                                    .~ Set.singleton oldInput
+                        txB =
+                            tx
+                                & bodyTxL
+                                    . inputsTxBodyL
+                                    .~ Set.singleton newInput
+                        resolutionMap =
+                            Map.fromList
+                                [ (oldInput, resolvedOutA)
+                                , (newInput, resolvedOutB)
+                                ]
+                        options =
+                            defaultTxDiffOptions
+                                { txDiffResolvedInputs = Just resolutionMap
+                                }
+                    diffConwayTxWith options txA txB
+                        `shouldBe` bodyDiff
+                            (bodyCommonExcept ["inputs"] txA)
+                            ( Map.singleton
+                                "inputs"
+                                ( DiffNode
+                                    (DiffPath ["body", "inputs"])
+                                    ( DiffArray
+                                        []
+                                        [
+                                            ( 0
+                                            , DiffNode
+                                                (DiffPath ["body", "inputs", "0"])
+                                                ( DiffObject
+                                                    Map.empty
+                                                    ( Map.fromList
+                                                        [
+                                                            ( "txIn"
+                                                            , DiffNode
+                                                                ( DiffPath
+                                                                    ["body", "inputs", "0", "txIn"]
+                                                                )
+                                                                ( DiffChanged
+                                                                    (txInJson oldInput)
+                                                                    (txInJson newInput)
+                                                                )
+                                                            )
+                                                        ,
+                                                            ( "resolved"
+                                                            , DiffNode
+                                                                ( DiffPath
+                                                                    ["body", "inputs", "0", "resolved"]
+                                                                )
+                                                                ( DiffObject
+                                                                    ( outputCommonExcept
+                                                                        ["coin"]
+                                                                        resolvedOutA
+                                                                    )
+                                                                    ( Map.singleton
+                                                                        "coin"
+                                                                        ( DiffNode
+                                                                            ( DiffPath
+                                                                                [ "body"
+                                                                                , "inputs"
+                                                                                , "0"
+                                                                                , "resolved"
+                                                                                , "coin"
+                                                                                ]
+                                                                            )
+                                                                            ( DiffChanged
+                                                                                (coinJson (resolvedOutA ^. coinTxOutL))
+                                                                                (coinJson (Coin 42))
+                                                                            )
+                                                                        )
+                                                                    )
+                                                                    Map.empty
+                                                                    Map.empty
+                                                                )
+                                                            )
+                                                        ]
+                                                    )
+                                                    Map.empty
+                                                    Map.empty
+                                                )
+                                            )
+                                        ]
+                                        []
+                                        []
+                                    )
+                                )
+                            )
+                [] ->
+                    expectationFailure "fixture has no outputs"
+
+        it "renders unresolved inputs as txIn-only subtrees when resolution is enabled but the map is empty" $ do
+            tx <- loadFixture sampleHash
+            let oldInput = mkTxIn 1
+                newInput = mkTxIn 2
+                txA =
+                    tx
+                        & bodyTxL
+                            . inputsTxBodyL
+                            .~ Set.singleton oldInput
+                txB =
+                    tx
+                        & bodyTxL
+                            . inputsTxBodyL
+                            .~ Set.singleton newInput
+                options =
+                    defaultTxDiffOptions
+                        { txDiffResolvedInputs = Just Map.empty
+                        }
+            diffConwayTxWith options txA txB
+                `shouldBe` bodyDiff
+                    (bodyCommonExcept ["inputs"] txA)
+                    ( Map.singleton
+                        "inputs"
+                        ( DiffNode
+                            (DiffPath ["body", "inputs"])
+                            ( DiffArray
+                                []
+                                [
+                                    ( 0
+                                    , DiffNode
+                                        (DiffPath ["body", "inputs", "0"])
+                                        ( DiffObject
+                                            Map.empty
+                                            ( Map.singleton
+                                                "txIn"
+                                                ( DiffNode
+                                                    ( DiffPath
+                                                        ["body", "inputs", "0", "txIn"]
+                                                    )
+                                                    ( DiffChanged
+                                                        (txInJson oldInput)
+                                                        (txInJson newInput)
+                                                    )
+                                                )
+                                            )
+                                            Map.empty
+                                            Map.empty
+                                        )
+                                    )
+                                ]
+                                []
+                                []
+                            )
+                        )
+                    )
+
         it "reports a Conway total collateral change at body.totalCollateral" $ do
             tx <- loadFixture sampleHash
             let oldTotalCollateral =

--- a/test/Cardano/Node/Client/TxDiff/ResolverSpec.hs
+++ b/test/Cardano/Node/Client/TxDiff/ResolverSpec.hs
@@ -1,0 +1,135 @@
+{- |
+Module      : Cardano.Node.Client.TxDiff.ResolverSpec
+Description : Resolver chain semantics
+-}
+module Cardano.Node.Client.TxDiff.ResolverSpec (spec) where
+
+import Data.IORef (modifyIORef', newIORef, readIORef)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromJust)
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Test.Hspec
+
+import Cardano.Crypto.Hash (hashFromStringAsHex)
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Api.Tx.Out (TxOut, mkBasicTxOut)
+import Cardano.Ledger.BaseTypes (Network (Testnet), TxIx (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Credential (Credential (KeyHashObj), StakeReference (StakeRefNull))
+import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
+import Cardano.Ledger.Keys (KeyHash (..), KeyRole (Payment))
+import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..))
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+
+import Cardano.Node.Client.TxDiff.Resolver (Resolver (..), resolveChain)
+
+spec :: Spec
+spec =
+    describe "Resolver chain" $ do
+        it "returns empty maps when the chain is empty and there are no inputs" $ do
+            (resolved, unresolved) <- resolveChain [] Set.empty
+            Map.keysSet resolved `shouldBe` Set.empty
+            unresolved `shouldBe` Map.empty
+
+        it "marks every input as not tried by any resolver when the chain is empty" $ do
+            let inputs = Set.fromList [mkTxIn 1, mkTxIn 2]
+            (resolved, unresolved) <- resolveChain [] inputs
+            Map.keysSet resolved `shouldBe` Set.empty
+            unresolved `shouldBe` Map.fromList [(mkTxIn 1, []), (mkTxIn 2, [])]
+
+        it "uses a single resolver and reports it as the only tried resolver for misses" $ do
+            let inputs = Set.fromList [mkTxIn 1, mkTxIn 2]
+                resolver = fakeResolver "alpha" (Map.singleton (mkTxIn 1) (mkTestTxOut 100))
+            (resolved, unresolved) <- resolveChain [resolver] inputs
+            Map.keysSet resolved `shouldBe` Set.singleton (mkTxIn 1)
+            unresolved `shouldBe` Map.singleton (mkTxIn 2) ["alpha"]
+
+        it "asks each later resolver only for inputs earlier resolvers could not resolve" $ do
+            seen <- newIORef ([] :: [(Text, Set TxIn)])
+            let inputs = Set.fromList [mkTxIn 1, mkTxIn 2, mkTxIn 3]
+                alpha =
+                    Resolver
+                        { resolverName = "alpha"
+                        , resolveInputs = \req -> do
+                            modifyIORef' seen (("alpha", req) :)
+                            pure (Map.singleton (mkTxIn 1) (mkTestTxOut 1))
+                        }
+                beta =
+                    Resolver
+                        { resolverName = "beta"
+                        , resolveInputs = \req -> do
+                            modifyIORef' seen (("beta", req) :)
+                            pure (Map.singleton (mkTxIn 2) (mkTestTxOut 2))
+                        }
+            (resolved, unresolved) <- resolveChain [alpha, beta] inputs
+            log_ <- reverse <$> readIORef seen
+            map fst log_ `shouldBe` ["alpha", "beta"]
+            map snd log_
+                `shouldBe` [ inputs
+                           , Set.fromList [mkTxIn 2, mkTxIn 3]
+                           ]
+            Map.keysSet resolved
+                `shouldBe` Set.fromList [mkTxIn 1, mkTxIn 2]
+            unresolved
+                `shouldBe` Map.singleton (mkTxIn 3) ["alpha", "beta"]
+
+        it "skips later resolvers once nothing remains to resolve" $ do
+            secondCalled <- newIORef False
+            let inputs = Set.singleton (mkTxIn 1)
+                alpha =
+                    fakeResolver "alpha" (Map.singleton (mkTxIn 1) (mkTestTxOut 1))
+                beta =
+                    Resolver
+                        { resolverName = "beta"
+                        , resolveInputs = \_ -> do
+                            modifyIORef' secondCalled (const True)
+                            pure Map.empty
+                        }
+            (resolved, unresolved) <- resolveChain [alpha, beta] inputs
+            Map.keysSet resolved `shouldBe` Set.singleton (mkTxIn 1)
+            unresolved `shouldBe` Map.empty
+            readIORef secondCalled
+                `shouldReturn` False
+
+fakeResolver :: Text -> Map TxIn (TxOut ConwayEra) -> Resolver
+fakeResolver name results =
+    Resolver
+        { resolverName = name
+        , resolveInputs = pure . Map.restrictKeys results
+        }
+
+mkTxIn :: Int -> TxIn
+mkTxIn n =
+    let hexStr =
+            replicate 60 '0'
+                ++ hexByte (n `div` 256)
+                ++ hexByte (n `mod` 256)
+        h = fromJust (hashFromStringAsHex hexStr)
+     in TxIn
+            (TxId (unsafeMakeSafeHash h))
+            (TxIx 0)
+
+mkTestTxOut :: Int -> TxOut ConwayEra
+mkTestTxOut n =
+    mkBasicTxOut (mkTestAddr n) (MaryValue (Coin (fromIntegral n)) (MultiAsset mempty))
+
+mkTestAddr :: Int -> Addr
+mkTestAddr n =
+    let hexStr =
+            replicate 52 '0'
+                ++ hexByte (n `div` 256)
+                ++ hexByte (n `mod` 256)
+        h = fromJust (hashFromStringAsHex hexStr)
+     in Addr
+            Testnet
+            (KeyHashObj (KeyHash h :: KeyHash Payment))
+            StakeRefNull
+
+hexByte :: Int -> String
+hexByte x =
+    let s = "0123456789abcdef"
+     in [s !! (x `div` 16), s !! (x `mod` 16)]

--- a/test/Cardano/Node/Client/TxDiff/ResolverSpec.hs
+++ b/test/Cardano/Node/Client/TxDiff/ResolverSpec.hs
@@ -4,6 +4,7 @@ Description : Resolver chain semantics
 -}
 module Cardano.Node.Client.TxDiff.ResolverSpec (spec) where
 
+import Control.Exception (ErrorCall (..), throwIO)
 import Data.IORef (modifyIORef', newIORef, readIORef)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -25,7 +26,9 @@ import Cardano.Ledger.Keys (KeyHash (..), KeyRole (Payment))
 import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 
+import Cardano.Node.Client.Provider (Provider (..))
 import Cardano.Node.Client.TxDiff.Resolver (Resolver (..), resolveChain)
+import Cardano.Node.Client.TxDiff.Resolver.N2C (n2cResolver)
 
 spec :: Spec
 spec =
@@ -77,6 +80,39 @@ spec =
             unresolved
                 `shouldBe` Map.singleton (mkTxIn 3) ["alpha", "beta"]
 
+        it "delegates the N2C resolver to the provider's queryUTxOByTxIn" $ do
+            let fixed =
+                    Map.fromList
+                        [ (mkTxIn 1, mkTestTxOut 11)
+                        , (mkTxIn 2, mkTestTxOut 12)
+                        ]
+                provider =
+                    stubProvider
+                        { queryUTxOByTxIn = pure . Map.restrictKeys fixed
+                        }
+                resolver = n2cResolver provider
+            results <-
+                resolveInputs resolver $
+                    Set.fromList [mkTxIn 1, mkTxIn 2, mkTxIn 3]
+            Map.keysSet results
+                `shouldBe` Set.fromList [mkTxIn 1, mkTxIn 2]
+            resolverName resolver `shouldBe` "n2c"
+
+        it "treats UTxOs the node cannot resolve as misses in the resolver chain" $ do
+            let provider =
+                    stubProvider
+                        { queryUTxOByTxIn = \_ -> pure Map.empty
+                        }
+                resolver = n2cResolver provider
+                inputs = Set.fromList [mkTxIn 5, mkTxIn 6]
+            (resolved, unresolved) <- resolveChain [resolver] inputs
+            Map.keysSet resolved `shouldBe` Set.empty
+            unresolved
+                `shouldBe` Map.fromList
+                    [ (mkTxIn 5, ["n2c"])
+                    , (mkTxIn 6, ["n2c"])
+                    ]
+
         it "skips later resolvers once nothing remains to resolve" $ do
             secondCalled <- newIORef False
             let inputs = Set.singleton (mkTxIn 1)
@@ -94,6 +130,34 @@ spec =
             unresolved `shouldBe` Map.empty
             readIORef secondCalled
                 `shouldReturn` False
+
+{- | A 'Provider IO' whose every field panics on call. Tests override only
+the fields they exercise so an accidental call to a non-overridden field
+is loud rather than silent. Each field is built from a lambda so the
+strict record construction does not force the underlying 'error'.
+-}
+stubProvider :: Provider IO
+stubProvider =
+    Provider
+        { withAcquired = \_ -> panicIO "withAcquired"
+        , queryUTxOs = \_ -> panicIO "queryUTxOs"
+        , queryUTxOByTxIn = \_ -> panicIO "queryUTxOByTxIn"
+        , queryProtocolParams = panicIO "queryProtocolParams"
+        , queryLedgerSnapshot = panicIO "queryLedgerSnapshot"
+        , queryStakeRewards = \_ -> panicIO "queryStakeRewards"
+        , queryRewardAccounts = \_ -> panicIO "queryRewardAccounts"
+        , queryVoteDelegatees = \_ -> panicIO "queryVoteDelegatees"
+        , queryTreasury = panicIO "queryTreasury"
+        , queryGovernanceState = panicIO "queryGovernanceState"
+        , evaluateTx = \_ -> panicIO "evaluateTx"
+        , posixMsToSlot = \_ -> panicIO "posixMsToSlot"
+        , posixMsCeilSlot = \_ -> panicIO "posixMsCeilSlot"
+        , queryUpperBoundSlot = \_ -> panicIO "queryUpperBoundSlot"
+        }
+  where
+    panicIO :: String -> IO a
+    panicIO field =
+        throwIO (ErrorCall ("stubProvider." <> field <> " called by an unprepared test"))
 
 fakeResolver :: Text -> Map TxIn (TxOut ConwayEra) -> Resolver
 fakeResolver name results =

--- a/test/Cardano/Node/Client/TxDiff/Web2Spec.hs
+++ b/test/Cardano/Node/Client/TxDiff/Web2Spec.hs
@@ -1,0 +1,178 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Cardano.Node.Client.TxDiff.Web2Spec
+Description : Web2 (Blockfrost-style) resolver tests against a canned fetcher
+-}
+module Cardano.Node.Client.TxDiff.Web2Spec (spec) where
+
+import Data.ByteString (ByteString)
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Char8 qualified as BS8
+import Data.Foldable (toList)
+import Data.IORef (modifyIORef', newIORef, readIORef)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromJust)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Lens.Micro ((^.))
+import System.IO.Unsafe (unsafePerformIO)
+import Test.Hspec
+
+import Cardano.Crypto.Hash (hashFromStringAsHex)
+import Cardano.Ledger.Api.Tx.Body (outputsTxBodyL)
+import Cardano.Ledger.Api.Tx.Out (TxOut, addrTxOutL)
+import Cardano.Ledger.BaseTypes (TxIx (..))
+import Cardano.Ledger.Binary (
+    Annotator,
+    Decoder,
+    decCBOR,
+    decodeFullAnnotatorFromHexText,
+    natVersion,
+ )
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core (bodyTxL)
+import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+
+import Cardano.Node.Client.Ledger (ConwayTx)
+import Cardano.Node.Client.TxDiff.Resolver (Resolver (..), resolveChain)
+import Cardano.Node.Client.TxDiff.Resolver.Web2 (
+    Web2Config (..),
+    Web2FetchError (..),
+    web2Resolver,
+ )
+
+spec :: Spec
+spec =
+    describe "Web2 (Blockfrost-style) resolver" $ do
+        it "resolves an input by indexing into the fetched tx's outputs" $ do
+            tx <- loadFixture
+            let cbor = fixtureCbor
+                fetcher _ = pure (Right cbor)
+                cfg =
+                    Web2Config
+                        { web2ResolverName = "web2"
+                        , web2Fetch = fetcher
+                        }
+                resolver = web2Resolver cfg
+                txIn = TxIn (mkTxId 0) (TxIx 0)
+            result <- resolveInputs resolver (Set.singleton txIn)
+            case toList (tx ^. bodyTxL . outputsTxBodyL) of
+                [] ->
+                    expectationFailure "fixture transaction has no outputs"
+                expected : _ ->
+                    Map.lookup txIn result
+                        `shouldSatisfy` matchesAddress expected
+
+        it "issues exactly one fetch per distinct TxId when several inputs share it" $ do
+            callCount <- newIORef (0 :: Int)
+            let cbor = fixtureCbor
+                fetcher _ = do
+                    modifyIORef' callCount (+ 1)
+                    pure (Right cbor)
+                cfg =
+                    Web2Config
+                        { web2ResolverName = "web2"
+                        , web2Fetch = fetcher
+                        }
+                resolver = web2Resolver cfg
+                txId = mkTxId 0
+                inputs =
+                    Set.fromList
+                        [ TxIn txId (TxIx 0)
+                        , TxIn txId (TxIx 1)
+                        ]
+            _ <- resolveInputs resolver inputs
+            readIORef callCount `shouldReturn` 1
+
+        it "treats HTTP failures as misses without raising" $ do
+            let fetcher _ =
+                    pure (Left (Web2FetchHttpError "boom"))
+                cfg =
+                    Web2Config
+                        { web2ResolverName = "web2"
+                        , web2Fetch = fetcher
+                        }
+                resolver = web2Resolver cfg
+                inputs = Set.fromList [TxIn (mkTxId 0) (TxIx 0)]
+            (resolved, unresolved) <- resolveChain [resolver] inputs
+            Map.keysSet resolved `shouldBe` Set.empty
+            unresolved
+                `shouldBe` Map.fromList
+                    [(TxIn (mkTxId 0) (TxIx 0), ["web2"])]
+
+        it "treats undecodable CBOR as misses without raising" $ do
+            let fetcher _ =
+                    pure (Right (BS8.pack "not-cbor"))
+                cfg =
+                    Web2Config
+                        { web2ResolverName = "web2"
+                        , web2Fetch = fetcher
+                        }
+                resolver = web2Resolver cfg
+                inputs = Set.fromList [TxIn (mkTxId 0) (TxIx 0)]
+            (resolved, _unresolved) <- resolveChain [resolver] inputs
+            Map.keysSet resolved `shouldBe` Set.empty
+
+        it "skips inputs whose TxIx is past the tx's output range" $ do
+            let cbor = fixtureCbor
+                fetcher _ = pure (Right cbor)
+                cfg =
+                    Web2Config
+                        { web2ResolverName = "web2"
+                        , web2Fetch = fetcher
+                        }
+                resolver = web2Resolver cfg
+                outOfRange = TxIn (mkTxId 0) (TxIx 9999)
+            result <- resolveInputs resolver (Set.singleton outOfRange)
+            Map.lookup outOfRange result `shouldBe` Nothing
+
+matchesAddress ::
+    TxOut ConwayEra -> Maybe (TxOut ConwayEra) -> Bool
+matchesAddress _ Nothing = False
+matchesAddress expected (Just got) =
+    expected ^. addrTxOutL == got ^. addrTxOutL
+
+fixturePath :: FilePath
+fixturePath =
+    "test/fixtures/mainnet-txbuild/"
+        <> "789f9a1393e3c9eacd19582ebb1b02b777696c8ddcedda2d8752cb5723c42ef6"
+        <> ".cbor.hex"
+
+fixtureHexText :: Text
+fixtureHexText =
+    unsafePerformIO (Text.strip . Text.pack <$> readFile fixturePath)
+{-# NOINLINE fixtureHexText #-}
+
+fixtureCbor :: ByteString
+fixtureCbor =
+    case Base16.decode (Text.encodeUtf8 fixtureHexText) of
+        Right raw -> raw
+        Left err -> error ("Web2Spec: fixtureCbor base16 decode failed: " <> err)
+
+loadFixture :: IO ConwayTx
+loadFixture =
+    case decodeFullAnnotatorFromHexText
+        (natVersion @11)
+        "Web2Spec fixture"
+        (decCBOR :: forall s. Decoder s (Annotator ConwayTx))
+        fixtureHexText of
+        Right tx -> pure tx
+        Left err -> fail ("Web2Spec.loadFixture: " <> show err)
+
+mkTxId :: Int -> TxId
+mkTxId n =
+    let hexStr =
+            replicate 60 '0'
+                ++ hexByte (n `div` 256)
+                ++ hexByte (n `mod` 256)
+        h = fromJust (hashFromStringAsHex hexStr)
+     in TxId (unsafeMakeSafeHash h)
+
+hexByte :: Int -> String
+hexByte x =
+    let s = "0123456789abcdef"
+     in [s !! (x `div` 16), s !! (x `mod` 16)]

--- a/test/Cardano/Node/Client/TxDiffSpec.hs
+++ b/test/Cardano/Node/Client/TxDiffSpec.hs
@@ -7,6 +7,7 @@ import Cardano.Node.Client.TxDiff.CliSpec qualified as CliSpec
 import Cardano.Node.Client.TxDiff.ConwaySpec qualified as ConwaySpec
 import Cardano.Node.Client.TxDiff.CoreSpec qualified as CoreSpec
 import Cardano.Node.Client.TxDiff.ResolverSpec qualified as ResolverSpec
+import Cardano.Node.Client.TxDiff.Web2Spec qualified as Web2Spec
 
 spec :: Spec
 spec =
@@ -16,3 +17,4 @@ spec =
         CoreSpec.spec
         ConwaySpec.spec
         ResolverSpec.spec
+        Web2Spec.spec

--- a/test/Cardano/Node/Client/TxDiffSpec.hs
+++ b/test/Cardano/Node/Client/TxDiffSpec.hs
@@ -6,6 +6,7 @@ import Cardano.Node.Client.TxDiff.BlueprintSpec qualified as BlueprintSpec
 import Cardano.Node.Client.TxDiff.CliSpec qualified as CliSpec
 import Cardano.Node.Client.TxDiff.ConwaySpec qualified as ConwaySpec
 import Cardano.Node.Client.TxDiff.CoreSpec qualified as CoreSpec
+import Cardano.Node.Client.TxDiff.ResolverSpec qualified as ResolverSpec
 
 spec :: Spec
 spec =
@@ -14,3 +15,4 @@ spec =
         CliSpec.spec
         CoreSpec.spec
         ConwaySpec.spec
+        ResolverSpec.spec


### PR DESCRIPTION
Closes #150.

Adds opt-in input resolution to `tx-diff`: each input (spending, reference,
collateral) can be paired with the `TxOut` it refers to, so the human
renderer can show address / coin / datum / referenceScript under each
input. Default behavior (no flags) is byte-identical to current main.

## Commits (logical slices)

- **`feat: tx-diff core supports resolved inputs`** — adds
  `txDiffResolvedInputs :: Maybe (Map TxIn (TxOut ConwayEra))` to
  `TxDiffOptions`. When `Just`, the `ConwayTxInValue` projection becomes an
  object with `txIn` and (if resolved) `resolved` children; when `Nothing`,
  the projection stays atomic and existing fixtures render byte-identical.
- **`feat: tx-diff resolver chain`** — introduces
  `Cardano.Node.Client.TxDiff.Resolver` with a `Resolver` record-of-functions
  and `resolveChain :: [Resolver] -> Set TxIn -> IO (Map TxIn (TxOut), Map TxIn [Text])`.
  Each resolver only sees the inputs the earlier ones missed; unresolved
  inputs carry the names of every resolver that was tried.
- **`feat: tx-diff N2C resolver`** — `n2cResolver :: Provider IO -> Resolver`,
  a thin shim over `queryUTxOByTxIn`. Spent inputs are silently absent
  (documented N2C semantics).
- **`feat: tx-diff Blockfrost web2 resolver`** —
  `Cardano.Node.Client.TxDiff.Resolver.Web2`. The HTTP transport is
  pluggable via `Web2FetchTx`, so unit tests inject canned responses
  without standing up a fake HTTP server. Production uses
  `http-client` + `http-client-tls` against
  `GET <base>/txs/<txid>/cbor` and parses Blockfrost's
  `{"cbor": "<hex>"}` envelope. Deduplicates by `TxId` so a repeated
  reference triggers exactly one HTTP call.
- **`feat: tx-diff CLI wires N2C and web2 resolvers`** — new flags:
  `--resolve-n2c PATH --network-magic N`,
  `--resolve-web2 URL [--web2-api-key KEY]`. The N2C resolver is tried
  first; web2 fills the remainder. Unresolved inputs are reported on
  stderr as:
  `tx-diff: input <txId>#<ix> not resolved by [<resolver>, ...]`
- **`docs+nix: tx-diff resolver flags and runtime CA bundle`** —
  `docs/executables/tx-diff.md` describes the flags, the resolver chain
  order, and the privacy / trust implications of web2 download. The
  `tx-diff` derivation in `flake.nix` is wrapped via `makeWrapper` to
  default `SSL_CERT_FILE` to the nix-store cacert bundle so HTTPS works
  inside AppImage/DEB/RPM bundles. The docker image's `copyToRoot`
  picks up `pkgs.cacert` too.

## Tests

`cardano-node-clients:unit-tests` now ships 324 examples (was 303).
New coverage:

- `ConwaySpec`: resolved inputs render under `body.inputs.<i>.resolved`;
  resolution-enabled-but-empty maps render as `body.inputs.<i>.txIn`
  only.
- `ResolverSpec`: empty chain, single-resolver miss accounting,
  two-resolver chain that observes the request set per resolver via
  `IORef`, short-circuit when nothing remains, N2C delegation through
  a stub `Provider`.
- `Web2Spec`: happy path against the existing mainnet fixture,
  deduplication of repeated `TxId`s, HTTP-error handling, undecodable
  CBOR handling, out-of-range `TxIx` handling.
- `CliSpec`: parsing for all four new flags, mutual-requirement
  validation (`--resolve-n2c` ↔ `--network-magic`,
  `--web2-api-key` ⊂ `--resolve-web2`), non-numeric `--network-magic`.

`nix develop --quiet -c just ci` is green locally on this branch.

## Spec, plan, tasks

- [spec.md](https://github.com/lambdasistemi/cardano-node-clients/blob/150-tx-diff-input-resolution/specs/150-tx-diff-input-resolution/spec.md)
- [plan.md](https://github.com/lambdasistemi/cardano-node-clients/blob/150-tx-diff-input-resolution/specs/150-tx-diff-input-resolution/plan.md)
- [tasks.md](https://github.com/lambdasistemi/cardano-node-clients/blob/150-tx-diff-input-resolution/specs/150-tx-diff-input-resolution/tasks.md)

## Out of scope (per spec)

- Submission / chain mutation.
- Alternative web2 providers whose API does not match the Blockfrost CBOR
  contract.
- Cross-run caching.
- Live boundary smoke tests: N2C requires a running node and web2 requires
  a real Blockfrost endpoint; both stay as operator follow-up.