### PR TITLE
fix(txbuild): self-validate Conway bodies against ledger Phase-1 (#153)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # cardano-node-clients-tx-builder Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-05-12
+Auto-generated from all feature plans. Last updated: 2026-05-15
 
 ## Active Technologies
 - Haskell, GHC 9.6+ (matches repo). (034-cardano-tx-generator)
@@ -11,6 +11,7 @@ Auto-generated from all feature plans. Last updated: 2026-05-12
 - N/A — pure tx assembly; no persistence change. (040-txbuild-conway-collateral)
 - Haskell, GHC pinned by `cabal.project` (current + `cardano-ledger-conway`, `cardano-ledger-api`, (042-conway-stake-treasury)
 - N/A. DSL is pure; produces a `ConwayTx` for submission. (042-conway-stake-treasury)
+- N/A. TxBuild is a pure assembly layer. (153-txbuild-integrity-hash)
 
 - Haskell (GHC 9.6+, same as cardano-node-clients) + cardano-ledger-api, cardano-ledger-conway, plutus-ledger-api, plutus-tx (ToData/FromData) (003-tx-builder-dsl)
 
@@ -30,9 +31,9 @@ tests/
 Haskell (GHC 9.6+, same as cardano-node-clients): Follow standard conventions
 
 ## Recent Changes
+- 153-txbuild-integrity-hash: Added Haskell, GHC 9.12.2 (matches existing
 - 042-conway-stake-treasury: Added Haskell, GHC pinned by `cabal.project` (current + `cardano-ledger-conway`, `cardano-ledger-api`,
 - 040-txbuild-conway-collateral: Added Haskell, GHC 9.12.2 (matches existing flake-pinned toolchain). + `cardano-ledger-conway` (1.21), `cardano-ledger-babbage` (1.13, supplies `totalCollateralTxBodyL` / `collateralReturnTxBodyL`), `cardano-ledger-alonzo` (supplies `ppCollateralPercentageL`), `cardano-ledger-api` (`estimateMinFeeTx`). All are already in the closure.
-- 037-tx-gen-indexer-fresh: Added Haskell, GHC 9.6+ (matches repo) + `cardano-ledger-conway`, `ouroboros-network`, internal `chain-follower` `Follower` abstraction, internal `N2C.Reconnect.runReconnectLoop` (PR #105)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/153-txbuild-integrity-hash/checklists/requirements.md
+++ b/specs/153-txbuild-integrity-hash/checklists/requirements.md
@@ -1,0 +1,45 @@
+# Specification Quality Checklist: TxBuild self-validates against ledger Phase-1
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Constitutional alignment: regression test runs against a real
+  ledger (cardano-ledger-api `applyTx`), not a mock — consistent
+  with project Principle II "Devnet E2E Testing" / no-mocks rule.
+- The spec deliberately references some ledger-side concepts
+  (CBOR keys `0b` / `5`, Plutus language versions, witness-set
+  datums map) because the bug is defined by them; this is not
+  implementation leakage — it is the contract the produced tx
+  body must satisfy with the ledger.
+- One named ledger function appears (`applyTx` from
+  `cardano-ledger-api`); kept because it pins down what
+  "Phase-1 validation" means for the regression test and is
+  unambiguous.

--- a/specs/153-txbuild-integrity-hash/contracts/txbuild-self-validation.md
+++ b/specs/153-txbuild-integrity-hash/contracts/txbuild-self-validation.md
@@ -1,0 +1,121 @@
+# Contract: TxBuild self-validation against ledger Phase-1
+
+**Branch**: `153-txbuild-integrity-hash` | **Date**: 2026-05-15
+
+The contract this PR commits to between TxBuild and any
+caller (test or library or downstream tool).
+
+---
+
+## C-1 Return-type contract
+
+`build` (and any equivalent public entry point) MUST
+return either:
+
+- `Right (Tx ConwayEra)` — a body that satisfies
+  `applyTx pp utxo slot tx == Right _` where `pp` is the
+  `PParams` value provided to the build call and `utxo`
+  is the UTxO TxBuild used to assemble the body;
+- or `Left (Check e)` — a check failure, where
+  `LedgerFail (Phase1Rejected err)` carries the ledger's
+  `ApplyTxError` verbatim.
+
+There is no third case. A `Right body` whose
+`script_integrity_hash` does not match the ledger's
+computation is a contract violation and a release
+blocker.
+
+---
+
+## C-2 PParams-identity contract
+
+For a single `build` call:
+
+- the `PParams` value used by the fee estimator,
+- the `PParams` value used by the exec-units estimator,
+- the `PParams` value used by
+  `computeScriptIntegrity`,
+- the `PParams` value used by the self-validation
+  `applyTx` call,
+
+MUST be `==`-equal. The design enforces this
+structurally (one argument, optionally wrapped in
+`PParamsBound`, per R-004).
+
+---
+
+## C-3 Integrity-hash contract
+
+For any `Tx ConwayEra` returned by `build`:
+
+- `body ^. scriptIntegrityHashTxBodyL == SNothing`
+  if and only if the body has no redeemers and no
+  witness-set datums.
+- Otherwise, `body ^. scriptIntegrityHashTxBodyL ==
+  SJust h` where `h` is computed over:
+  - the redeemers exactly as serialized in the witness
+    set (Conway map form, witness-set key `5`);
+  - the set of language views for languages
+    *referenced by the body's redeemers and
+    reference-script inputs* (no language view for any
+    language not so referenced);
+  - the witness-set datums map (`TxDats` value, may
+    be empty for inline-only datum txs);
+  - keyed off the same `PParams` as C-2.
+
+---
+
+## C-4 Negative-build contract
+
+If the caller's plan results in a body that fails
+Phase-1, `build` returns:
+
+```haskell
+Left (LedgerFail (Phase1Rejected err))
+```
+
+where `err :: ApplyTxError ConwayEra` is the
+unmodified value the ledger produced. TxBuild does
+NOT pretty-print, classify, or otherwise mangle the
+error before returning it — callers may pattern-match
+on `err` for their own UX.
+
+---
+
+## C-5 Reproduction-fixture contract
+
+The mainnet `swap-cancel` reproduction
+(tx `84b2bb78f7f5dd2beb2830e8e6e88fd853a8f70ea73b161f0a0327de8c70146f`)
+replayed offline through `build` against a captured
+mainnet `PParams` snapshot MUST yield:
+
+- `Right body`,
+- with `body ^. scriptIntegrityHashTxBodyL`
+  `== SJust 41a7cd5798b8b6f081bfaee0f5f88dc02eea894b7ed888b2a8658b3784dcdcf9`,
+- and `applyTx pp utxo slot body == Right _`.
+
+The test asserting this lives in `test/` and runs
+under `just ci`.
+
+---
+
+## C-6 Downstream contract: no duplicate Phase-1 gates
+
+After this PR lands, callers of `build` SHOULD NOT
+add a second Phase-1 validation pass on the returned
+body. The companion `amaru-treasury-tx` ticket
+proposing such a gate is closed as superseded.
+
+This is "SHOULD NOT" rather than "MUST NOT" because
+nothing prevents a caller from re-running `applyTx`
+on the returned body — it is simply redundant.
+
+---
+
+## C-7 Stability contract
+
+C-1..C-5 are stable invariants of the `build` public
+API. Any future change that weakens them — for
+example, adding a "skip self-validation for
+performance" flag — is a breaking change and requires
+its own spec/PR.

--- a/specs/153-txbuild-integrity-hash/data-model.md
+++ b/specs/153-txbuild-integrity-hash/data-model.md
@@ -1,0 +1,161 @@
+# Data Model: TxBuild self-validates against ledger Phase-1
+
+**Branch**: `153-txbuild-integrity-hash` | **Date**: 2026-05-15
+
+TxBuild is a pure assembly layer; there is no persisted
+state to model. The "data model" for this feature is the
+small set of types we introduce or extend so that the
+invariants in [spec.md](./spec.md) can be enforced
+structurally.
+
+---
+
+## E-1 `PParamsBound era` (NEW, internal-only)
+
+**Shape** (provisional, settled by R-004):
+
+```haskell
+newtype PParamsBound era = PParamsBound
+  { unPParamsBound :: PParams era }
+```
+
+**Construction**: smart constructor exposed only at the
+build entrypoint (e.g. `runBuild :: PParams era -> … ->
+m (Either (Check e) (Tx era))`). Once inside the
+build, only the `PParamsBound` value is passed around.
+
+**Invariant**: every internal helper that depends on
+protocol parameters (fee estimation, exec-units
+estimation, integrity-hash computation, self-validation)
+accepts `PParamsBound era`, not raw `PParams era`. This
+enforces FR-002 at the type level.
+
+**Why a newtype, not a Reader monad**: TxBuild's
+monad is already an operational `TxBuild` interpreted
+by `draft`/`build`/`InterpretIO`; adding a reader
+layer is intrusive. A newtype is cheap, local, and
+gives the same "one source of truth" guarantee.
+
+**Status**: contingent on R-004 — if the audit shows
+`PParams` is already threaded as one argument, the
+newtype may be skipped in favor of a comment + a
+property-style audit test. Either path satisfies the
+spec.
+
+---
+
+## E-2 `LedgerCheck` (EXTEND)
+
+**Today** (`TxBuild.hs:305`):
+
+```haskell
+data LedgerCheck
+  = MinUtxoViolation Word32 Coin Coin
+  | TxSizeExceeded Natural Natural
+  | ValueNotConserved MaryValue MaryValue
+  | CollateralInsufficient Coin Coin
+```
+
+**After**:
+
+```haskell
+data LedgerCheck era
+  = MinUtxoViolation Word32 Coin Coin
+  | TxSizeExceeded Natural Natural
+  | ValueNotConserved MaryValue MaryValue
+  | CollateralInsufficient Coin Coin
+  | Phase1Rejected (ApplyTxError era)
+```
+
+`Check e` (`TxBuild.hs:295`) gains the same `era`
+parameter where needed.
+
+**Migration**: every constructor of the existing
+enum stays — we add `Phase1Rejected`, we do not
+delete anything in this PR. Some existing
+constructors may be subsumed by `Phase1Rejected`
+on a future cleanup; that follow-up is out of scope
+(per `feedback_destructive_api_mutations`).
+
+---
+
+## E-3 Language-set derivation (helper, internal)
+
+**Shape** (provisional, settled by R-003):
+
+```haskell
+languagesUsedInBody
+  :: TxBody ConwayEra
+  -> UTxO ConwayEra
+  -> Set Language
+```
+
+**Behavior**: walks (a) the body's spending redeemers and
+their resolved scripts, (b) any reference-script inputs
+that supply a Plutus script, and returns the set of
+`Language` values actually used. Native (timelock) scripts
+do not contribute.
+
+**Usage**: feeds `computeScriptIntegrity` instead of the
+current single-`Language` argument. Tying the language
+set to the body — not to caller intent — is the FR-001
+fix.
+
+---
+
+## E-4 `computeScriptIntegrity` (CHANGE signature)
+
+**Today** (`Scripts.hs:84`):
+
+```haskell
+computeScriptIntegrity
+  :: Language
+  -> PParams ConwayEra
+  -> Redeemers ConwayEra
+  -> StrictMaybe ScriptIntegrityHash
+```
+
+**After**:
+
+```haskell
+computeScriptIntegrity
+  :: Set Language
+  -> PParamsBound ConwayEra            -- or PParams ConwayEra, per R-004
+  -> Redeemers ConwayEra
+  -> TxDats ConwayEra                  -- witness-set datums
+  -> StrictMaybe ScriptIntegrityHash
+```
+
+The witness-set datums argument replaces the hard-coded
+`TxDats mempty`; even though the issue-#153 tx has no
+datums, hard-coding `mempty` is the same caller-trust
+footgun as hard-coding the language.
+
+---
+
+## E-5 No persistent entities
+
+The remaining "entities" listed in the spec — script
+integrity hash, language view, Conway redeemers,
+`PParams` instance, Phase-1 validation — are all
+ledger-defined types. We import, we don't redefine.
+
+---
+
+## Cross-cutting invariants
+
+(These are the same as the spec's FRs; restated here as
+data-model contracts.)
+
+- *Single `PParams` instance.* For a given build call,
+  exactly one `PParams era` value flows in through the
+  smart constructor; every internal type that
+  references protocol parameters is parameterized over
+  the same value.
+- *Body-derived language set.* The language set used in
+  the integrity-hash computation is derived from the
+  body, not provided by the caller.
+- *Phase-1 result decides return type.* The build call
+  returns `Right (Tx era)` iff
+  `applyTx pp utxo slot tx == Right _`; otherwise it
+  returns `Left (LedgerFail (Phase1Rejected err))`.

--- a/specs/153-txbuild-integrity-hash/plan.md
+++ b/specs/153-txbuild-integrity-hash/plan.md
@@ -1,0 +1,318 @@
+# Implementation Plan: TxBuild self-validates against ledger Phase-1
+
+**Branch**: `153-txbuild-integrity-hash` | **Date**: 2026-05-15 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/153-txbuild-integrity-hash/spec.md`
+
+## Summary
+
+Make the ledger's Phase-1 application function (`applyTx` /
+`Cardano.Ledger.Api.Tx.applyTx`-equivalent from
+`cardano-ledger-api`) a mandatory step inside TxBuild's
+build/finalize path. The same `PParams` value drives fee
+estimation, exec-units, integrity-hash computation, and the
+self-validation step — threaded structurally as a single
+argument, never re-fetched. The existing
+`script_integrity_hash` divergence is fixed as one instance
+the new gate catches.
+
+Bug-level technical approach for the integrity hash itself:
+
+- `computeScriptIntegrity` currently takes a single
+  `Language` and a `Redeemers ConwayEra` and folds in one
+  `LangDepView`. The Conway witness set serializes
+  redeemers as a map; verify `hashScriptIntegrity` from
+  `Cardano.Ledger.Alonzo.Tx` follows the body's CBOR
+  serialization (Conway map form, witness-set key `5`).
+  If it does not, switch to the Conway-era
+  `hashScriptIntegrity` (or equivalent) from
+  `Cardano.Ledger.Conway`/`Cardano.Ledger.Api`.
+- Replace the single-`Language` argument with the
+  *set* of languages actually referenced by redeemers
+  in the body, derived from the body itself — never
+  from caller convention.
+
+## Technical Context
+
+**Language/Version**: Haskell, GHC 9.12.2 (matches existing
+flake-pinned toolchain).
+**Primary Dependencies**:
+- `cardano-ledger-conway` (1.21) — already in closure.
+- `cardano-ledger-alonzo` — `hashScriptIntegrity`,
+  `ScriptIntegrity`, `LangDepView`, `getLanguageView`.
+- `cardano-ledger-api` — `applyTx` (or equivalent
+  Phase-1 functional path) for self-validation.
+- `cardano-ledger-core` — `PParams`, `ApplyTxError`.
+- All already pulled in by `lib-tx-build`'s cabal file;
+  no new `source-repository-package` entries expected.
+**Storage**: N/A. TxBuild is a pure assembly layer.
+**Testing**: `hspec` + `tasty`-style golden, as in the rest
+of the suite. New tests live in
+`test/Cardano/Node/Client/TxBuildSpec.hs` (the property/
+golden home for tx-builder tests) and a new fixture-driven
+spec in `test/Cardano/Node/Client/Scripts*Spec.hs` if the
+existing files don't fit.
+**Target Platform**: Linux x86_64 (same as repo CI).
+**Project Type**: Haskell library (`lib-tx-build`).
+**Performance Goals**: One additional `applyTx` call per
+TxBuild build (a few ms against an in-memory UTxO). Not a
+hot path; well within `just ci` budget.
+**Constraints**:
+- Same `PParams` instance threaded through the whole build
+  call. Structural, not by convention — single argument.
+- Self-validation runs against the UTxO TxBuild already has
+  in scope; no new network query.
+- Failure must surface the ledger's `ApplyTxError` faithfully
+  to the caller.
+**Scale/Scope**: Roughly two modules touched
+(`TxBuild.hs`, `Scripts.hs`), one or two new test specs,
+plus golden fixtures for the mainnet reproduction.
+
+## Constitution Check
+
+Pulled from
+`/code/cardano-node-clients-issue-153/.specify/memory/constitution.md`.
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Channel-Driven N2C Clients | N/A | This is the pure tx-build layer; no Ouroboros channels involved. |
+| II. Devnet E2E Testing | PASS | The mainnet-reproduction test is a fixture-driven check using a captured `PParams` snapshot + a captured `UTxO`. The negative test (FR-007) is also fixture-driven. No mocks for the ledger — we call the real ledger functional API. An E2E spec under `test/Cardano/Node/Client/E2E/TxBuildSpec.hs` can also exercise self-validation end-to-end against `withCardanoNode` if desired (stretch, not required by spec). |
+| III. Minimal Dependencies | PASS | All deps already in closure. Adds no application-specific types. |
+| IV. Test Utilities Are First-Class | PASS | Reusable helper (e.g. `applyTxBody :: PParams -> UTxO -> Slot -> Tx -> Either ApplyTxError ()`) lands in `lib-tx-build` so downstream tests can use the same gate to assert tx-bodies they construct elsewhere are also Phase-1-valid. |
+| Quality Gates: `just ci` passes | PASS | New tests must run under `just ci`; no new external setup. |
+| Quality Gates: real devnet for E2E | PASS | Untouched. |
+| Quality Gates: no mocks for node | PASS | Untouched. |
+| Workflow: Nix-first, Fourmolu, rebase | PASS | Standard. |
+
+No violations; Complexity Tracking section is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/153-txbuild-integrity-hash/
+├── plan.md                       # This file
+├── spec.md
+├── checklists/
+│   └── requirements.md
+├── research.md                   # Phase 0 output
+├── data-model.md                 # Phase 1 output
+├── quickstart.md                 # Phase 1 output
+├── contracts/                    # Phase 1 output
+│   └── txbuild-self-validation.md
+└── tasks.md                      # /speckit.tasks output
+```
+
+### Source Code (repository root)
+
+```text
+lib-tx-build/Cardano/Node/Client/
+├── TxBuild.hs        # Build/finalize path; integrate Phase-1 self-validation
+│                     # at the return point. Thread the single PParams arg.
+├── Scripts.hs        # Fix `computeScriptIntegrity`: accept Set Language
+│                     # derived from the body, use the Conway-era
+│                     # hashScriptIntegrity if needed.
+├── Balance.hs        # PParams already lives here for fee estimation;
+│                     # confirm it's the same value passed to the new
+│                     # self-validation step.
+├── Inputs.hs / Witnesses.hs / Deposits.hs / Credentials.hs / Ledger.hs
+│                     # Likely untouched; check that no PParams source
+│                     # is re-fetched here.
+
+test/Cardano/Node/Client/
+├── TxBuildSpec.hs           # Add golden tests for self-validation
+│                            # (positive + negative + mainnet repro).
+├── TxBuildGoldenSpec.hs     # Possibly: add the mainnet swap-cancel
+│                            # vector if it fits the golden style.
+├── ScriptsSpec.hs           # NEW (if needed): focused integrity-hash
+│                            # tests over Conway redeemers + mixed langs.
+test/fixtures/
+├── pparams.json             # Mainnet PParams snapshot for the
+│                            # swap-cancel reproduction
+│                            # (NOTE: a 707-line `pparams.json` is
+│                            # already staged in the main repo from a
+│                            # prior session — confirm with user before
+│                            # picking up vs starting fresh).
+└── mainnet-txbuild/
+    └── swap-cancel-issue-153/  # NEW fixture dir for the reproduction
+        ├── utxo.json
+        ├── plan.json or .hs    # The exact TxBuild plan
+        └── expected-body.cbor.hex
+```
+
+**Structure Decision**: stay within the existing
+`lib-tx-build` Haskell library layout. No new module
+directories. Self-validation is exposed as a small public
+helper (so consumers can use it too if they ever construct
+bodies by hand), but the build/finalize path calls it
+unconditionally.
+
+## Phase 0: Outline & Research
+
+Open questions to resolve before writing code. Each one
+gets a Decision / Rationale / Alternatives entry in
+`research.md`.
+
+1. **Ledger Phase-1 API choice.** Which exact function
+   from `cardano-ledger-api` (or `cardano-ledger-conway`)
+   represents "Phase-1 validation that includes
+   `script_integrity_hash` check but excludes Plutus script
+   execution"? Candidates:
+   - `Cardano.Ledger.Api.Tx.applyTx` — full transition
+     (Phase-1 + Phase-2 trigger).
+   - A reapplication function that skips script execution.
+   - A `Cardano.Ledger.Shelley.Rules.UTXOW`-style rule
+     applied directly.
+   The pick must (a) include script-integrity-hash check
+   and (b) be cheap enough for every build.
+
+2. **Conway redeemers form.** Does
+   `Cardano.Ledger.Alonzo.Tx.hashScriptIntegrity` already
+   serialize redeemers as the Conway map (witness-set key
+   `5`)? If not, identify the Conway-era replacement.
+   Empirically: hash the issue-#153 fixture with current
+   code, compare to the ledger's expected
+   `41a7cd57…dcf9`.
+
+3. **`PParams` single-instance threading.** Audit
+   `TxBuild.hs` and `Balance.hs`: is `PParams` already a
+   single argument passed straight through, or is it
+   re-fetched / mutated at any point in
+   `draft`/`build`/`finalize`? Document the actual flow
+   in research, then decide whether a refactor is
+   required to satisfy FR-002 ("structurally
+   impossible to mis-source"). The cheapest fix may be
+   to add a newtype wrapper that can only be constructed
+   at the build entrypoint.
+
+4. **Self-validation UTxO source.** What UTxO is in scope
+   at the build/finalize point? The same `UTxO` the
+   balancer used to assemble inputs and collateral.
+   Confirm we can hand it to `applyTx` without
+   re-querying.
+
+5. **Test pparams snapshot.** Reuse the staged
+   `test/fixtures/pparams.json` already present in
+   `/code/cardano-node-clients` (main repo), or take a
+   fresh snapshot scoped to the issue-#153 reproduction?
+   Flag for user decision in Phase 0 output; do not
+   silently absorb the staged file (per
+   `feedback_investigate_bugs` / `feedback_semantic_changes`).
+
+**Output**: `research.md` with answers, links to
+ledger-api Haddock pages, and a short note on each
+alternative considered.
+
+## Phase 1: Design & Contracts
+
+**Prerequisites**: `research.md` complete.
+
+### Data model
+
+`data-model.md` will describe two small additions:
+
+- `PParamsBound era` (newtype or smart constructor)
+  — wraps `PParams era` so that all four consumers
+  inside TxBuild (fees / exunits / integrity-hash /
+  self-validation) take the wrapped value, and the
+  wrapper can only be built at the build entrypoint.
+  Implements FR-002 structurally.
+- Extend (or replace) `LedgerCheck` so that
+  `Phase1Rejected ApplyTxError` is a constructor.
+  The existing closed enum
+  (`MinUtxoViolation`, `TxSizeExceeded`,
+  `ValueNotConserved`, `CollateralInsufficient`)
+  becomes a subset of what Phase-1 catches; some of
+  those may be subsumed by `applyTx` and can be
+  retired in a follow-up (NOT in this PR — scope
+  discipline).
+
+### Contracts
+
+`contracts/txbuild-self-validation.md` will spell out the
+new TxBuild invariants:
+
+- *Pre-return contract:* on every successful build call,
+  the body returned has passed
+  `applyTx pparams utxo slot tx == Right _`, where
+  `pparams` is the same value provided to the build
+  call.
+- *Failure contract:* a body that fails Phase-1 is never
+  returned; instead the caller receives the
+  `ApplyTxError` from the ledger, wrapped in
+  `LedgerFail (Phase1Rejected …)`.
+- *Hash contract:* for any tx with redeemers,
+  `script_integrity_hash` is computed from (a) the
+  redeemers exactly as they appear in the witness set
+  in Conway map form, (b) the set of language views for
+  the Plutus versions actually referenced by those
+  redeemers (derived from the body, not from caller),
+  (c) the witness-set datums map (empty when only inline
+  datums are used), all keyed off the same
+  `PParamsBound`.
+
+### Quickstart
+
+`quickstart.md` will show the minimal caller usage:
+
+```haskell
+-- before this PR
+body <- build cfg plan        -- may silently produce invalid body
+
+-- after this PR
+result <- build cfg plan
+case result of
+  Right body            -> submit body
+  Left (LedgerFail e)   -> reportPhase1 e
+  Left (CustomFail e)   -> reportUser e
+```
+
+And the negative-test recipe (deliberately invalid plan
+→ assert `Left (LedgerFail (Phase1Rejected _))`).
+
+### Agent context update
+
+Run `./.specify/scripts/bash/update-agent-context.sh
+--agent claude` after Phase 1 so `CLAUDE.md` picks up
+the new feature row (153-txbuild-integrity-hash).
+
+**Outputs**: `data-model.md`, `contracts/txbuild-self-validation.md`,
+`quickstart.md`, `CLAUDE.md` updated.
+
+## Phase 2: Tasks (preview — generated by /speckit.tasks)
+
+Sketch only, not a substitute for `tasks.md`:
+
+1. (RED) Add the mainnet-#153 reproduction fixture under
+   `test/fixtures/mainnet-txbuild/swap-cancel-issue-153/`
+   + a failing golden in `TxBuildSpec.hs` asserting
+   computed `script_integrity_hash` ==
+   `41a7cd57…dcf9`. Watch it fail.
+2. (RED) Add a negative-build property test (e.g.
+   artificially zero the fee) asserting the build
+   returns `Left (LedgerFail (Phase1Rejected _))`.
+   Watch it fail because no self-validation step
+   exists yet.
+3. (GREEN, hash) Fix `Scripts.computeScriptIntegrity`
+   per Phase 0 finding (Conway-form redeemers, Set of
+   languages derived from body). Make test 1 pass.
+4. (GREEN, validation) Add the `applyTx` self-validation
+   step to TxBuild's finalize path; thread `PParamsBound`
+   structurally. Make test 2 pass.
+5. (REFACTOR) Adjust callers of `computeScriptIntegrity`
+   inside `TxBuild.hs` to feed the body-derived language
+   set (three call sites).
+6. (POLISH) Update `lib-tx-build` Haddock and module
+   header for `Scripts.hs` to describe the new contract.
+   Update `quickstart.md`.
+7. (DOWNSTREAM) On a separate branch in
+   `lambdasistemi/amaru-treasury-tx`, remove any
+   post-build Phase-1 gate (or close the companion ticket
+   if it never landed) — referenced by the PR body, but
+   *not* a code change in this PR.
+8. Final `just ci`; squash-fix where needed for vertical
+   commits.
+
+## Complexity Tracking
+
+No constitution violations; section intentionally empty.

--- a/specs/153-txbuild-integrity-hash/quickstart.md
+++ b/specs/153-txbuild-integrity-hash/quickstart.md
@@ -1,0 +1,123 @@
+# Quickstart: TxBuild self-validation
+
+**Branch**: `153-txbuild-integrity-hash` | **Date**: 2026-05-15
+
+How callers and test authors use the new TxBuild
+contract after this PR lands.
+
+---
+
+## 1. Building a transaction (caller view)
+
+Today (pre-fix):
+
+```haskell
+body <- build cfg plan
+-- body may silently be Phase-1-invalid; we found out
+-- only when the ledger rejected it on submission.
+submit body
+```
+
+After this PR:
+
+```haskell
+result <- build cfg plan
+case result of
+  Right body            -> submit body            -- guaranteed Phase-1-valid
+  Left (LedgerFail e)   -> reportPhase1 e         -- carries ledger's ApplyTxError
+  Left (CustomFail e)   -> reportUser e
+```
+
+Where `reportPhase1`'s payload includes
+`Phase1Rejected (ApplyTxError ConwayEra)` for the
+new self-validation failure path. Existing
+`LedgerFail` constructors
+(`MinUtxoViolation`, `TxSizeExceeded`, …) continue
+to be returned as before.
+
+---
+
+## 2. Reproducing the issue-#153 mainnet bug
+
+Once the fixture lands in
+`test/fixtures/mainnet-txbuild/swap-cancel-issue-153/`:
+
+```haskell
+-- in TxBuildSpec.hs (or a sibling file)
+it "swap-cancel: computes the ledger's integrity hash" $ do
+  pp   <- loadPParams "test/fixtures/pparams.json"
+  utxo <- loadUtxo   "test/fixtures/mainnet-txbuild/swap-cancel-issue-153/utxo.json"
+  plan <- loadPlan   "test/fixtures/mainnet-txbuild/swap-cancel-issue-153/plan.hs"
+  Right body <- runBuild pp utxo plan
+  body ^. scriptIntegrityHashTxBodyL
+    `shouldBe` SJust expectedHash
+  where
+    expectedHash =
+      ScriptIntegrityHash
+        "41a7cd5798b8b6f081bfaee0f5f88dc02eea894b7ed888b2a8658b3784dcdcf9"
+```
+
+The same fixture also drives the Phase-1 assertion:
+
+```haskell
+it "swap-cancel: passes ledger Phase-1" $ do
+  pp   <- loadPParams "test/fixtures/pparams.json"
+  utxo <- loadUtxo   "test/fixtures/mainnet-txbuild/swap-cancel-issue-153/utxo.json"
+  plan <- loadPlan   "test/fixtures/mainnet-txbuild/swap-cancel-issue-153/plan.hs"
+  result <- runBuild pp utxo plan
+  result `shouldSatisfy` isRight
+  -- (implicitly: runBuild already ran applyTx and only
+  -- returns Right after Phase-1 acceptance.)
+```
+
+---
+
+## 3. Negative-build test recipe
+
+To verify FR-007 (deliberately invalid plan ⇒ error,
+not body):
+
+```haskell
+it "rejects a body the ledger would refuse" $ do
+  pp   <- loadPParams "test/fixtures/pparams.json"
+  utxo <- loadUtxo   "test/fixtures/mainnet-txbuild/swap-cancel-issue-153/utxo.json"
+  -- Force a Phase-1 failure: pin the fee to zero
+  -- (or use an artificial PParams with prohibitive
+  -- maxTxSize). The exact knob falls out of R-001.
+  result <- runBuild pp utxo (forceInvalid plan)
+  result `shouldBe` Left (LedgerFail (Phase1Rejected someErr))
+```
+
+The body is never returned in this case.
+
+---
+
+## 4. What changes for downstream tools
+
+Tools that today call `build` and then re-run their
+own Phase-1 gate (`amaru-treasury-tx`'s companion
+ticket, any future consumer) can simply drop that
+gate. The build result is already validated.
+
+A grep recipe to verify there are no stale gates:
+
+```bash
+# Run against amaru-treasury-tx and any other consumer
+git grep -nE 'applyTx|reapplyTx|Phase1' -- '*.hs'
+```
+
+The expected result is "no post-build invocations of
+ledger validation on the TxBuild output".
+
+---
+
+## 5. Running it
+
+Standard:
+
+```bash
+nix develop --quiet -c just ci
+```
+
+The new test cases run under the existing `lib-tx-build`
+test suite and require no new external setup.

--- a/specs/153-txbuild-integrity-hash/research.md
+++ b/specs/153-txbuild-integrity-hash/research.md
@@ -1,0 +1,202 @@
+# Research: TxBuild self-validates against ledger Phase-1
+
+**Branch**: `153-txbuild-integrity-hash` | **Date**: 2026-05-15
+**Plan**: [plan.md](./plan.md)
+
+This file captures the open design questions that Phase 0
+must resolve before implementation starts. Each entry is
+Decision / Rationale / Alternatives, with the current
+status (RESOLVED or OPEN). Anything OPEN must be closed
+before the corresponding GREEN task in `tasks.md`.
+
+---
+
+## R-001: Which ledger function exposes Phase-1 validation?
+
+**Status**: OPEN
+
+**Question**: What is the right
+`cardano-ledger-api`/`cardano-ledger-conway` entry point
+for "Phase-1 validation only" — i.e. it must (a) include
+the `script_integrity_hash` check, (b) include
+fee/min-utxo/collateral checks, (c) not execute Plutus
+scripts (Phase-2)?
+
+**Candidates**:
+- `Cardano.Ledger.Api.Tx.applyTx`
+  — likely the full transition; pricey when scripts run.
+- `Cardano.Ledger.Api.Tx.reapplyTx`
+  — re-applies an already-validated tx; may skip
+  Phase-1 in some shapes. Probably wrong.
+- `Cardano.Ledger.Shelley.Rules.UTXOW`
+  applied directly via `applyRuleByName` /
+  `runRule` — gives the precise Phase-1 step but
+  is lower-level.
+
+**Acceptance**: chosen function, called from a test
+fixture, returns `Left _` for the pre-fix
+swap-cancel body and `Right _` for the post-fix
+body. We measure roundtrip cost on a typical Conway
+tx (target < 5 ms; if > 20 ms we re-evaluate).
+
+**Alternatives considered**: writing a bespoke
+Phase-1 reimplementation in `lib-tx-build`. Rejected
+on FR-002 / constitution III grounds — we must not
+ship a parallel ledger.
+
+---
+
+## R-002: Does `hashScriptIntegrity` already use Conway redeemer encoding?
+
+**Status**: OPEN
+
+**Question**: Conway witness-set redeemers are encoded
+as a CBOR map (witness-set key `5`). The current
+`lib-tx-build/.../Scripts.hs:84` uses
+`Cardano.Ledger.Alonzo.Tx.hashScriptIntegrity`. Does
+this function serialize redeemers consistently with
+the Conway body's witness set, or does it still use
+the pre-Conway array form?
+
+**How we'll answer**: run `computeScriptIntegrity`
+over the swap-cancel fixture's redeemers + cost-model
+view at the pre-fix code, and compare the hash to
+both (a) the body's value
+(`03e9d7edc4e9b65b14a6076b19c7f13810292687b0c51b14c038ee4849f81941`)
+and (b) the ledger's expected value
+(`41a7cd5798b8b6f081bfaee0f5f88dc02eea894b7ed888b2a8658b3784dcdcf9`).
+- If the current code reproduces the *body*'s wrong
+  hash, the bug is in `hashScriptIntegrity`'s redeemer
+  encoding for Conway → switch to Conway-era hash.
+- If the current code reproduces neither, the bug is
+  somewhere else (likely cost-model scope, R-003).
+
+**Acceptance**: a passing assertion that the hash for
+the issue-#153 fixture equals
+`41a7cd57…dcf9`.
+
+---
+
+## R-003: Cost-models scope — single language or set?
+
+**Status**: PARTIALLY OPEN
+
+**Question**: The current
+`computeScriptIntegrity :: Language -> PParams -> Redeemers -> …`
+takes a single `Language` and folds in one
+`LangDepView`. The ledger hashes the *set* of languages
+referenced by redeemers in the body. If a tx uses only
+PlutusV3 the existing API may or may not be correct in
+practice — but it is fragile: the caller's chosen
+`Language` is the source of truth, not the body.
+
+**Decision (provisional)**: switch the API to derive
+the language set from the body (specifically, the set
+of script hashes resolved at each redeemer site and
+each reference-script input). Caller can no longer
+pass the wrong value.
+
+**Rationale**: aligns with FR-001 "derived from the
+body, not from caller convention" and removes a
+recurring footgun.
+
+**Alternatives considered**:
+- Keep single `Language`, audit all three call sites.
+  Rejected: same bug class will recur on the next
+  mixed-language transaction.
+- Derive from the resolved UTxO. Equivalent; either
+  source yields the same answer for a well-formed
+  body.
+
+---
+
+## R-004: `PParams` threading — does it need a newtype?
+
+**Status**: OPEN
+
+**Question**: Today, is `PParams ConwayEra` passed as
+a regular argument through `draft` / `build` /
+`finalize`? Or is it ever (a) re-fetched from a query
+mid-build, (b) implicitly carried in a context that
+could be replaced, (c) provided separately to the
+balancer and to `computeScriptIntegrity`?
+
+**How we'll answer**: read `TxBuild.hs` lines 1042,
+1066, 1288, 1296, 1774, 1782 (the three integrity-hash
+sites) plus `Balance.hs` 444, 569 (fee estimation),
+and trace the `PParams` value back to the build entry
+point. Note any divergence.
+
+**Decision shape**:
+- If `PParams` is already a single argument threaded
+  through, no newtype is strictly required — a
+  comment + an audit-style test suffices.
+- If `PParams` is re-fetched or split, introduce a
+  `PParamsBound era` newtype with smart constructor at
+  the build entrypoint; pass `PParamsBound` to all
+  four consumers (fee, exunits, integrity hash, self-
+  validation). The wrapper is the "structurally
+  impossible to mis-source" enforcement from FR-002.
+
+**Acceptance**: every consumer of `PParams` in
+`lib-tx-build` either takes `PParamsBound` or is
+visibly downstream of a single `PParamsBound`
+unwrap.
+
+---
+
+## R-005: Test PParams snapshot — reuse the staged file or take a fresh one?
+
+**Status**: OPEN — needs user input.
+
+**Question**: A 707-line `test/fixtures/pparams.json`
+is already staged in `/code/cardano-node-clients`
+(main repo, not committed) from a prior session.
+Should we (a) pick it up and use it as the
+swap-cancel reproduction's `PParams`, (b) capture a
+fresh one specifically scoped to the issue-#153 slot,
+or (c) both — keep the staged one as a general
+fixture, capture a smaller scoped one for this test?
+
+**Why we won't decide silently**: per repo memory
+(`feedback_semantic_changes`, `feedback_investigate_bugs`)
+absorbing an unknown staged file into this PR is
+exactly the kind of cross-context drift we avoid.
+
+**Action**: surface to user before tasks RED-1 runs.
+
+---
+
+## R-006: UTxO source for self-validation
+
+**Status**: PARTIALLY OPEN
+
+**Question**: `applyTx` needs the UTxO containing
+every input the tx spends or references. What is the
+UTxO value in scope at TxBuild's finalize point?
+
+**Provisional answer**: the same `UTxO ConwayEra` the
+balancer already used to resolve inputs and collateral
+(seen near `Balance.hs:444` / `:569`). We do not
+re-query; we pass that exact value.
+
+**Open sub-question**: do reference inputs reside in
+the same UTxO map, or are they passed separately? If
+the latter, we need a step that constructs the
+combined UTxO for `applyTx`.
+
+**Acceptance**: a build path where `applyTx` is called
+with exactly the inputs + reference inputs + collateral
+that the body declares.
+
+---
+
+## Closing rule
+
+When all entries above move to RESOLVED, this file
+gets one final "Summary of decisions" section
+listing the chosen ledger function name, the
+chosen Conway hash function name, the chosen
+language-derivation strategy, and the `PParamsBound`
+decision. That summary is the input to
+`/speckit.tasks`.

--- a/specs/153-txbuild-integrity-hash/research.md
+++ b/specs/153-txbuild-integrity-hash/research.md
@@ -13,73 +13,87 @@ before the corresponding GREEN task in `tasks.md`.
 
 ## R-001: Which ledger function exposes Phase-1 validation?
 
-**Status**: OPEN
+**Status**: RESOLVED (2026-05-15)
 
-**Question**: What is the right
-`cardano-ledger-api`/`cardano-ledger-conway` entry point
-for "Phase-1 validation only" — i.e. it must (a) include
-the `script_integrity_hash` check, (b) include
-fee/min-utxo/collateral checks, (c) not execute Plutus
-scripts (Phase-2)?
+**Decision**: `Cardano.Ledger.Api.Tx.applyTx` from
+`cardano-ledger-api` (pinned to `1.13.0.0` in
+`cabal.project` line 68). It performs the full UTXOW
+transition, which includes the
+`script_integrity_hash` check, fee / min-utxo /
+collateral checks, and witness completeness; under
+Phase-1 it does **not** execute Plutus scripts —
+script evaluation happens in a separate Phase-2
+function. This is the entry point the plan calls
+out and the one already used by the wider ecosystem
+for offline tx validation.
 
-**Candidates**:
-- `Cardano.Ledger.Api.Tx.applyTx`
-  — likely the full transition; pricey when scripts run.
-- `Cardano.Ledger.Api.Tx.reapplyTx`
-  — re-applies an already-validated tx; may skip
-  Phase-1 in some shapes. Probably wrong.
-- `Cardano.Ledger.Shelley.Rules.UTXOW`
-  applied directly via `applyRuleByName` /
-  `runRule` — gives the precise Phase-1 step but
-  is lower-level.
+**Rationale**: it is the smallest API surface that
+fully matches FR-003 ("ledger Phase-1 on its own
+output"), already in the closure, and behaves the
+same way as the node at submission time.
 
-**Acceptance**: chosen function, called from a test
-fixture, returns `Left _` for the pre-fix
-swap-cancel body and `Right _` for the post-fix
-body. We measure roundtrip cost on a typical Conway
-tx (target < 5 ms; if > 20 ms we re-evaluate).
+**Alternatives considered**:
+- `reapplyTx` — re-applies an already-validated tx;
+  may skip checks we care about. Rejected.
+- `Cardano.Ledger.Shelley.Rules.UTXOW` via
+  `applyRuleByName` / `runRule` — lower-level,
+  same semantics but more boilerplate. Rejected.
+- A bespoke Phase-1 reimplementation in
+  `lib-tx-build` — rejected on FR-002 / constitution
+  III grounds (no parallel ledger).
 
-**Alternatives considered**: writing a bespoke
-Phase-1 reimplementation in `lib-tx-build`. Rejected
-on FR-002 / constitution III grounds — we must not
-ship a parallel ledger.
+**Caveat**: the exact type signature of
+`applyTx 1.13.0.0` is verified empirically at T011
+when we first call it from a test. If the signature
+forces a wrapper, the wrapper lives in
+`lib-tx-build` and exposes the simpler shape
+`applyTxBody :: PParamsBound era -> UTxO era ->
+SlotNo -> Tx era -> Either (ApplyTxError era) ()`.
 
 ---
 
 ## R-002: Does `hashScriptIntegrity` already use Conway redeemer encoding?
 
-**Status**: OPEN
+**Status**: DEFERRED (decision rule recorded; empirical
+verification happens at T011).
 
-**Question**: Conway witness-set redeemers are encoded
-as a CBOR map (witness-set key `5`). The current
-`lib-tx-build/.../Scripts.hs:84` uses
-`Cardano.Ledger.Alonzo.Tx.hashScriptIntegrity`. Does
-this function serialize redeemers consistently with
-the Conway body's witness set, or does it still use
-the pre-Conway array form?
-
-**How we'll answer**: run `computeScriptIntegrity`
-over the swap-cancel fixture's redeemers + cost-model
-view at the pre-fix code, and compare the hash to
-both (a) the body's value
-(`03e9d7edc4e9b65b14a6076b19c7f13810292687b0c51b14c038ee4849f81941`)
-and (b) the ledger's expected value
-(`41a7cd5798b8b6f081bfaee0f5f88dc02eea894b7ed888b2a8658b3784dcdcf9`).
-- If the current code reproduces the *body*'s wrong
-  hash, the bug is in `hashScriptIntegrity`'s redeemer
-  encoding for Conway → switch to Conway-era hash.
-- If the current code reproduces neither, the bug is
-  somewhere else (likely cost-model scope, R-003).
-
-**Acceptance**: a passing assertion that the hash for
-the issue-#153 fixture equals
+**Decision rule**: we keep
+`Cardano.Ledger.Alonzo.Tx.hashScriptIntegrity` for now —
+the `Redeemers ConwayEra` value's `EncCBOR` instance is
+era-parameterized and is expected to produce the
+Conway map form (witness-set key `5`). The first RED
+test (T011) computes the hash for the issue-#153
+fixture and compares it to the ledger's expected value
 `41a7cd57…dcf9`.
+
+- If the result matches → the existing
+  `hashScriptIntegrity` is correct for Conway; the bug
+  is purely in the cost-models / language-set scope
+  (R-003). No change to `hashScriptIntegrity` itself.
+- If the result differs → the encoding bug is real;
+  switch to the Conway-era equivalent
+  (`Cardano.Ledger.Conway.Tx.hashScriptIntegrity` if
+  it exists, or a re-export from
+  `Cardano.Ledger.Api`).
+
+**Rationale for deferring**: the source for
+`cardano-ledger-alonzo 1.15.0.0` is not in the
+worktree closure; an empirical golden-vector check
+is cheaper and more reliable than reading the ledger
+source through cabal. The check is required anyway
+(SC-002), so this is a no-cost deferral.
+
+**Acceptance**: T011 (the RED test for the mainnet
+reproduction) computes the hash and compares it to
+`41a7cd57…dcf9`. The R-002 outcome is encoded in
+whether T016 needs to change `hashScriptIntegrity`'s
+import or not.
 
 ---
 
 ## R-003: Cost-models scope — single language or set?
 
-**Status**: PARTIALLY OPEN
+**Status**: RESOLVED (2026-05-15)
 
 **Question**: The current
 `computeScriptIntegrity :: Language -> PParams -> Redeemers -> …`
@@ -90,104 +104,153 @@ PlutusV3 the existing API may or may not be correct in
 practice — but it is fragile: the caller's chosen
 `Language` is the source of truth, not the body.
 
-**Decision (provisional)**: switch the API to derive
-the language set from the body (specifically, the set
-of script hashes resolved at each redeemer site and
-each reference-script input). Caller can no longer
-pass the wrong value.
+**Decision**: switch the API to derive the language
+set from the body (specifically, the set of script
+hashes resolved at each redeemer site and each
+reference-script input). Caller can no longer pass
+the wrong value.
+
+**Confirmed by source reading**: all three call
+sites in `lib-tx-build/Cardano/Node/Client/TxBuild.hs`
+(lines 1043, 1289, 1775) currently hardcode the
+literal `PlutusV3`. Caller convention is the only
+guarantee today — exactly the footgun this
+re-scopes away.
+
+**Helper signature**: per
+[data-model.md](./data-model.md) E-3,
+
+```haskell
+languagesUsedInBody
+  :: TxBody ConwayEra
+  -> UTxO ConwayEra
+  -> Set Language
+```
+
+Walks (a) the body's spending redeemers and their
+resolved scripts, (b) reference-script inputs that
+supply a Plutus script. Native (timelock) scripts
+do not contribute. All inputs available at every
+existing call site (`inputUtxos` + `refUtxos`).
 
 **Rationale**: aligns with FR-001 "derived from the
 body, not from caller convention" and removes a
-recurring footgun.
+recurring footgun. Implementable from data already
+in scope; no new query.
 
 **Alternatives considered**:
 - Keep single `Language`, audit all three call sites.
   Rejected: same bug class will recur on the next
   mixed-language transaction.
-- Derive from the resolved UTxO. Equivalent; either
-  source yields the same answer for a well-formed
-  body.
+- Derive from the resolved UTxO instead of the body.
+  Equivalent; either source yields the same answer
+  for a well-formed body. Body-derived chosen
+  because it keeps the helper independent of any
+  enclosing UTxO map's completeness.
 
 ---
 
 ## R-004: `PParams` threading — does it need a newtype?
 
-**Status**: OPEN
+**Status**: RESOLVED (2026-05-15, user decision)
 
-**Question**: Today, is `PParams ConwayEra` passed as
-a regular argument through `draft` / `build` /
-`finalize`? Or is it ever (a) re-fetched from a query
-mid-build, (b) implicitly carried in a context that
-could be replaced, (c) provided separately to the
-balancer and to `computeScriptIntegrity`?
+**Decision**: introduce `PParamsBound era` per
+[data-model.md](./data-model.md) E-1. Smart
+constructor at the build entrypoint; every internal
+helper that depends on protocol parameters takes
+`PParamsBound era` instead of `PParams era`.
 
-**How we'll answer**: read `TxBuild.hs` lines 1042,
-1066, 1288, 1296, 1774, 1782 (the three integrity-hash
-sites) plus `Balance.hs` 444, 569 (fee estimation),
-and trace the `PParams` value back to the build entry
-point. Note any divergence.
+**Rationale**: a structural guarantee is preferred
+over a behavioral one even if today's flow happens
+to be single-instance. The newtype is ~10 lines, the
+API surface change is internal-only (callers still
+pass `PParams era` to the build entry point and the
+wrapper is constructed inside), and it eliminates
+the entire "PParams source drift" failure mode at
+the type level, which is the FR-002 contract.
 
-**Decision shape**:
-- If `PParams` is already a single argument threaded
-  through, no newtype is strictly required — a
-  comment + an audit-style test suffices.
-- If `PParams` is re-fetched or split, introduce a
-  `PParamsBound era` newtype with smart constructor at
-  the build entrypoint; pass `PParamsBound` to all
-  four consumers (fee, exunits, integrity hash, self-
-  validation). The wrapper is the "structurally
-  impossible to mis-source" enforcement from FR-002.
-
-**Acceptance**: every consumer of `PParams` in
-`lib-tx-build` either takes `PParamsBound` or is
-visibly downstream of a single `PParamsBound`
-unwrap.
+**Acceptance**: every reference to `PParams` inside
+`lib-tx-build`'s build path either takes
+`PParamsBound era` or is visibly the single
+`unPParamsBound` unwrap at a leaf consumer
+(`estimateMinFeeTx`, the ledger Phase-1 call) where
+the underlying ledger API still demands raw
+`PParams`.
 
 ---
 
 ## R-005: Test PParams snapshot — reuse the staged file or take a fresh one?
 
-**Status**: OPEN — needs user input.
+**Status**: RESOLVED (2026-05-15, user decision)
 
-**Question**: A 707-line `test/fixtures/pparams.json`
-is already staged in `/code/cardano-node-clients`
-(main repo, not committed) from a prior session.
-Should we (a) pick it up and use it as the
-swap-cancel reproduction's `PParams`, (b) capture a
-fresh one specifically scoped to the issue-#153 slot,
-or (c) both — keep the staged one as a general
-fixture, capture a smaller scoped one for this test?
+**Decision**: recapture a fresh `pparams.json`
+scoped to the issue-#153 slot. Ignore the 707-line
+file staged in `/code/cardano-node-clients` from a
+prior session — it stays untouched, and that worktree
+remains the user's to dispose of.
 
-**Why we won't decide silently**: per repo memory
-(`feedback_semantic_changes`, `feedback_investigate_bugs`)
-absorbing an unknown staged file into this PR is
-exactly the kind of cross-context drift we avoid.
+**Acceptance**: T009 captures mainnet PParams at the
+epoch active when tx
+`84b2bb78f7f5dd2beb2830e8e6e88fd853a8f70ea73b161f0a0327de8c70146f`
+was rejected, writes them to
+`test/fixtures/pparams.json` of this worktree, and
+commits the file alongside the swap-cancel fixture.
 
-**Action**: surface to user before tasks RED-1 runs.
+**Mechanism**: this project's own LSQ client
+against a mainnet node socket — the same code path
+`cardano-node-clients` ships for protocol-parameter
+queries. Concretely either (a) a small one-off
+program in the worktree that opens
+`LSQChannel`, issues `GetCurrentPParams`, and dumps
+the result as JSON, or (b)
+`cardano-cli query protocol-parameters --mainnet
+--socket-path …`, which is the same Ouroboros LSQ
+query underneath. Either source is the ledger's own
+form — no Blockfrost, no third-party service, no
+external API dependency in the test fixture.
+
+Memory `feedback_fix_own_tools`: the project is the
+N2C client toolkit; using anything else to capture
+PParams *for this project's tests* would be the
+wrong direction.
 
 ---
 
 ## R-006: UTxO source for self-validation
 
-**Status**: PARTIALLY OPEN
+**Status**: RESOLVED (2026-05-15)
 
-**Question**: `applyTx` needs the UTxO containing
-every input the tx spends or references. What is the
-UTxO value in scope at TxBuild's finalize point?
+**Decision**: build the `UTxO ConwayEra` argument to
+`applyTx` as the union of three lists already in
+scope at the return point of `buildWith` in
+`lib-tx-build/Cardano/Node/Client/TxBuild.hs`:
+`inputUtxos`, `boCollateralUtxos opts`, and
+`refUtxos`. No new query is required.
 
-**Provisional answer**: the same `UTxO ConwayEra` the
-balancer already used to resolve inputs and collateral
-(seen near `Balance.hs:444` / `:569`). We do not
-re-query; we pass that exact value.
+**Confirmed by source reading**:
+`lib-tx-build/Cardano/Node/Client/TxBuild.hs` lines
+1245–1246, 1250 (the three UTxO lists arrive at
+`buildWith` as parameters); lines 1309–1316
+(`balanceTxWith` is called with all three); lines
+1515 and 1569 (the final balanced tx is returned
+while all three lists remain in lexical scope).
+`lib-tx-build/Cardano/Node/Client/Balance.hs` lines
+206–224 (signature of `balanceTxWith` taking all
+three UTxO sources separately).
 
-**Open sub-question**: do reference inputs reside in
-the same UTxO map, or are they passed separately? If
-the latter, we need a step that constructs the
-combined UTxO for `applyTx`.
+**Combined-UTxO helper**: introduce a small
+`combinedUtxo :: [(TxIn, TxOut era)] -> [(TxIn, TxOut era)]
+-> [(TxIn, TxOut era)] -> UTxO era` (or inline at the
+call site) that folds the three lists into a single
+`Map TxIn (TxOut era)` and wraps it in `UTxO`. It is
+the caller of `applyTx`, not part of the public API.
 
-**Acceptance**: a build path where `applyTx` is called
-with exactly the inputs + reference inputs + collateral
-that the body declares.
+**Acceptance**: the `applyTx` call site at finalize
+time consumes exactly the inputs + reference inputs +
+collateral that the body declares. T018 verifies this
+by passing a body whose collateral references a
+UTxO outside the union and observing the resulting
+`UtxoFailure` is surfaced.
 
 ---
 
@@ -200,3 +263,18 @@ chosen Conway hash function name, the chosen
 language-derivation strategy, and the `PParamsBound`
 decision. That summary is the input to
 `/speckit.tasks`.
+
+---
+
+## Summary of decisions (2026-05-15)
+
+| ID | Decision |
+|----|----------|
+| R-001 | Phase-1 entry point = `Cardano.Ledger.Api.Tx.applyTx` from `cardano-ledger-api 1.13.0.0`. Signature verified empirically at T011; wrapper added in `lib-tx-build` if needed. |
+| R-002 | Keep `Cardano.Ledger.Alonzo.Tx.hashScriptIntegrity`; rely on `Redeemers ConwayEra`'s era-parameterized encoding to produce the Conway map. T011 golden-vector check decides whether a Conway-specific replacement is needed. |
+| R-003 | Body-derived `Set Language` via `languagesUsedInBody :: TxBody ConwayEra -> UTxO ConwayEra -> Set Language`. Replaces the literal `PlutusV3` hardcoded at TxBuild.hs:1043,1289,1775. |
+| R-004 | Add `PParamsBound era` newtype per [data-model.md](./data-model.md) E-1. Smart constructor at the build entrypoint; all internal helpers consume `PParamsBound era`. |
+| R-005 | Recapture a fresh mainnet `pparams.json` scoped to issue #153's epoch via this project's own LSQ client (`GetCurrentPParams`) or `cardano-cli query protocol-parameters --mainnet`. **No Blockfrost / external service.** Staged file in `/code/cardano-node-clients` (main repo) is ignored. |
+| R-006 | `UTxO ConwayEra` for `applyTx` = union of `inputUtxos ∪ boCollateralUtxos opts ∪ refUtxos` already in scope at `buildWith` (lines 1245–1316). No new query. |
+
+These are the inputs to `/speckit.tasks`.

--- a/specs/153-txbuild-integrity-hash/spec.md
+++ b/specs/153-txbuild-integrity-hash/spec.md
@@ -1,0 +1,255 @@
+# Feature Specification: TxBuild self-validates against ledger Phase-1
+
+**Feature Branch**: `153-txbuild-integrity-hash`
+**Created**: 2026-05-15
+**Status**: Draft
+**Input**: GitHub issue [lambdasistemi/cardano-node-clients#153](https://github.com/lambdasistemi/cardano-node-clients/issues/153)
+
+## Background
+
+TxBuild today can emit a Conway transaction body that fails ledger
+Phase-1 validation. The concrete bug surfaced as a
+`script_integrity_hash` (CBOR key `0b`) mismatch — reproduced on
+mainnet via `amaru-treasury-tx swap-cancel`
+(tx `84b2bb78f7f5dd2beb2830e8e6e88fd853a8f70ea73b161f0a0327de8c70146f`):
+
+```
+script integrity hash mismatch
+  expected (ledger):  41a7cd5798b8b6f081bfaee0f5f88dc02eea894b7ed888b2a8658b3784dcdcf9
+  provided (body):    03e9d7edc4e9b65b14a6076b19c7f13810292687b0c51b14c038ee4849f81941
+```
+
+The deeper problem is that the only way the bug was discovered was
+*downstream* — when a consumer submitted the tx and the ledger
+rejected it. The cross-referenced companion ticket on
+`amaru-treasury-tx` proposes a post-build validation gate in the
+consumer. That is the wrong place: every consumer would have to
+re-implement the same gate. TxBuild itself must guarantee that its
+output is ledger-valid.
+
+This spec re-scopes the work: fix the `script_integrity_hash`
+divergence *and* make TxBuild responsible for validating every body
+it produces against the ledger's Phase-1 rules before returning it.
+The integrity-hash bug becomes one instance of a class TxBuild now
+self-detects.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — TxBuild refuses to return a Phase-1-invalid body (Priority: P1)
+
+A caller asks TxBuild to assemble a Conway transaction. TxBuild
+computes the body, then runs the ledger's Phase-1 validation on
+that body against the same `PParams` it used during assembly. If
+Phase-1 rejects the body, TxBuild fails with an error that names
+the Phase-1 failure (e.g. `script integrity hash mismatch`,
+`fee too small`, `missing collateral`); it never returns an
+invalid body to the caller.
+
+**Why this priority**: this is the contract change that makes the
+bug class impossible to surface downstream again. Without it,
+fixing only the integrity-hash divergence leaves the next
+ledger-side change (new era, new cost-model layout, new redeemer
+form) one bug away from another silent regression.
+
+**Independent Test**: build any Conway tx through TxBuild against a
+`PParams` snapshot, capture the result. If the body is valid, the
+call returns it; if forced to be invalid (e.g. by injecting a
+deliberate `PParams` mismatch in a test harness), the call returns
+an error naming the Phase-1 failure. No consumer-side validation
+gate exists.
+
+**Acceptance Scenarios**:
+
+1. **Given** a TxBuild plan that, with the current code, produces a
+   body the ledger would accept, **When** TxBuild assembles and
+   self-validates, **Then** the call returns the body and the
+   self-validation step records `applyTx … = Right _`.
+2. **Given** a TxBuild plan that, with the *pre-fix* code, produced
+   a body with a wrong `script_integrity_hash`, **When** TxBuild
+   assembles and self-validates against the same `PParams` it
+   used for assembly, **Then** before the fix the call returns an
+   error naming `script integrity hash mismatch`; after the fix
+   the call returns the body and self-validation passes.
+3. **Given** any Conway PlutusV3 plan equivalent to the mainnet
+   `swap-cancel` reproduction (Sundae V3 order, redeemer
+   `Constr 1 []`, inline datum, no witness-set datums, collateral
+   return), **When** TxBuild rebuilds the body offline against a
+   captured mainnet `PParams` snapshot, **Then** the
+   `script_integrity_hash` field equals
+   `41a7cd5798b8b6f081bfaee0f5f88dc02eea894b7ed888b2a8658b3784dcdcf9`
+   *and* TxBuild's self-validation returns `Right _`.
+
+---
+
+### User Story 2 — Consumers no longer carry a duplicate Phase-1 gate (Priority: P1)
+
+The cross-referenced companion ticket on `amaru-treasury-tx`
+(post-build Phase-1 validation gate in the consumer) is closed.
+Consumers trust TxBuild's contract: a returned body is
+ledger-valid against the `PParams` TxBuild was given. Nobody
+duplicates the gate.
+
+**Why this priority**: the consumer-side gate proposal is the
+symptom of TxBuild's broken contract. Closing it is how we verify
+the contract is now strong enough to be relied on.
+
+**Independent Test**: search consumer codebases (starting with
+`amaru-treasury-tx`) for any post-TxBuild `applyTx` /
+`evaluateTxBody` style guard; expect zero. The companion ticket on
+`amaru-treasury-tx` is closed with a link back to this work.
+
+**Acceptance Scenarios**:
+
+1. **Given** the fix has landed and TxBuild's contract is in
+   force, **When** the `amaru-treasury-tx` companion ticket is
+   reviewed, **Then** it is closed as superseded with a reference
+   to this feature.
+2. **Given** any consumer of TxBuild, **When** they call the
+   builder, **Then** they need not re-validate the result before
+   signing/submission to detect Phase-1 issues.
+
+---
+
+### Edge Cases
+
+- **No Plutus inputs**: tx has no redeemers and no
+  `script_integrity_hash` field (`SNothing`). Self-validation
+  must accept this body.
+- **Mixed Plutus versions**: a tx with both PlutusV2 and PlutusV3
+  inputs includes only V2 and V3 cost-model language views in the
+  integrity hash; self-validation enforces this.
+- **PParams sourcing**: TxBuild has exactly one `PParams` instance
+  in scope per build call; the same value feeds fee computation,
+  exec-units estimation, `script_integrity_hash` computation, and
+  self-validation. Two different `PParams` instances in a single
+  build is a programming error and SHOULD be impossible by
+  construction (not just by convention).
+- **Inline datum, empty witness-set datums**: the witness-set
+  datums map is empty; the integrity hash and self-validation
+  must reflect that.
+- **Stake / cert-only Conway tx**: no scripts, no redeemers. The
+  body still goes through self-validation; the validation must
+  not falsely require Plutus witnesses.
+- **Phase-1 failure that is not `script_integrity_hash`**:
+  e.g. insufficient fee, missing collateral, expired validity.
+  Self-validation surfaces the failure with the ledger's own
+  message; TxBuild returns an error, not a body.
+- **Self-validation cost**: the call adds one ledger
+  `applyTx`-style evaluation per build. Acceptable as the cost
+  of a strong contract; not opt-out.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: TxBuild MUST compute `script_integrity_hash` over
+  the redeemers as they appear in the transaction's Conway
+  witness set (map form, witness-set key `5`), using only the
+  cost-model language views for Plutus versions actually
+  referenced by a redeemer in the transaction.
+- **FR-002**: TxBuild MUST source the `PParams` value used for
+  fee estimation, exec-units estimation, integrity-hash
+  computation, and self-validation from a single `PParams`
+  instance passed into the build call; the design MUST make a
+  multi-instance bug structurally impossible (single argument
+  threaded through, not re-fetched midway).
+- **FR-003**: Before returning a transaction body, TxBuild MUST
+  run the ledger's Phase-1 validation (`applyTx` or the
+  equivalent functional path from `cardano-ledger-api`) on that
+  body against the same `PParams` instance from FR-002 and the
+  UTxO it already has in scope.
+- **FR-004**: If Phase-1 validation rejects the body, TxBuild
+  MUST return an error that surfaces the ledger's failure
+  reason (the original `ApplyTxError` value or a faithful
+  rendering thereof). TxBuild MUST NOT return the body in this
+  case.
+- **FR-005**: TxBuild MUST omit the `script_integrity_hash`
+  field (`SNothing`) from a body that carries no redeemers and
+  no datums, and self-validation MUST accept such a body.
+- **FR-006**: The mainnet `swap-cancel` reproduction from issue
+  #153, replayed offline against a captured `PParams` snapshot,
+  MUST produce `script_integrity_hash` =
+  `41a7cd5798b8b6f081bfaee0f5f88dc02eea894b7ed888b2a8658b3784dcdcf9`
+  and self-validation MUST return `Right _`. This is enforced
+  by a test in the project's test suite.
+- **FR-007**: At least one negative test MUST exercise FR-004:
+  given a deliberately invalid plan (e.g. fee artificially
+  zeroed, or a forced pparams mismatch), TxBuild returns an
+  error naming the Phase-1 failure and does not return a body.
+- **FR-008**: The companion `amaru-treasury-tx` ticket
+  (post-build Phase-1 validation gate in the consumer) is
+  closed as superseded by this work. No consumer is expected to
+  carry a duplicate Phase-1 gate.
+- **FR-009**: The fix MUST NOT regress any existing passing
+  TxBuild test in `just ci`.
+
+### Key Entities
+
+- **Script integrity hash**: a 32-byte BLAKE2b-256 hash committed
+  to in the tx body (CBOR key `0b`) and recomputed by the ledger
+  from the witnesses + cost-model language views. Mismatch is a
+  Phase-1 validation failure.
+- **Language view**: the cost-model entry for a single Plutus
+  version, in the ledger-canonical serialization form for that
+  version.
+- **Redeemers (Conway witness set)**: redeemers indexed by
+  `(tag, index)`, serialized as a map in Conway; the integrity
+  hash uses the same serialization the witness set carries.
+- **PParams instance**: the protocol-parameter value threaded
+  through a single TxBuild call; single source of truth for fees,
+  exec units, integrity hash, and self-validation.
+- **Phase-1 validation**: the ledger's structural / static
+  acceptance check, exposed via `cardano-ledger-api`'s
+  `applyTx` (or equivalent); does NOT run Plutus scripts —
+  Phase-2 does. The script-integrity check happens here.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100 % of TxBuild calls that today produce a
+  Phase-1-valid body continue to return that body; no false
+  rejection.
+- **SC-002**: 100 % of TxBuild calls that today produce a
+  Phase-1-invalid body now return an error naming the ledger
+  failure. The previously-shipped mainnet `swap-cancel`
+  reproduction is among these and is rejected with
+  `script integrity hash mismatch` against pre-fix code, and
+  accepted against post-fix code.
+- **SC-003**: A grep across the consumer set (starting with
+  `amaru-treasury-tx`) finds zero post-TxBuild Phase-1
+  validation gates; the companion ticket is closed as
+  superseded.
+- **SC-004**: `just ci` passes green on the branch.
+- **SC-005**: A future ledger / cost-model / era change that
+  breaks the equivalence is caught by TxBuild's self-validation
+  in `just ci` (or in the first consumer test run), not by a
+  Phase-1 rejection in production.
+
+## Assumptions
+
+- TxBuild has, at body-return time, access to enough state to run
+  Phase-1 validation: the `PParams` instance, the slot, and the
+  UTxO it already used to construct inputs/collateral. No new
+  external query is required. If this turns out to be false, the
+  spec will be updated and user approval requested before
+  extending the API surface.
+- "Ledger Phase-1 validation" in this spec means the ledger
+  function exposed via `cardano-ledger-api` that performs the
+  same static checks the node runs before Plutus script
+  execution. Phase-2 (Plutus script execution) is out of scope —
+  this work does not promise script-logic validation, only that
+  bodies are well-formed and self-consistent with witnesses and
+  PParams.
+- The mainnet `PParams` snapshot used in the FR-006 reproduction
+  is taken at a slot consistent with the failing tx's slot, so
+  the cost-models in scope match those the ledger used at
+  rejection time.
+- The work is confined to `lib-tx-build/Cardano/Node/Client/`
+  (notably `TxBuild.hs` and `Scripts.hs`) and its tests. If the
+  fix forces a TxBuild public-API change, the spec is updated
+  and user approval requested before the API moves.
+- Closing the `amaru-treasury-tx` companion ticket is part of
+  the deliverable (see FR-008 / SC-003) but happens after the
+  TxBuild fix lands — the consumer ticket is closed *as
+  superseded by this PR*, with a backlink.

--- a/specs/153-txbuild-integrity-hash/tasks.md
+++ b/specs/153-txbuild-integrity-hash/tasks.md
@@ -91,8 +91,15 @@ Blocks Phase 3.
   `84b2bb78f7f5dd2beb2830e8e6e88fd853a8f70ea73b161f0a0327de8c70146f`.
   Source the data from `amaru-treasury-tx` reproduction
   artifacts; do not redraft.
-- [ ] T009 Place the chosen mainnet `pparams.json` snapshot
-  at `test/fixtures/pparams.json` per T005 outcome.
+- [ ] T009 Capture a mainnet `pparams.json` snapshot for the
+  epoch active when tx `84b2bb…0146f` was rejected, and
+  write it to `test/fixtures/pparams.json` of this worktree.
+  Source: this project's LSQ client (`GetCurrentPParams`)
+  against a mainnet node socket, or
+  `cardano-cli query protocol-parameters --mainnet
+  --socket-path …` (same Ouroboros query underneath).
+  **Do not use Blockfrost or any other external service**
+  per memory `feedback_fix_own_tools` and R-005.
 - [ ] T010 [P] Add helpers `loadPParams`, `loadUtxo`,
   `loadPlan` to `test/Cardano/Node/Client/TxBuildSpec.hs`
   (or a new sibling test module) per

--- a/specs/153-txbuild-integrity-hash/tasks.md
+++ b/specs/153-txbuild-integrity-hash/tasks.md
@@ -1,0 +1,312 @@
+---
+description: "Tasks for issue #153 — TxBuild self-validates against ledger Phase-1"
+---
+
+# Tasks: TxBuild self-validates against ledger Phase-1
+
+**Input**: Design documents in `/specs/153-txbuild-integrity-hash/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md),
+[research.md](./research.md), [data-model.md](./data-model.md),
+[contracts/txbuild-self-validation.md](./contracts/txbuild-self-validation.md),
+[quickstart.md](./quickstart.md)
+
+**Tests**: TDD is in force per project constitution. Every
+implementation task has a RED test that precedes it. See
+[quickstart.md](./quickstart.md) §2-3 for canonical test
+recipes.
+
+**Organization**: tasks are grouped by user story (US1, US2)
+from [spec.md](./spec.md). Each user story is independently
+testable per the spec's "Independent Test" criteria.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: parallelizable (different files, no incomplete-task
+  dependencies)
+- **[Story]**: which user story this task belongs to (US1 / US2)
+- Each task names exact file paths
+
+---
+
+## Phase 1: Setup — Resolve Phase-0 research
+
+**Purpose**: close every OPEN entry in
+[research.md](./research.md) so implementation has zero
+"NEEDS CLARIFICATION" left. No code changes yet.
+
+- [ ] T001 Resolve R-001 in [research.md](./research.md): pick the exact
+  `cardano-ledger-api` / `cardano-ledger-conway` function for
+  Phase-1 validation. Verify it (a) catches
+  `script_integrity_hash` mismatches and (b) does not run
+  Plutus scripts. Update R-001 to RESOLVED with the chosen
+  function name and Haddock link.
+- [ ] T002 [P] Resolve R-002 in [research.md](./research.md): run the
+  current `Cardano.Node.Client.Scripts.computeScriptIntegrity`
+  against captured swap-cancel inputs in a one-off `ghci`
+  session, record whether it reproduces the *body* hash
+  (`03e9d7ed…1941`) or the *ledger* hash
+  (`41a7cd57…dcf9`). Pick the right Conway hash function
+  accordingly. Update R-002 to RESOLVED.
+- [ ] T003 [P] Resolve R-003 in [research.md](./research.md): confirm
+  the body-derived `Set Language` strategy and the helper
+  signature (see [data-model.md](./data-model.md) E-3). Update
+  R-003 to RESOLVED.
+- [ ] T004 Resolve R-004 in [research.md](./research.md): audit
+  `PParams` flow in `lib-tx-build/Cardano/Node/Client/TxBuild.hs`
+  (lines 1042, 1066, 1288, 1296, 1774, 1782) and
+  `lib-tx-build/Cardano/Node/Client/Balance.hs` (lines 444,
+  569). Decide whether `PParamsBound era` newtype is needed
+  (see [data-model.md](./data-model.md) E-1). Update R-004 to
+  RESOLVED.
+- [ ] T005 Resolve R-005: ask user whether to reuse the staged
+  `test/fixtures/pparams.json` from the main repo or capture
+  a fresh one. Do **not** absorb the staged file silently
+  (memory `feedback_semantic_changes`, `feedback_investigate_bugs`).
+  Update R-005 to RESOLVED.
+- [ ] T006 Resolve R-006 in [research.md](./research.md): confirm
+  the `UTxO ConwayEra` source at TxBuild finalize time, and
+  whether reference inputs need an explicit merge with the
+  spending UTxO before `applyTx`. Update R-006 to RESOLVED.
+- [ ] T007 Add the "Summary of decisions" closing section to
+  [research.md](./research.md), naming the ledger function,
+  hash function, language-derivation, and PParamsBound
+  decision. Single signed commit:
+  `docs(specs/153): close phase-0 research`.
+
+**Checkpoint**: every research entry in
+[research.md](./research.md) reads RESOLVED. No code in
+`lib-tx-build` has been touched yet.
+
+---
+
+## Phase 2: Foundational — test fixture infrastructure
+
+**Purpose**: shared scaffolding both user stories need.
+Blocks Phase 3.
+
+- [ ] T008 Capture the issue-#153 swap-cancel reproduction
+  inputs to `test/fixtures/mainnet-txbuild/swap-cancel-issue-153/`:
+  `utxo.json`, `plan.hs` (or `plan.json`), and
+  `expected-body.cbor.hex` for mainnet tx
+  `84b2bb78f7f5dd2beb2830e8e6e88fd853a8f70ea73b161f0a0327de8c70146f`.
+  Source the data from `amaru-treasury-tx` reproduction
+  artifacts; do not redraft.
+- [ ] T009 Place the chosen mainnet `pparams.json` snapshot
+  at `test/fixtures/pparams.json` per T005 outcome.
+- [ ] T010 [P] Add helpers `loadPParams`, `loadUtxo`,
+  `loadPlan` to `test/Cardano/Node/Client/TxBuildSpec.hs`
+  (or a new sibling test module) per
+  [quickstart.md](./quickstart.md) §2. Keep them small;
+  no logic beyond JSON decode + lookup.
+
+**Checkpoint**: test scaffolding compiles, fixtures
+present, no functional change to `lib-tx-build`.
+
+---
+
+## Phase 3: User Story 1 — TxBuild refuses Phase-1-invalid bodies (P1) 🎯 MVP
+
+**Goal**: per [spec.md](./spec.md) US1 — the build call
+self-validates and returns an error rather than an invalid
+body.
+
+**Independent Test**: per
+[spec.md](./spec.md) US1 — fixture-driven; build the
+swap-cancel plan, assert `Right body`,
+`scriptIntegrityHashTxBodyL == SJust 41a7cd57…dcf9`,
+`applyTx pp utxo slot body == Right _`.
+
+### RED tests for US1 — write FIRST, watch fail
+
+- [ ] T011 [US1] Add failing golden in
+  `test/Cardano/Node/Client/TxBuildSpec.hs` per
+  [quickstart.md](./quickstart.md) §2 part 1: build
+  swap-cancel offline, assert
+  `body ^. scriptIntegrityHashTxBodyL ==
+  SJust 41a7cd5798b8b6f081bfaee0f5f88dc02eea894b7ed888b2a8658b3784dcdcf9`.
+  Confirm RED before moving on.
+- [ ] T012 [P] [US1] Add failing Phase-1 assertion in
+  `test/Cardano/Node/Client/TxBuildSpec.hs` per
+  [quickstart.md](./quickstart.md) §2 part 2: build
+  swap-cancel offline, assert the build call self-validated
+  (the result `isRight`). Will fail because no self-
+  validation step exists yet; confirm RED.
+- [ ] T013 [US1] Add failing negative-build test per
+  [quickstart.md](./quickstart.md) §3 in
+  `test/Cardano/Node/Client/TxBuildSpec.hs`: deliberately
+  invalid plan → expect
+  `Left (LedgerFail (Phase1Rejected _))`. Currently no
+  `Phase1Rejected` constructor exists and no self-
+  validation runs — confirm RED.
+
+### Implementation for US1
+
+- [ ] T014 [US1] Extend `LedgerCheck` per
+  [data-model.md](./data-model.md) E-2 in
+  `lib-tx-build/Cardano/Node/Client/TxBuild.hs`: add
+  `Phase1Rejected (ApplyTxError era)`, parameterize types
+  by `era` as needed. Existing constructors retained
+  (memory `feedback_destructive_api_mutations`). Single
+  commit, compiles, but tests still RED.
+- [ ] T015 [US1] If T004 decided in favor of
+  `PParamsBound`: add the newtype in
+  `lib-tx-build/Cardano/Node/Client/TxBuild.hs`
+  (or a small sibling module), threaded through `build`
+  per [data-model.md](./data-model.md) E-1. Single
+  commit, compiles, tests still RED. If T004 decided
+  *against*, skip this task and leave
+  [data-model.md](./data-model.md) E-1 noted as "decided
+  against; see R-004 summary".
+- [ ] T016 [US1] Fix `computeScriptIntegrity` in
+  `lib-tx-build/Cardano/Node/Client/Scripts.hs` per
+  [data-model.md](./data-model.md) E-4 and the R-002 / R-003
+  outcomes: accept `Set Language` derived from body, accept
+  witness-set datums, use the Conway-form hash function from
+  T002. Add `languagesUsedInBody` helper per
+  [data-model.md](./data-model.md) E-3. T011 turns GREEN.
+- [ ] T017 [US1] Update the three call sites of
+  `computeScriptIntegrity` in
+  `lib-tx-build/Cardano/Node/Client/TxBuild.hs` (lines 1042,
+  1288, 1774) to feed the body-derived language set and
+  the witness-set datums map. Compiles; T011 stays GREEN.
+- [ ] T018 [US1] Add self-validation in TxBuild's
+  finalize path per [contracts/txbuild-self-validation.md](./contracts/txbuild-self-validation.md)
+  C-1, C-4: at the point the body is about to be returned,
+  call the Phase-1 function chosen in T001 with the same
+  `PParams` / `UTxO` / slot already in scope. On `Left e`,
+  return `Left (LedgerFail (Phase1Rejected e))`; otherwise
+  return the body. T012 and T013 turn GREEN.
+- [ ] T019 [US1] Verify integrity-hash and Phase-1
+  invariants in a property test
+  (`test/Cardano/Node/Client/TxBuildSpec.hs`): generate a
+  range of Conway PlutusV3-only TxBuild plans (script
+  spend with inline datum, no datum-witness, simple
+  redeemer); assert all build calls succeed and the
+  returned bodies pass `applyTx`. Edge cases per
+  [spec.md](./spec.md) "Edge Cases" section.
+
+**Checkpoint**: US1 fully delivered. Build calls return
+ledger-valid bodies or `LedgerFail` errors; the
+swap-cancel reproduction matches the ledger's
+expected hash; `just ci` passes.
+
+---
+
+## Phase 4: User Story 2 — close downstream duplicate-gate ticket (P1)
+
+**Goal**: per [spec.md](./spec.md) US2 / FR-008 — the
+companion `amaru-treasury-tx` ticket is closed as
+superseded; no consumer carries a duplicate Phase-1 gate.
+
+**Independent Test**: per [spec.md](./spec.md) US2 — a
+grep across consumers (starting with
+`amaru-treasury-tx`) finds zero post-TxBuild Phase-1
+gates; the companion ticket is closed with a backlink
+to PR #154.
+
+### Tasks for US2
+
+- [ ] T020 [US2] Locate the companion ticket on
+  `lambdasistemi/amaru-treasury-tx`. Update PR #154's
+  description with the ticket URL.
+- [ ] T021 [US2] Run the verification grep from
+  [quickstart.md](./quickstart.md) §4 across
+  `amaru-treasury-tx` and any other known TxBuild
+  consumer. Record findings (a) in PR #154's description
+  (consumer list confirmed clean), and (b) as a comment
+  on the companion ticket.
+- [ ] T022 [US2] Close the companion ticket as
+  superseded with a reference to PR #154 — only after
+  Phase 3 has merged and the consumer grep returned
+  clean. If the ticket is still in open-PR form
+  (consumer-side patch), coordinate with user before
+  closing (memory `feedback_no_push_upstream`).
+
+**Checkpoint**: US2 fully delivered. The class of bug
+that motivated issue #153 cannot recur via a missing
+consumer gate, because the consumer gate is gone.
+
+---
+
+## Phase 5: Polish
+
+- [ ] T023 [P] Update Haddock on
+  `Cardano.Node.Client.Scripts.computeScriptIntegrity`
+  and `languagesUsedInBody` in
+  `lib-tx-build/Cardano/Node/Client/Scripts.hs` to
+  describe the body-derivation rule and the Conway hash
+  function used.
+- [ ] T024 [P] Update Haddock on `LedgerCheck` and the
+  build entry point in
+  `lib-tx-build/Cardano/Node/Client/TxBuild.hs` to
+  describe the Phase-1 self-validation contract and
+  `Phase1Rejected`.
+- [ ] T025 Refresh PR #154 description: replace the
+  "Status: Draft — only the spec is in" preamble with
+  the implementation summary (modules touched, tests
+  added, fixture path, link to companion-ticket
+  closure). Memory `feedback_update_pr_description`.
+- [ ] T026 Run `nix develop --quiet -c just ci` locally
+  (memory `feedback_always_local_ci`) and confirm green.
+  Push, mark PR #154 ready for review.
+- [ ] T027 Add a `## Recent Changes` line to
+  `CLAUDE.md` summarizing this feature
+  (auto-generated by `update-agent-context.sh`; verify
+  the entry is correct).
+
+---
+
+## Dependencies
+
+```text
+Phase 1 (T001-T007)  ──►  Phase 2 (T008-T010)  ──►  Phase 3 (T011-T019)
+                                                          │
+                                                          ▼
+                                                Phase 4 (T020-T022)
+                                                          │
+                                                          ▼
+                                                Phase 5 (T023-T027)
+```
+
+- Within Phase 1: T002, T003 are parallel after T001
+  produces enough context.
+- Within Phase 2: T008 and T009 are sequential (T009
+  depends on T005's outcome captured in T009);
+  T010 [P] can start as soon as T008 lands.
+- Within Phase 3: T011, T012 are parallel writes
+  (different test fixtures, same file → sequential
+  in practice). T014/T015 are sequential (type
+  parameterization order). T016 must precede T017
+  (signature change before call-site update). T018 is
+  the last RED→GREEN flip.
+- Phase 4 starts only after Phase 3 has merged to main
+  (consumer-grep makes no sense before the fix lands).
+  Per memory `feedback_test_before_merge` we may also
+  want to run the MPFS / amaru-treasury-tx E2E against
+  the unmerged branch before declaring Phase 3 done.
+- Phase 5 polishes can interleave; T025 / T026 are the
+  release gate.
+
+---
+
+## Implementation strategy
+
+- **MVP** = Phase 3 (US1) only. The build self-validates,
+  the swap-cancel reproduction is GREEN, and the bug is
+  closed at the TxBuild layer. Even without Phase 4 /
+  Phase 5, the original issue #153 is resolved.
+- **Incremental delivery**: Phase 3 ships as PR #154's
+  first reviewable round; Phase 4 closes the loop on the
+  downstream consumer; Phase 5 polishes the surface.
+- **Vertical commits** (memory
+  `feedback_vertical_commits`): one commit per
+  meaningful unit (RED test bundle, type extension,
+  hash fix, language-set helper, self-validation hook,
+  property test). No fixup commits — use `stg goto` /
+  `stg refresh` per memory `feedback_stgit_retroactive_fixes`
+  if anything needs amending.
+- **Bisect-safe** (memory `feedback_bisect_safe_commits`):
+  every commit compiles. The order RED → type-extend →
+  hash-fix → call-site → self-validate keeps every
+  intermediate state green-on-build, RED-on-target-test
+  until the matching GREEN step.


### PR DESCRIPTION
Closes (eventually) lambdasistemi/cardano-node-clients#153.

## Status

**Draft — spec, plan, and tasks committed; no code yet.**
Phase-0 research items in [research.md](https://github.com/lambdasistemi/cardano-node-clients/blob/153-txbuild-integrity-hash/specs/153-txbuild-integrity-hash/research.md) are still OPEN; they are closed by tasks T001–T007 before any code change.

## Why this PR exists

Issue #153 reports that TxBuild emits a Conway tx body whose
`script_integrity_hash` (CBOR key `0b`) does not match what the ledger
recomputes during Phase-1 validation. Reproduced on mainnet via
`amaru-treasury-tx swap-cancel`
(tx `84b2bb78f7f5dd2beb2830e8e6e88fd853a8f70ea73b161f0a0327de8c70146f`).

The bug surfaced *downstream*: the only thing that noticed was the
ledger refusing the tx at submission. The issue cross-references a
companion ticket on `amaru-treasury-tx` proposing a post-build
Phase-1 validation gate inside the consumer. That is the wrong place.

## What this PR commits to

Rather than patch the hash divergence in isolation, the spec
re-scopes the work:

- TxBuild MUST self-validate every body it returns against the
  ledger's Phase-1 rules (`applyTx` /
  `cardano-ledger-api`) using the *same* `PParams` instance it
  used during assembly.
- If Phase-1 rejects the body, TxBuild returns
  `Left (LedgerFail (Phase1Rejected (ApplyTxError era)))` carrying
  the ledger's own failure; it never returns an invalid body.
- The integrity-hash divergence becomes one instance the new
  contract catches; other Phase-1 failure modes (fee, collateral,
  language scope, witness completeness) are caught for free.
- The companion ticket on `amaru-treasury-tx` is closed as
  superseded — consumers no longer need a duplicate Phase-1 gate.

## Spec artifacts on this branch

- [`spec.md`](https://github.com/lambdasistemi/cardano-node-clients/blob/153-txbuild-integrity-hash/specs/153-txbuild-integrity-hash/spec.md)
  — full spec: user stories (P1×2), 9 functional requirements, 5
  success criteria, edge cases, assumptions, scope discipline.
- [`plan.md`](https://github.com/lambdasistemi/cardano-node-clients/blob/153-txbuild-integrity-hash/specs/153-txbuild-integrity-hash/plan.md)
  — implementation plan: which modules, dependencies (all already in
  closure), constitution check (no violations).
- [`research.md`](https://github.com/lambdasistemi/cardano-node-clients/blob/153-txbuild-integrity-hash/specs/153-txbuild-integrity-hash/research.md)
  — six OPEN research items closed by Phase-1 tasks.
- [`data-model.md`](https://github.com/lambdasistemi/cardano-node-clients/blob/153-txbuild-integrity-hash/specs/153-txbuild-integrity-hash/data-model.md)
  — `PParamsBound era` (newtype, contingent on R-004),
  `Phase1Rejected` constructor in `LedgerCheck`, body-derived
  `Set Language` for `computeScriptIntegrity`.
- [`contracts/txbuild-self-validation.md`](https://github.com/lambdasistemi/cardano-node-clients/blob/153-txbuild-integrity-hash/specs/153-txbuild-integrity-hash/contracts/txbuild-self-validation.md)
  — 7 invariants C-1..C-7 between TxBuild and callers.
- [`quickstart.md`](https://github.com/lambdasistemi/cardano-node-clients/blob/153-txbuild-integrity-hash/specs/153-txbuild-integrity-hash/quickstart.md)
  — caller usage, swap-cancel reproduction recipe, negative-test
  recipe.
- [`tasks.md`](https://github.com/lambdasistemi/cardano-node-clients/blob/153-txbuild-integrity-hash/specs/153-txbuild-integrity-hash/tasks.md)
  — 27 tasks across 5 phases (setup / foundational / US1 MVP / US2
  downstream cleanup / polish), TDD-ordered, vertical commits,
  bisect-safe.
- [`checklists/requirements.md`](https://github.com/lambdasistemi/cardano-node-clients/blob/153-txbuild-integrity-hash/specs/153-txbuild-integrity-hash/checklists/requirements.md)
  — quality checklist (all green).

## Spec highlights

| FR | What |
|----|------|
| FR-001 | `script_integrity_hash` over Conway-form redeemers; language set derived from body, not caller |
| FR-002 | Single `PParams` instance threaded through fee/exunits/hash/self-validation — structural, not by convention |
| FR-003 | TxBuild runs ledger Phase-1 on its own output before returning |
| FR-004 | Phase-1 failure → `Left (LedgerFail (Phase1Rejected err))`, never a body |
| FR-006 | Mainnet reproduction asserts hash `41a7cd57…dcf9` and `Right _` |
| FR-007 | Negative test: deliberately invalid plan → error, not body |
| FR-008 | `amaru-treasury-tx` companion ticket closed as superseded |

## Open question to resolve before code

R-005 (in `research.md`): there is a 707-line `test/fixtures/pparams.json` already staged in the main repo (`/code/cardano-node-clients`) from a prior session. Reuse it as the swap-cancel reproduction's `PParams`, or capture a fresh one scoped to issue #153's slot? Flagged for user input per memory `feedback_semantic_changes` — will not silently absorb.

## What's next on this branch

1. Close R-001…R-006 (Phase 1 tasks T001–T007).
2. Capture fixture (T008–T010).
3. RED tests, then GREEN implementation, then property test (T011–T019).
4. Downstream cleanup (T020–T022).
5. Polish + final `just ci` + ready for review (T023–T027).

## Review focus for now

Spec, plan, tasks. Specifically:

- Is `Phase1Rejected (ApplyTxError era)` the right error
  representation, or do we want to render it to a project-owned
  type at the boundary?
- Is `PParamsBound era` worth the API surface, or is an audit-style
  property test sufficient to enforce single-instance threading?
- Anything missing from the edge-case list in `spec.md`?