### PR TITLE
feat: interest-set address filter on withChainSyncFollower

### DIFF
--- a/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
@@ -37,6 +37,7 @@ import Cardano.Node.Client.N2C.Trace (
 import Cardano.Node.Client.UTxOIndexer.Follower (
     ChainSyncConfig (..),
     FollowerHandle (..),
+    InterestSet (..),
     Readiness (..),
     withChainSyncFollower,
  )
@@ -144,6 +145,12 @@ toChainSyncCfg cfg =
         , csSecurityParamK = dcSecurityParamK cfg
         , csReconnectPolicy = dcReconnectPolicy cfg
         , csProbeConfig = dcProbeConfig cfg
+        , -- The bundled @utxo-indexer@ daemon indexes
+          -- the full chain by default (issue #158).
+          -- Downstream in-process consumers can construct
+          -- a 'ChainSyncConfig' directly with
+          -- 'IndexAddressSet' to bound the on-disk store.
+          csInterestSet = IndexAll
         }
 
 {- | Derive the bundled daemon's wire-format 'ReadyStatus'

--- a/lib/Cardano/Node/Client/UTxOIndexer/Follower.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Follower.hs
@@ -53,6 +53,10 @@ module Cardano.Node.Client.UTxOIndexer.Follower (
     -- * Configuration
     ChainSyncConfig (..),
 
+    -- * Interest-set filter
+    InterestSet (..),
+    filterBlockOps,
+
     -- * Readiness state
     Readiness (..),
     initialReadiness,
@@ -84,7 +88,11 @@ import Cardano.Node.Client.UTxOIndexer.BlockExtract (
 import Cardano.Node.Client.UTxOIndexer.Indexer (
     IndexerHandle (..),
  )
+import Cardano.Node.Client.UTxOIndexer.IndexerOp (
+    UtxoOp (..),
+ )
 import Cardano.Node.Client.UTxOIndexer.Types (
+    Address,
     BlockHash (..),
     SlotNo (..),
  )
@@ -107,6 +115,8 @@ import Control.Concurrent.STM (
 import Control.Monad (void)
 import Control.Tracer (Tracer, nullTracer)
 import Data.ByteString.Short qualified as SBS
+import Data.Set (Set)
+import Data.Set qualified as Set
 import Data.Time.Clock (UTCTime, getCurrentTime)
 import Data.Word (Word64)
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (
@@ -148,8 +158,73 @@ data ChainSyncConfig = ChainSyncConfig
     -- ^ LSQ tip-probe configuration that gates each
     -- reconnect attempt — chain-replay-tolerant
     -- (unbounded total timeout) by default.
+    , csInterestSet :: !InterestSet
+    -- ^ Apply-time address filter (issue #158). Default
+    -- 'IndexAll' preserves the prior full-chain behavior
+    -- so existing daemon and reconnect tests stay green.
+    -- 'IndexAddressSet' bounds the on-disk store to
+    -- @O(|set|)@ entries by dropping every
+    -- 'UtxoCreate' whose output address is outside the
+    -- set; 'UtxoSpend' is always processed (a spend on a
+    -- previously-filtered create is a clean no-op
+    -- because the 'TxInCol' entry never existed).
     }
     deriving stock (Show)
+
+{- | Address filter applied to each @[UtxoOp]@ batch
+between 'extractBlock' and 'applyAtSlot'.
+
+= Semantics
+
+* 'IndexAll' — pass every op through unchanged. Matches
+  the pre-#158 follower; the bundled daemon binary
+  always passes this, so its tests stay green.
+* @'IndexAddressSet' s@ — keep 'UtxoCreate' ops whose
+  output address belongs to @s@; drop the rest. ALL
+  'UtxoSpend' ops are kept (the underlying indexer is
+  rollback-aware: a spend on a previously-filtered
+  create finds no @TxInCol@ entry and is a silent
+  no-op).
+
+= State invariant
+
+For every query restricted to addresses in @s@ (i.e.
+'snapshotAt' / 'awaitTxIn' on addresses the caller knows
+are in @s@), the resulting state is byte-identical to
+running the follower with 'IndexAll'. Disk grows as
+@O(|s| × avg UTxOs per address × time)@ instead of
+@O(entire chain UTxO set)@.
+
+Out of scope: dynamic mutation of the set after
+'withChainSyncFollower' returns the 'FollowerHandle'
+(the value is captured by reference at apply time but
+not exposed for STM updates). A future ticket can lift
+the field into an STM-mutable value if multi-tenant
+onboarding requires it.
+-}
+data InterestSet
+    = -- | Pass-through; preserves the pre-#158 daemon
+      -- semantics.
+      IndexAll
+    | -- | Keep only 'UtxoCreate' ops whose address
+      -- belongs to the set. Spends always pass.
+      IndexAddressSet !(Set Address)
+    deriving stock (Eq, Show)
+
+{- | Pure: filter a batch of 'UtxoOp's against an
+'InterestSet'. Called by the follower's @rollForward@
+between 'extractBlock' and 'applyAtSlot'; exported so
+unit tests can exercise the filter without spinning up
+a chain-sync session.
+-}
+filterBlockOps :: InterestSet -> [UtxoOp] -> [UtxoOp]
+filterBlockOps IndexAll = id
+filterBlockOps (IndexAddressSet s) = filter (inInterestSet s)
+  where
+    inInterestSet :: Set Address -> UtxoOp -> Bool
+    inInterestSet set op = case op of
+        UtxoCreate _ addr _ -> addr `Set.member` set
+        UtxoSpend _ -> True
 
 {- | Live readiness snapshot updated by the follower
 thread after every roll-forward and on every reconnect
@@ -401,8 +476,12 @@ mkFollower cfg readinessVar idx = self
     self =
         Follower
             { rollForward = \fetched tip -> do
-                let (slot, ops) =
+                let (slot, rawOps) =
                         extractBlock (fetchedBlock fetched)
+                    ops =
+                        filterBlockOps
+                            (csInterestSet cfg)
+                            rawOps
                     bh =
                         pointToBlockHash
                             (fetchedPoint fetched)

--- a/test/Cardano/Node/Client/UTxOIndexer/FollowerSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/FollowerSpec.hs
@@ -30,7 +30,9 @@ import Cardano.Node.Client.N2C.Trace (nullN2CTracer)
 import Cardano.Node.Client.UTxOIndexer.Follower (
     ChainSyncConfig (..),
     FollowerHandle (..),
+    InterestSet (..),
     Readiness (..),
+    filterBlockOps,
     withChainSyncFollower,
  )
 import Cardano.Node.Client.UTxOIndexer.Indexer (
@@ -50,6 +52,7 @@ import Cardano.Node.Client.UTxOIndexer.Types (
 import Control.Concurrent.Async qualified as Async
 import Control.Concurrent.STM (atomically)
 import Data.ByteString qualified as BS
+import Data.Set qualified as Set
 import Ouroboros.Network.Magic (NetworkMagic (..))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec (Spec, describe, it, shouldBe)
@@ -130,8 +133,128 @@ spec =
                                         _follower = fhAsync fh
                                     pure ()
 
+        describe "filterBlockOps (interest-set semantics)" $ do
+            it
+                "keeps UtxoCreate ops at addresses in the\
+                \ interest set and drops the rest"
+                $ withInMemoryIndexer
+                $ \idx -> do
+                    let set = Set.fromList [addrA]
+                        ops =
+                            [ UtxoCreate txInA addrA outA
+                            , UtxoCreate txInB addrB outB
+                            , UtxoCreate txInC addrC outC
+                            ]
+                    applyAtSlot
+                        idx
+                        (SlotNo 10)
+                        blk1
+                        (filterBlockOps (IndexAddressSet set) ops)
+                    snapA <- snapshotAt idx addrA
+                    snapA `shouldBe` [(txInA, outA)]
+
+            it
+                "leaves UtxoCreate ops at addresses outside\
+                \ the interest set unstored — snapshotAt\
+                \ returns []"
+                $ withInMemoryIndexer
+                $ \idx -> do
+                    let set = Set.fromList [addrA]
+                        ops =
+                            [ UtxoCreate txInA addrA outA
+                            , UtxoCreate txInB addrB outB
+                            , UtxoCreate txInC addrC outC
+                            ]
+                    applyAtSlot
+                        idx
+                        (SlotNo 10)
+                        blk1
+                        (filterBlockOps (IndexAddressSet set) ops)
+                    snapB <- snapshotAt idx addrB
+                    snapB `shouldBe` []
+                    snapC <- snapshotAt idx addrC
+                    snapC `shouldBe` []
+
+            it
+                "always processes UtxoSpend on a stored\
+                \ entry — the entry disappears from the\
+                \ snapshot"
+                $ withInMemoryIndexer
+                $ \idx -> do
+                    let set = Set.fromList [addrA]
+                    applyAtSlot
+                        idx
+                        (SlotNo 10)
+                        blk1
+                        ( filterBlockOps
+                            (IndexAddressSet set)
+                            [UtxoCreate txInA addrA outA]
+                        )
+                    applyAtSlot
+                        idx
+                        (SlotNo 11)
+                        blk2
+                        ( filterBlockOps
+                            (IndexAddressSet set)
+                            [UtxoSpend txInA]
+                        )
+                    snapA <- snapshotAt idx addrA
+                    snapA `shouldBe` []
+
+            it
+                "always processes UtxoSpend on a previously-\
+                \filtered (never stored) entry — no error,\
+                \ other addresses unaffected"
+                $ withInMemoryIndexer
+                $ \idx -> do
+                    let set = Set.fromList [addrA]
+                    applyAtSlot
+                        idx
+                        (SlotNo 10)
+                        blk1
+                        ( filterBlockOps
+                            (IndexAddressSet set)
+                            [ UtxoCreate txInA addrA outA
+                            , UtxoCreate txInB addrB outB
+                            ]
+                        )
+                    -- spend the filtered-out addrB entry —
+                    -- must be a clean no-op.
+                    applyAtSlot
+                        idx
+                        (SlotNo 11)
+                        blk2
+                        ( filterBlockOps
+                            (IndexAddressSet set)
+                            [UtxoSpend txInB]
+                        )
+                    snapA <- snapshotAt idx addrA
+                    snapA `shouldBe` [(txInA, outA)]
+                    snapB <- snapshotAt idx addrB
+                    snapB `shouldBe` []
+
+            it
+                "IndexAll preserves every UtxoCreate\
+                \ regardless of address (current daemon\
+                \ behavior)"
+                $ withInMemoryIndexer
+                $ \idx -> do
+                    let ops =
+                            [ UtxoCreate txInA addrA outA
+                            , UtxoCreate txInB addrB outB
+                            ]
+                    applyAtSlot
+                        idx
+                        (SlotNo 10)
+                        blk1
+                        (filterBlockOps IndexAll ops)
+                    snapA <- snapshotAt idx addrA
+                    snapA `shouldBe` [(txInA, outA)]
+                    snapB <- snapshotAt idx addrB
+                    snapB `shouldBe` [(txInB, outB)]
+
 -- ---------------------------------------------------------------------------
--- Helpers
+-- Helpers + interest-set test fixtures
 
 {- | Test 'ChainSyncConfig' parameterised on the relay
 socket path. Defaults match the existing 'DaemonSpec.testCfg'
@@ -148,4 +271,31 @@ mkCfg sock =
         , csSecurityParamK = 432
         , csReconnectPolicy = defaultReconnectPolicy
         , csProbeConfig = defaultProbeConfig
+        , csInterestSet = IndexAll
         }
+
+-- Three distinct test addresses (1-byte tag plus padding
+-- so they're distinguishable on the wire).
+addrA, addrB, addrC :: Address
+addrA = Address (BS.replicate 29 0xAA)
+addrB = Address (BS.replicate 29 0xBB)
+addrC = Address (BS.replicate 29 0xCC)
+
+-- Three distinct test TxIns at indices 0..2 of three fake
+-- producing transactions.
+txInA, txInB, txInC :: TxIn
+txInA = TxIn (BS.replicate 32 0x01) 0
+txInB = TxIn (BS.replicate 32 0x02) 0
+txInC = TxIn (BS.replicate 32 0x03) 0
+
+-- Three distinct test TxOuts (raw byte tags).
+outA, outB, outC :: TxOut
+outA = TxOut "tag-A"
+outB = TxOut "tag-B"
+outC = TxOut "tag-C"
+
+-- Two distinct block hashes for the two apply-block slots
+-- used across the filter scenarios.
+blk1, blk2 :: BlockHash
+blk1 = BlockHash (BS.replicate 32 0xF1)
+blk2 = BlockHash (BS.replicate 32 0xF2)


### PR DESCRIPTION
Resolves #158. Paired with #157 ([#156](https://github.com/lambdasistemi/cardano-node-clients/issues/156)) and downstream [amaru-treasury-tx#242](https://github.com/lambdasistemi/amaru-treasury-tx/issues/242) ([PR #254](https://github.com/lambdasistemi/amaru-treasury-tx/pull/254)).

## Status

**Phase = Bootstrap.** Worktree + gate.sh only. Spec/plan/tasks in issue #158. Implementation arriving via driver+navigator pair dispatch.

## Base

Branched off [`feat/156-with-chain-sync-follower`](https://github.com/lambdasistemi/cardano-node-clients/tree/feat/156-with-chain-sync-follower) at `bb0b8c38`. **Merge order**: #157 first, then this PR after a rebase onto the merged commit.

## Goal

Extend the `ChainSyncConfig` from #157 with an optional `csInterestSet :: InterestSet` field so downstream consumers can run the indexer against a bounded set of addresses instead of the full chain UTxO set.

See [issue #158](https://github.com/lambdasistemi/cardano-node-clients/issues/158) for the proposed signature, filter semantics (apply-time), scope, and TDD shape.

## Downstream coupling

[`amaru-treasury-tx#254`](https://github.com/lambdasistemi/amaru-treasury-tx/pull/254) slice-interest-set-downstream consumes this PR — pins the SRP to the branch tip, plumbs the 5 treasury+swap addresses through `IndexerConfig`. RocksDB volume bounded to interest-set growth instead of full-chain growth.

## Worker pair

Same driver+navigator pair as #157 / atx#242 (panes `%148` / `%149`, persistent across slices per orchestrator preference).