### PR TITLE
fix(utxo-indexer): mainnet cold-boot — #162 + #163 + add mainnet smoke #164

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -21,8 +21,8 @@ repository cardano-haskell-packages
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/chain-follower
-  tag: 371b5930976ac3bb4e8a4ef576d5098d706984ee
-  --sha256: 1rks78zmgmxz5cg4v82vnc6hwib8vrylwk2m7y82iqaymmnskdvf
+  tag: d592a5015f8d7edb2d6022936a67a054dfe5329f
+  --sha256: 1pm2yhsm2zg5nv01aixv6ss21f2ka8ysq6dv2q4mpf9smz0m8g78
 
 source-repository-package
   type: git

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -176,6 +176,7 @@ library utxo-indexer-lib
     , bytestring
     , chain-follower
     , containers
+    , contra-tracer
     , data-default-class
     , dependent-map
     , dependent-sum
@@ -237,6 +238,7 @@ test-suite unit-tests
     , cardano-node-clients:utxo-indexer-lib
     , cardano-slotting
     , cardano-strict-containers
+    , chain-follower
     , containers
     , contra-tracer
     , directory

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -211,6 +211,7 @@ test-suite unit-tests
     Cardano.Node.Client.UTxOIndexer.DaemonSpec
     Cardano.Node.Client.UTxOIndexer.FollowerSpec
     Cardano.Node.Client.UTxOIndexer.IndexerSpec
+    Cardano.Node.Client.UTxOIndexer.MainnetSmokeSpec
     Cardano.Node.Client.UTxOIndexer.PersistenceSpec
     Cardano.Node.Client.UTxOIndexer.ServerSpec
     Cardano.Node.Client.UTxOIndexer.TypesSpec
@@ -237,6 +238,7 @@ test-suite unit-tests
     , cardano-slotting
     , cardano-strict-containers
     , containers
+    , contra-tracer
     , directory
     , filepath
     , hspec

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -75,6 +75,7 @@ library
     , bytestring
     , cardano-binary
     , cardano-crypto-class
+    , cardano-crypto-wrapper
     , cardano-diffusion
     , cardano-diffusion:protocols
     , cardano-ledger-allegra
@@ -209,6 +210,7 @@ test-suite unit-tests
     Cardano.Node.Client.ConwayFixtures
     Cardano.Node.Client.N2C.ProbeSpec
     Cardano.Node.Client.N2C.TraceSpec
+    Cardano.Node.Client.UTxOIndexer.BlockExtractSpec
     Cardano.Node.Client.UTxOIndexer.DaemonSpec
     Cardano.Node.Client.UTxOIndexer.FollowerSpec
     Cardano.Node.Client.UTxOIndexer.IndexerSpec
@@ -226,11 +228,13 @@ test-suite unit-tests
     , base16-bytestring
     , bytestring
     , cardano-crypto-class
+    , cardano-crypto-wrapper
     , cardano-data
     , cardano-ledger-allegra
     , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-binary
+    , cardano-ledger-byron
     , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-mary
@@ -247,6 +251,7 @@ test-suite unit-tests
     , microlens
     , network
     , ouroboros-consensus
+    , ouroboros-consensus:cardano
     , ouroboros-network:api
     , plutus-core
     , QuickCheck

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Columns.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Columns.hs
@@ -19,16 +19,17 @@ Three columns:
   @lenByte || address || txId || ix@ so a cursor seek to
   @lenByte || address@ yields every UTxO at that address
   with its full 'TxOut' inline (no second-stage lookup).
-* 'RollbackCol' :: @KV SlotNo ('RollbackPoint' 'UtxoOp'
+* 'RollbackCol' :: @KV SlotNo ('RollbackPoint' ['UtxoOp']
   'BlockHash')@ — slot-tagged inverse-op log used to
   undo apply-block writes on a chain-sync rollback.
   Keyed by 'SlotNo' (8-byte BE) so cursor ordering
   matches numeric slot ordering. The value uses
   @chain-follower@'s canonical 'RollbackPoint' shape —
-  @rpInverses@ holds the reverse-ordered op list to
-  replay, @rpMeta@ holds the block hash so a startup
-  can read the latest entry to derive the resume
-  @Point@ without a separate tip column.
+  @rpInverses@ holds block-level inverse batches. Normal
+  following rows keep one batch plus the block hash in
+  @rpMeta@ so a startup can derive resume @Point@s;
+  restoration rows are sentinels with @rpInverses = []@
+  and @rpMeta = Nothing@.
 
 Both the in-memory and RocksDB backends share these
 column definitions verbatim — the column choice happens
@@ -92,13 +93,13 @@ data Cols c where
     -- pairs directly.
     AddressIndex :: Cols (KV AddrKey TxOut)
     -- | Rollback log: 'SlotNo' →
-    -- @'RollbackPoint' 'UtxoOp' 'BlockHash'@. Uses
+    -- @'RollbackPoint' ['UtxoOp'] 'BlockHash'@. Uses
     -- @chain-follower@'s canonical shape: @rpInverses@
-    -- is the reverse-ordered op list (already in apply
-    -- order on rollback), @rpMeta@ holds the block hash
-    -- so a future startup can recover the resume
-    -- @Point@ from the latest entry.
-    RollbackCol :: Cols (KV SlotNo (RollbackPoint UtxoOp BlockHash))
+    -- stores block-level inverse batches (each already in
+    -- apply order on rollback). Following rows keep one
+    -- batch plus the block hash in @rpMeta@; restoration
+    -- rows are sentinels with @rpMeta = Nothing@.
+    RollbackCol :: Cols (KV SlotNo (RollbackPoint [UtxoOp] BlockHash))
     -- | Observation index: every live (i.e. created and
     -- not yet spent) 'TxIn' carries the @('SlotNo',
     -- 'BlockHash')@ of the block that created it. Used
@@ -155,14 +156,16 @@ observationColCodecs =
         , valueCodec = observationPrism
         }
 
-{- | Codecs for the rollback-log column. The on-disk
-value is @blockHashLen(4 BE) || blockHash || ops@ where
-@ops@ uses the stable hand-rolled form (see 'encodeOps').
-Decoded into @chain-follower@'s 'RollbackPoint' shape so
-the @Rollbacks.*@ library functions accept it directly.
+{- | Codecs for the rollback-log column. Following rows use
+@blockHashLen(4 BE) || blockHash || ops@ where @ops@ uses
+the stable hand-rolled form (see 'encodeOps'). Restoration
+sentinels use @0xffffffff || ops@, with @ops@ normally
+empty. Decoded into @chain-follower@'s 'RollbackPoint'
+shape so the @Rollbacks.*@ library functions accept it
+directly.
 -}
 rollbackCodecs ::
-    Codecs (KV SlotNo (RollbackPoint UtxoOp BlockHash))
+    Codecs (KV SlotNo (RollbackPoint [UtxoOp] BlockHash))
 rollbackCodecs =
     Codecs
         { keyCodec = slotPrism
@@ -200,33 +203,52 @@ slotPrism :: Prism' ByteString SlotNo
 slotPrism = prism' slotToBytes slotFromBytes
 
 {- | Codec for the rollback entry. On-disk shape stays
-@blockHashLen(4 BE) || blockHash || encodeOps@; we just
-wrap/unwrap @chain-follower@'s 'RollbackPoint'. The
-'BlockHash' lives in @rpMeta@ as @Just bh@ — the indexer
-always records a hash, so we never produce or accept
-@Nothing@ on disk.
+@blockHashLen(4 BE) || blockHash || encodeOps@ for normal
+following rows. Restoration rows use a reserved length word
+(@0xffffffff@) followed by @encodeOps@ and decode as
+@rpMeta = Nothing@.
 -}
 rollbackEntryPrism ::
-    Prism' ByteString (RollbackPoint UtxoOp BlockHash)
+    Prism' ByteString (RollbackPoint [UtxoOp] BlockHash)
 rollbackEntryPrism = prism' encode decode
   where
     encode RollbackPoint{rpInverses, rpMeta} =
         case rpMeta of
             Just (BlockHash bh) ->
-                lenPrefixed bh <> encodeOps rpInverses
+                lenPrefixed bh <> encodeOps (flattenBatches rpInverses)
             Nothing ->
-                error
-                    "rollbackEntryPrism: encountered \
-                    \RollbackPoint with rpMeta = Nothing; \
-                    \indexer always records a block hash."
+                noMetadataPrefix <> encodeOps (flattenBatches rpInverses)
     decode bs0 = do
-        (bhBs, rest) <- readLenPrefixed bs0
-        ops <- decodeOps rest
-        Just
-            RollbackPoint
-                { rpInverses = ops
-                , rpMeta = Just (BlockHash bhBs)
-                }
+        (n, rest0) <- readWord32 bs0
+        if n == noMetadataMarker
+            then do
+                ops <- decodeOps rest0
+                Just
+                    RollbackPoint
+                        { rpInverses = toBatches ops
+                        , rpMeta = Nothing
+                        }
+            else do
+                (bhBs, rest1) <- readFixedLen n rest0
+                ops <- decodeOps rest1
+                Just
+                    RollbackPoint
+                        { rpInverses = [ops]
+                        , rpMeta = Just (BlockHash bhBs)
+                        }
+
+flattenBatches :: [[UtxoOp]] -> [UtxoOp]
+flattenBatches = concat
+
+toBatches :: [UtxoOp] -> [[UtxoOp]]
+toBatches [] = []
+toBatches ops = [ops]
+
+noMetadataMarker :: Word32
+noMetadataMarker = maxBound
+
+noMetadataPrefix :: ByteString
+noMetadataPrefix = word32BE noMetadataMarker
 
 {- | Codec for the @('SlotNo', 'BlockHash')@ observation
 entry: @slotBytes(8 BE) || blockHashLen(4 BE) || blockHash@.
@@ -313,10 +335,14 @@ splitFixed n bs
 readLenPrefixed :: ByteString -> Maybe (ByteString, ByteString)
 readLenPrefixed bs0 = do
     (n, rest0) <- readWord32 bs0
+    readFixedLen n rest0
+
+readFixedLen :: Word32 -> ByteString -> Maybe (ByteString, ByteString)
+readFixedLen n bs =
     let len = fromIntegral n
-    if BS.length rest0 < len
-        then Nothing
-        else Just (BS.splitAt len rest0)
+     in if BS.length bs < len
+            then Nothing
+            else Just (BS.splitAt len bs)
 
 readWord32 :: ByteString -> Maybe (Word32, ByteString)
 readWord32 bs

--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+
 {- |
 Module      : Cardano.Node.Client.UTxOIndexer.Indexer
 Description : Address->UTxO indexer state and read API
@@ -12,6 +16,10 @@ exposes the operations the rest of the daemon needs:
   in one transaction, atomically records the inverse list
   in the rollback column, and wakes up any registered
   waiters whose 'TxIn' was just created.
+* 'newFollowerState' and 'processFollowerBlock' expose an
+  opaque chain-follower 'Runner.processBlock' wrapper for
+  restoration/cold-sync phases without leaking the
+  database runner type.
 * 'rollbackTo' replays the inverse-op log for every slot
   strictly greater than the target. Awaiters whose
   observed 'TxIn' gets rolled back stay closed (the
@@ -44,6 +52,7 @@ swap.
 module Cardano.Node.Client.UTxOIndexer.Indexer (
     -- * Indexer handle
     IndexerHandle (..),
+    IndexerFollowerState,
     withInMemoryIndexer,
     withRocksDBIndexer,
 
@@ -69,14 +78,19 @@ import Cardano.Node.Client.UTxOIndexer.Types (
     AddrKey (..),
     Address (..),
     BlockHash (..),
-    SlotNo,
+    SlotNo (..),
     TxIn (..),
     TxOut,
+ )
+import ChainFollower.Backend (
+    Following (..),
+    Restoring (..),
  )
 import ChainFollower.Rollbacks.Store qualified as Rollbacks
 import ChainFollower.Rollbacks.Types (
     RollbackPoint (..),
  )
+import ChainFollower.Runner qualified as Runner
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race)
 import Control.Concurrent.STM (
@@ -94,6 +108,8 @@ import Control.Concurrent.STM (
     writeTVar,
  )
 import Control.Exception (Exception, throwIO)
+import Control.Monad (when)
+import Control.Tracer (nullTracer)
 import Data.ByteString qualified as BS
 import Data.Default.Class (def)
 import Data.Dependent.Map (DMap)
@@ -107,6 +123,7 @@ import Data.IORef (
 import Data.List.SampleFibonacci (sampleAtFibonacciIntervals)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Maybe (isJust)
 import Database.KV.Cursor (
     Cursor,
     Entry (..),
@@ -169,6 +186,41 @@ data AwaitObservation = AwaitObservation
     }
     deriving stock (Eq, Show)
 
+type IndexerTx cf op =
+    Transaction IO cf Cols op
+
+data IndexerBlock = IndexerBlock !SlotNo !BlockHash ![UtxoOp]
+
+type IndexerRunnerPhase cf op =
+    Runner.Phase
+        IO
+        cf
+        Cols
+        op
+        IndexerBlock
+        [UtxoOp]
+        BlockHash
+
+{- | Opaque chain-follower phase state for the UTxO
+indexer. It packages the concrete @kv-transactions@
+runner type with the current 'Runner.Phase' so
+'withChainSyncFollower' can thread phase state through
+roll-forward continuations without exposing backend
+internals to downstream consumers.
+-}
+data IndexerFollowerState where
+    IndexerFollowerState ::
+        { ifsRunTransaction ::
+            forall a.
+            IndexerTx cf op a ->
+            IO a
+        , ifsWaiters :: !Waiters
+        , ifsObserved :: !Observed
+        , ifsCount :: !(TVar Int)
+        , ifsPhase :: !(IndexerRunnerPhase cf op)
+        } ->
+        IndexerFollowerState
+
 {- | Operations the rest of the daemon performs against
 the indexer state.
 -}
@@ -195,6 +247,32 @@ data IndexerHandle = IndexerHandle
     -- ^ Roll the index back to the given slot by
     -- replaying inverse-op lists for every slot
     -- @> target@, in descending slot order.
+    , newFollowerState :: Bool -> IO IndexerFollowerState
+    -- ^ Build an opaque chain-follower phase state for
+    -- 'processFollowerBlock'. Pass 'True' to start in
+    -- restoration mode when the rollback log contains no
+    -- following rows; pass 'False' for always-following
+    -- behavior.
+    , processFollowerBlock ::
+        IndexerFollowerState ->
+        Int ->
+        Bool ->
+        SlotNo ->
+        BlockHash ->
+        [UtxoOp] ->
+        IO (IndexerFollowerState, Bool)
+    -- ^ Process one non-EBB block through
+    -- 'ChainFollower.Runner.processBlock'. The 'Bool'
+    -- argument is the Runner's within-stability-window
+    -- signal: 'False' keeps restoration active, 'True'
+    -- transitions to or stays in following. The returned
+    -- 'Bool' is 'True' when the block was processed.
+    , rollbackFollowerState ::
+        IndexerFollowerState ->
+        SlotNo ->
+        IO IndexerFollowerState
+    -- ^ Roll back the persistent indexer and update the
+    -- opaque chain-follower phase count.
     , pruneRollbacks :: Int -> IO Int
     -- ^ Keep at most @maxKeep@ rollback-log entries
     -- (the most-recent ones); drop the oldest. Returns
@@ -230,6 +308,14 @@ data IndexerHandle = IndexerHandle
     -- thinning keeps the candidate list log-sized in
     -- @k@ instead of linear: dense near the tip, sparse
     -- deep in the past.
+    , getRollbackHistory ::
+        IO [(SlotNo, RollbackPoint [UtxoOp] BlockHash)]
+    -- ^ Read the raw rollback-log history oldest-to-newest.
+    -- Restoration-phase sentinel rows have
+    -- @rpInverses = []@ and @rpMeta = Nothing@; following
+    -- rows carry one inverse-operation batch and block hash
+    -- metadata. Primarily intended for diagnostics and
+    -- focused tests.
     }
 
 {- | Open an in-memory indexer, run the action with the
@@ -376,6 +462,16 @@ mkHandle
                 atomically $ do
                     modifyTVar' countVar (subtract deleted)
                     pruneObservedAfter observedVar slot
+            , newFollowerState =
+                newIndexerFollowerState
+                    runTransaction
+                    waitersVar
+                    observedVar
+                    countVar
+            , processFollowerBlock =
+                processIndexerFollowerBlock
+            , rollbackFollowerState =
+                rollbackIndexerFollowerState
             , pruneRollbacks = \maxKeep -> do
                 count <- readTVarIO countVar
                 deleted <-
@@ -403,6 +499,9 @@ mkHandle
                             ]
                 ref <- newIORef pairs
                 sampleAtFibonacciIntervals (popFront ref)
+            , getRollbackHistory =
+                runTransaction
+                    (Rollbacks.queryHistory RollbackCol)
             }
 
 {- | Internal: outcome of the apply transaction. Private
@@ -414,6 +513,192 @@ data ApplyResult
     = Applied
     | AlreadyApplied
     | Conflict !BlockHash !BlockHash
+
+newIndexerFollowerState ::
+    (forall a. IndexerTx cf op a -> IO a) ->
+    Waiters ->
+    Observed ->
+    TVar Int ->
+    Bool ->
+    IO IndexerFollowerState
+newIndexerFollowerState
+    runTransaction
+    waitersVar
+    observedVar
+    countVar
+    startRestoring = do
+        history <- runTransaction (Rollbacks.queryHistory RollbackCol)
+        count <- readTVarIO countVar
+        let hasFollowingRows =
+                any (isJust . rpMeta . snd) history
+            restoring = indexerRestoring
+            phase
+                | startRestoring && not hasFollowingRows =
+                    Runner.InRestoration restoring
+                | otherwise =
+                    Runner.InFollowing count indexerFollowing
+        pure
+            IndexerFollowerState
+                { ifsRunTransaction = runTransaction
+                , ifsWaiters = waitersVar
+                , ifsObserved = observedVar
+                , ifsCount = countVar
+                , ifsPhase = phase
+                }
+
+processIndexerFollowerBlock ::
+    IndexerFollowerState ->
+    Int ->
+    Bool ->
+    SlotNo ->
+    BlockHash ->
+    [UtxoOp] ->
+    IO (IndexerFollowerState, Bool)
+processIndexerFollowerBlock
+    IndexerFollowerState
+        { ifsRunTransaction = runTransaction
+        , ifsWaiters = waitersVar
+        , ifsObserved = observedVar
+        , ifsCount = countVar
+        , ifsPhase = phase
+        }
+    securityParam
+    withinStabilityWindow
+    slot
+    bh
+    ops = do
+        phase' <-
+            Runner.processBlock
+                nullTracer
+                withinStabilityWindow
+                runTransaction
+                RollbackCol
+                securityParam
+                slot
+                (IndexerBlock slot bh ops)
+                phase
+        atomically $
+            syncRunnerCount countVar phase phase'
+        when (blockWasFollowed phase withinStabilityWindow) $
+            atomically $
+                fireWaiters
+                    waitersVar
+                    observedVar
+                    slot
+                    bh
+                    ops
+        pure
+            ( IndexerFollowerState
+                { ifsRunTransaction = runTransaction
+                , ifsWaiters = waitersVar
+                , ifsObserved = observedVar
+                , ifsCount = countVar
+                , ifsPhase = phase'
+                }
+            , True
+            )
+
+rollbackIndexerFollowerState ::
+    IndexerFollowerState ->
+    SlotNo ->
+    IO IndexerFollowerState
+rollbackIndexerFollowerState
+    IndexerFollowerState
+        { ifsRunTransaction = runTransaction
+        , ifsWaiters = waitersVar
+        , ifsObserved = observedVar
+        , ifsCount = countVar
+        , ifsPhase = phase
+        }
+    slot = do
+        deleted <- runTransaction (rollbackToSlot slot)
+        let phase' = reducePhaseCount deleted phase
+        atomically $ do
+            modifyTVar' countVar (subtract deleted)
+            pruneObservedAfter observedVar slot
+        pure
+            IndexerFollowerState
+                { ifsRunTransaction = runTransaction
+                , ifsWaiters = waitersVar
+                , ifsObserved = observedVar
+                , ifsCount = countVar
+                , ifsPhase = phase'
+                }
+
+blockWasFollowed ::
+    IndexerRunnerPhase cf op ->
+    Bool ->
+    Bool
+blockWasFollowed (Runner.InFollowing _ _) _ = True
+blockWasFollowed (Runner.InRestoration _) withinStabilityWindow =
+    withinStabilityWindow
+
+syncRunnerCount ::
+    TVar Int ->
+    IndexerRunnerPhase cf op ->
+    IndexerRunnerPhase cf op ->
+    STM ()
+syncRunnerCount countVar oldPhase newPhase =
+    case newPhase of
+        Runner.InRestoration _ ->
+            case oldPhase of
+                Runner.InRestoration _ ->
+                    modifyTVar' countVar (+ 1)
+                Runner.InFollowing _ _ ->
+                    writeTVar countVar 0
+        Runner.InFollowing n _ ->
+            writeTVar countVar n
+
+reducePhaseCount ::
+    Int ->
+    IndexerRunnerPhase cf op ->
+    IndexerRunnerPhase cf op
+reducePhaseCount deleted = \case
+    Runner.InRestoration restoring ->
+        Runner.InRestoration restoring
+    Runner.InFollowing n following ->
+        Runner.InFollowing (max 0 (n - deleted)) following
+
+indexerRestoring ::
+    Restoring IO (IndexerTx cf op) IndexerBlock [UtxoOp] BlockHash
+indexerRestoring = restoring
+  where
+    restoring =
+        Restoring
+            { restore = \(IndexerBlock slot bh ops) -> do
+                applyOpsOnly slot bh ops
+                pure restoring
+            , toFollowing = pure indexerFollowing
+            }
+
+indexerFollowing ::
+    Following IO (IndexerTx cf op) IndexerBlock [UtxoOp] BlockHash
+indexerFollowing = following
+  where
+    following =
+        Following
+            { follow = followBlock
+            , toRestoring = pure indexerRestoring
+            , applyInverse =
+                traverse_
+                    (applyOne (SlotNo 0) (BlockHash mempty))
+            }
+    followBlock (IndexerBlock slot bh ops) = do
+        inverses <- traverse step ops
+        pure (reverse inverses, Just bh, following)
+      where
+        step op = do
+            inv <- inverseOf op
+            applyOpsOnly slot bh [op]
+            pure inv
+
+applyOpsOnly ::
+    SlotNo ->
+    BlockHash ->
+    [UtxoOp] ->
+    Transaction IO cf Cols op ()
+applyOpsOnly slot bh =
+    traverse_ (applyOne slot bh)
 
 {- | Within one transaction: decide whether @slot@ has
 already been applied.
@@ -481,12 +766,11 @@ applyAndLog slot bh ops = do
                         | otherwise ->
                             pure (Conflict existingBh bh)
                     Just RollbackPoint{rpMeta = Nothing} ->
-                        -- Indexer always records rpMeta = Just bh;
-                        -- a Nothing here is a corruption / schema
-                        -- drift signal, not a normal state.
-                        error
-                            "applyAndLog: RollbackPoint with rpMeta \
-                            \= Nothing — schema drift"
+                        -- Restoration sentinels carry no block
+                        -- hash. The slot is at-or-below the
+                        -- rollback-log tip, so treat it as a
+                        -- skipped/already-processed block.
+                        pure AlreadyApplied
   where
     applyFresh = do
         inverses <- traverse step ops
@@ -494,13 +778,13 @@ applyAndLog slot bh ops = do
             RollbackCol
             slot
             RollbackPoint
-                { rpInverses = reverse inverses
+                { rpInverses = [reverse inverses]
                 , rpMeta = Just bh
                 }
         pure Applied
     step op = do
         inv <- inverseOf op
-        applyOne slot bh op
+        applyOpsOnly slot bh [op]
         pure inv
 
 {- | After @applyAndLog@ commits, walk the ops and:
@@ -657,12 +941,18 @@ rollbackToSlot target = do
     -- after a rollback returns the rollback slot for restored
     -- UTxOs. The TxOut is still correct, which is what
     -- consumers actually care about.
-    undoSlot (slot, bh, invs) = do
-        traverse_ (applyOne slot bh) invs
+    undoSlot (slot, Just bh, invBatches) = do
+        traverse_ (traverse_ (applyOne slot bh)) invBatches
         delete RollbackCol slot
+    undoSlot (slot, Nothing, []) =
+        delete RollbackCol slot
+    undoSlot (_slot, Nothing, _ : _) =
+        error
+            "rollbackToSlot: sentinel RollbackPoint carries \
+            \inverse operations — schema drift"
 
 {- | Cursor program: from 'lastEntry' walk backwards,
-collecting @(slot, blockHash, invs)@ triples while
+collecting @(slot, metadata, invs)@ triples while
 @slot > target@. Returns them in descending-slot order.
 -}
 collectGreaterThan ::
@@ -670,23 +960,16 @@ collectGreaterThan ::
     SlotNo ->
     Cursor
         m
-        (KV SlotNo (RollbackPoint UtxoOp BlockHash))
-        [(SlotNo, BlockHash, [UtxoOp])]
+        (KV SlotNo (RollbackPoint [UtxoOp] BlockHash))
+        [(SlotNo, Maybe BlockHash, [[UtxoOp]])]
 collectGreaterThan target =
     lastEntry >>= go []
   where
     go acc Nothing = pure (reverse acc)
     go acc (Just Entry{entryKey = slot, entryValue = rp})
         | slot > target =
-            let bh = case rpMeta rp of
-                    Just b -> b
-                    Nothing ->
-                        error
-                            "collectGreaterThan: \
-                            \RollbackPoint with rpMeta \
-                            \= Nothing — schema drift"
-                invs = rpInverses rp
-             in prevEntry >>= go ((slot, bh, invs) : acc)
+            let invs = rpInverses rp
+             in prevEntry >>= go ((slot, rpMeta rp, invs) : acc)
         | otherwise = pure (reverse acc)
 
 -- | Inverse of a single op against current state.

--- a/lib/Cardano/Node/Client/UTxOIndexer/BlockExtract.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/BlockExtract.hs
@@ -16,20 +16,25 @@ goes through (e.g. @SafeHash@ → @Hashes@,
 @Cardano.Ledger.Shelley.BlockBody@, @txid@ → @txIdTx@,
 @Tx era@ → @Tx l era@, @TxId c@ → @TxId@) — they all
 live below 'cardano-ledger-read''s API surface.
-
-Byron support is stubbed (returns @[]@). Devnet
-workloads post-date the Byron→Shelley hard fork; if a
-consumer ever needs Byron data, the stub is the obvious
-place to wire it in.
 -}
 module Cardano.Node.Client.UTxOIndexer.BlockExtract (
     extractBlock,
 ) where
 
-import Cardano.Crypto.Hash.Class (hashToBytes)
-import Cardano.Ledger.Address (serialiseAddr)
+import Cardano.Chain.Common (unsafeGetLovelace)
+import Cardano.Chain.UTxO qualified as ByronUTxO
+import Cardano.Crypto.Hash.Class (Hash (..), hashToBytes)
+import Cardano.Crypto.Hashing (abstractHashToShort)
+import Cardano.Ledger.Address (
+    Addr (..),
+    BootstrapAddress (..),
+    serialiseAddr,
+ )
+import Cardano.Ledger.Api.Tx.Out (mkBasicTxOut)
 import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.Binary (serialize')
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core (
     EraTx,
     EraTxBody,
@@ -43,8 +48,9 @@ import Cardano.Ledger.Core (
     txIdTxBody,
  )
 import Cardano.Ledger.Core qualified as Ledger
-import Cardano.Ledger.Hashes (extractHash)
+import Cardano.Ledger.Hashes (extractHash, unsafeMakeSafeHash)
 import Cardano.Ledger.TxIn qualified as SH
+import Cardano.Ledger.Val (inject)
 import Cardano.Node.Client.Types (Block)
 import Cardano.Node.Client.UTxOIndexer.IndexerOp (UtxoOp (..))
 import Cardano.Node.Client.UTxOIndexer.Types (
@@ -57,6 +63,7 @@ import Cardano.Read.Ledger.Block.Block (fromConsensusBlock)
 import Cardano.Read.Ledger.Block.Txs (getEraTransactions)
 import Cardano.Read.Ledger.Eras.EraValue (applyEraFun)
 import Cardano.Read.Ledger.Eras.KnownEras (
+    Byron,
     Era (..),
     IsEra,
     theEra,
@@ -65,7 +72,10 @@ import Cardano.Read.Ledger.Eras.KnownEras (
 -- Era pattern aliases are exported via 'Era (..)' above; the
 -- 'Dijkstra' case in 'changes' below requires this re-export
 -- pattern match to be exhaustive.
+import Cardano.Read.Ledger.Tx.Inputs (Inputs (..), getEraInputs)
+import Cardano.Read.Ledger.Tx.Outputs (Outputs (..), getEraOutputs)
 import Cardano.Read.Ledger.Tx.Tx (Tx (..))
+import Cardano.Read.Ledger.Tx.TxId (TxId (..), getEraTxId)
 import Data.ByteString (ByteString)
 import Data.Foldable (toList)
 import Data.Word (Word16)
@@ -99,16 +109,15 @@ blockSlot blk =
         Network.Point.Origin -> SlotNo 0
         Network.Point.At s -> SlotNo (Network.unSlotNo s)
 
-{- | UTxO ops produced by a single era's tx list. Byron
-returns @[]@ — pre-Shelley blocks are not exercised by
-current workloads. Each Shelley-family branch narrows
+{- | UTxO ops produced by a single era's tx list. Each
+Shelley-family branch narrows
 @TxT era ~ Core.Tx Core.TopTx era@ so the
 @bodyTxL@/@inputsTxBodyL@/@outputsTxBodyL@ lenses
 become applicable.
 -}
 changes :: forall era. (IsEra era) => [Tx era] -> [UtxoOp]
 changes txs = case theEra @era of
-    Byron -> []
+    Byron -> concatMap byronTxChanges txs
     Shelley -> concatMap (shelleyTxChanges . unTx) txs
     Allegra -> concatMap (shelleyTxChanges . unTx) txs
     Mary -> concatMap (shelleyTxChanges . unTx) txs
@@ -116,6 +125,26 @@ changes txs = case theEra @era of
     Babbage -> concatMap (shelleyTxChanges . unTx) txs
     Conway -> concatMap (shelleyTxChanges . unTx) txs
     Dijkstra -> concatMap (shelleyTxChanges . unTx) txs
+
+{- | Convert a Byron transaction into @UtxoOp@s.
+
+Byron tx ids are raw Blake2b_256 hashes wrapped by
+@cardano-chain@. We re-wrap them as Shelley 'SH.TxId'
+only to reuse the same 32-byte storage representation as
+Shelley-family inputs and created outputs.
+-}
+byronTxChanges :: Tx Byron -> [UtxoOp]
+byronTxChanges tx =
+    let tid = byronTxIdBytes (unTxId (getEraTxId tx))
+        Inputs ins = getEraInputs tx
+        Outputs outs = getEraOutputs tx
+        spends = UtxoSpend . byronTxInToIndexer <$> toList ins
+        creates =
+            zipWith
+                (mkByronCreate tid)
+                [0 ..]
+                (toList outs)
+     in spends <> creates
 
 {- | Convert a Shelley-family @'Core.Tx' TopTx era@ into a
 list of @UtxoOp@s.
@@ -144,14 +173,27 @@ shelleyTxChanges tx =
 txBodyIdBytes ::
     forall era. (EraTxBody era) => Ledger.TxBody TopTx era -> ByteString
 txBodyIdBytes body =
-    case txIdTxBody body of
-        SH.TxId safeHash -> hashToBytes (extractHash safeHash)
+    shelleyTxIdBytes (txIdTxBody body)
+
+byronTxIdBytes :: ByronUTxO.TxId -> ByteString
+byronTxIdBytes = shelleyTxIdBytes . byronTxIdToShelley
+
+shelleyTxIdBytes :: SH.TxId -> ByteString
+shelleyTxIdBytes (SH.TxId safeHash) =
+    hashToBytes (extractHash safeHash)
 
 shelleyTxInToIndexer :: SH.TxIn -> TxIn
-shelleyTxInToIndexer (SH.TxIn (SH.TxId safeHash) (TxIx ix)) =
+shelleyTxInToIndexer (SH.TxIn txId (TxIx ix)) =
     TxIn
-        { txInId = hashToBytes (extractHash safeHash)
+        { txInId = shelleyTxIdBytes txId
         , txInIx = fromIntegral ix
+        }
+
+byronTxInToIndexer :: ByronUTxO.TxIn -> TxIn
+byronTxInToIndexer (ByronUTxO.TxInUtxo txId ix) =
+    TxIn
+        { txInId = byronTxIdBytes txId
+        , txInIx = ix
         }
 
 mkCreate ::
@@ -168,3 +210,44 @@ mkCreate tid ix out =
         TxIn{txInId = tid, txInIx = ix}
         (Address (serialiseAddr (out ^. addrTxOutL)))
         (TxOut (serialize' (eraProtVerLow @era) out))
+
+mkByronCreate ::
+    -- | producing tx id (32 raw bytes)
+    ByteString ->
+    -- | output index
+    Word16 ->
+    ByronUTxO.TxOut ->
+    UtxoOp
+mkByronCreate tid ix out =
+    UtxoCreate
+        TxIn{txInId = tid, txInIx = ix}
+        (byronTxOutAddress out)
+        ( TxOut
+            ( serialize'
+                (eraProtVerLow @ConwayEra)
+                (fromByronOutput out)
+            )
+        )
+
+byronTxOutAddress :: ByronUTxO.TxOut -> Address
+byronTxOutAddress (ByronUTxO.TxOut addr _lovelace) =
+    Address (serialiseAddr (AddrBootstrap (BootstrapAddress addr)))
+
+{- | Convert a Byron 'ByronUTxO.TxOut' to the Conway-era
+@TxOut@ shape consumed by downstream indexer readers.
+-}
+fromByronOutput :: ByronUTxO.TxOut -> Ledger.TxOut ConwayEra
+fromByronOutput (ByronUTxO.TxOut addr lovelace) =
+    mkBasicTxOut @ConwayEra
+        (AddrBootstrap (BootstrapAddress addr))
+        (inject $ Coin $ toInteger $ unsafeGetLovelace lovelace)
+
+{- | Convert a Byron TxId to a Shelley TxId.
+
+This mirrors cardano-utxo-csmt: extract the underlying
+32-byte Blake2b_256 hash and re-wrap it as a Shelley safe
+hash so both eras feed the indexer the same tx-id bytes.
+-}
+byronTxIdToShelley :: ByronUTxO.TxId -> SH.TxId
+byronTxIdToShelley =
+    SH.TxId . unsafeMakeSafeHash . UnsafeHash . abstractHashToShort

--- a/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
@@ -54,7 +54,7 @@ import Cardano.Node.Client.UTxOIndexer.Types (
  )
 import Control.Concurrent.STM (atomically)
 import Control.Exception (onException)
-import Control.Tracer (Tracer, traceWith)
+import Control.Tracer (Tracer, nullTracer, traceWith)
 import Data.Word (Word32, Word64)
 import Ouroboros.Network.Magic (NetworkMagic (..))
 
@@ -152,6 +152,8 @@ toChainSyncCfg cfg =
           -- a 'ChainSyncConfig' directly with
           -- 'IndexAddressSet' to bound the on-disk store.
           csInterestSet = IndexAll
+        , csBlockTracer = nullTracer
+        , csTipTracer = nullTracer
         }
 
 {- | Derive the bundled daemon's wire-format 'ReadyStatus'

--- a/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
@@ -141,6 +141,7 @@ toChainSyncCfg cfg =
         { csRelaySocket = dcRelaySocket cfg
         , csNetworkMagic = NetworkMagic (dcNetworkMagic cfg)
         , csByronEpochSlots = dcByronEpochSlots cfg
+        , csStartPoint = Nothing
         , csReadyThresholdSlots = dcReadyThresholdSlots cfg
         , csSecurityParamK = dcSecurityParamK cfg
         , csReconnectPolicy = dcReconnectPolicy cfg

--- a/lib/Cardano/Node/Client/UTxOIndexer/Follower.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Follower.hs
@@ -91,6 +91,7 @@ import Cardano.Node.Client.UTxOIndexer.BlockExtract (
     extractBlock,
  )
 import Cardano.Node.Client.UTxOIndexer.Indexer (
+    IndexerFollowerState,
     IndexerHandle (..),
  )
 import Cardano.Node.Client.UTxOIndexer.IndexerOp (
@@ -118,7 +119,7 @@ import Control.Concurrent.STM (
     writeTVar,
  )
 import Control.Exception (SomeException)
-import Control.Monad (void, when)
+import Control.Monad (void)
 import Control.Tracer (Tracer)
 import Data.ByteString.Short qualified as SBS
 import Data.Set (Set)
@@ -576,7 +577,11 @@ mkIntersector bootMode cfg readinessVar idx = self
                 -- retained point intersected because of
                 -- an offline rollback.
                 rollbackTo idx (slotOfPoint point)
-                pure (mkFollower cfg readinessVar idx)
+                followerState <-
+                    newFollowerState
+                        idx
+                        True
+                pure (mkFollower cfg readinessVar idx followerState)
             , intersectNotFound = case bootMode of
                 ColdBoot ->
                     pure
@@ -617,10 +622,11 @@ mkFollower ::
     ChainSyncConfig ->
     TVar Readiness ->
     IndexerHandle ->
+    IndexerFollowerState ->
     Follower HeaderPoint Network.SlotNo Fetched
-mkFollower cfg readinessVar idx = self
+mkFollower cfg readinessVar idx = go
   where
-    self =
+    go followerState =
         Follower
             { rollForward = \fetched tip -> do
                 let (slot, rawOps) =
@@ -634,22 +640,75 @@ mkFollower cfg readinessVar idx = self
                             (fetchedPoint fetched)
                     isEBB =
                         blockToIsEBB (fetchedBlock fetched)
-                applied <- applyBlockOps idx isEBB slot bh ops
-                when applied $
-                    void $
-                        pruneRollbacks
-                            idx
+                    withinWindow =
+                        withinStabilityWindow
                             (csSecurityParamK cfg)
+                            slot
+                            tip
+                (nextFollowerState, _processed) <-
+                    applyBlockOpsWithPhase
+                        cfg
+                        idx
+                        followerState
+                        isEBB
+                        withinWindow
+                        slot
+                        bh
+                        ops
                 updateReadiness readinessVar slot tip
-                pure self
+                pure (go nextFollowerState)
             , rollBackward = \point -> do
                 let slot = case Network.pointSlot point of
                         Network.Point.Origin -> SlotNo 0
                         Network.Point.At s ->
                             SlotNo (Network.unSlotNo s)
-                rollbackTo idx slot
-                pure (Progress self)
+                state' <- rollbackFollowerState idx followerState slot
+                pure (Progress (go state'))
             }
+
+withinStabilityWindow :: Int -> SlotNo -> Network.SlotNo -> Bool
+withinStabilityWindow securityParamK (SlotNo blockSlot) tipSlot =
+    tip >= blockSlot
+        && tip - blockSlot <= fromIntegral (max 0 securityParamK)
+  where
+    tip = Network.unSlotNo tipSlot
+
+{- | Apply a block via the indexer's chain-follower
+Runner wrapper according to the block's distance from
+the upstream tip. Far-from-tip blocks stay in restoration;
+blocks inside the stability window transition to following.
+-}
+applyBlockOpsWithPhase ::
+    ChainSyncConfig ->
+    IndexerHandle ->
+    IndexerFollowerState ->
+    IsEBB ->
+    Bool ->
+    SlotNo ->
+    BlockHash ->
+    [UtxoOp] ->
+    IO (IndexerFollowerState, Bool)
+applyBlockOpsWithPhase
+    cfg
+    idx
+    followerState
+    isEBB
+    withinWindow
+    slot
+    bh
+    ops =
+        case isEBB of
+            IsEBB ->
+                pure (followerState, False)
+            IsNotEBB ->
+                processFollowerBlock
+                    idx
+                    followerState
+                    (csSecurityParamK cfg)
+                    withinWindow
+                    slot
+                    bh
+                    ops
 
 {- | Pull the block hash bytes out of an
 'OneEraHash'-shaped 'HeaderPoint'. Origin (no block) maps

--- a/lib/Cardano/Node/Client/UTxOIndexer/Follower.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Follower.hs
@@ -56,6 +56,7 @@ module Cardano.Node.Client.UTxOIndexer.Follower (
 
     -- * Interest-set filter
     InterestSet (..),
+    applyBlockOps,
     filterBlockOps,
 
     -- * Readiness state
@@ -113,13 +114,19 @@ import Control.Concurrent.STM (
     readTVarIO,
     writeTVar,
  )
-import Control.Monad (void)
+import Control.Monad (void, when)
 import Control.Tracer (Tracer, nullTracer)
 import Data.ByteString.Short qualified as SBS
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Time.Clock (UTCTime, getCurrentTime)
 import Data.Word (Word64)
+import Ouroboros.Consensus.Block.Abstract (
+    blockToIsEBB,
+ )
+import Ouroboros.Consensus.Block.EBB (
+    IsEBB (..),
+ )
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (
     OneEraHash (..),
  )
@@ -231,6 +238,30 @@ filterBlockOps (IndexAddressSet s) = filter (inInterestSet s)
     inInterestSet set op = case op of
         UtxoCreate _ addr _ -> addr `Set.member` set
         UtxoSpend _ -> True
+
+{- | Apply a fetched block's extracted UTxO operations,
+unless the consensus layer identifies it as an Epoch
+Boundary Block. EBBs carry no UTxO operations and may
+share their slot with the following regular Byron block,
+so recording them in the rollback log would create a
+same-slot, different-hash conflict on mainnet cold boot.
+
+Returns 'True' only when the block was persisted via
+'applyAtSlot'.
+-}
+applyBlockOps ::
+    IndexerHandle ->
+    IsEBB ->
+    SlotNo ->
+    BlockHash ->
+    [UtxoOp] ->
+    IO Bool
+applyBlockOps idx isEBB slot bh ops =
+    case isEBB of
+        IsEBB -> pure False
+        IsNotEBB -> do
+            applyAtSlot idx slot bh ops
+            pure True
 
 {- | Live readiness snapshot updated by the follower
 thread after every roll-forward and on every reconnect
@@ -499,11 +530,14 @@ mkFollower cfg readinessVar idx = self
                     bh =
                         pointToBlockHash
                             (fetchedPoint fetched)
-                applyAtSlot idx slot bh ops
-                _ <-
-                    pruneRollbacks
-                        idx
-                        (csSecurityParamK cfg)
+                    isEBB =
+                        blockToIsEBB (fetchedBlock fetched)
+                applied <- applyBlockOps idx isEBB slot bh ops
+                when applied $
+                    void $
+                        pruneRollbacks
+                            idx
+                            (csSecurityParamK cfg)
                 updateReadiness readinessVar slot tip
                 pure self
             , rollBackward = \point -> do

--- a/lib/Cardano/Node/Client/UTxOIndexer/Follower.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Follower.hs
@@ -52,6 +52,7 @@ slice brief's "actual codebase wins" guidance.
 module Cardano.Node.Client.UTxOIndexer.Follower (
     -- * Configuration
     ChainSyncConfig (..),
+    coldBootResumePoints,
 
     -- * Interest-set filter
     InterestSet (..),
@@ -142,6 +143,11 @@ data ChainSyncConfig = ChainSyncConfig
     , csByronEpochSlots :: !Word64
     -- ^ Byron @EpochSlots@, used by the chain-sync codec
     -- to decode pre-Shelley blocks.
+    , csStartPoint :: !(Maybe (SlotNo, BlockHash))
+    -- ^ Optional explicit cold-boot intersection point.
+    -- 'Nothing' preserves the historical Origin boot; a
+    -- concrete @(slot, hash)@ lets callers start from a
+    -- known point instead of replaying from genesis.
     , csReadyThresholdSlots :: !Word64
     -- ^ Slot-lag threshold beyond which @ready@ flips to
     -- @False@. Plumbed through to consumers (the follower
@@ -307,10 +313,7 @@ withChainSyncFollower tracer cfg idx action = do
     let chainSession = do
             bootMode <- detectBootMode idx
             let resumePoints = case bootMode of
-                    ColdBoot ->
-                        [ Network.Point
-                            Network.Point.Origin
-                        ]
+                    ColdBoot -> coldBootResumePoints cfg
                     WarmBoot ps -> fmap toHeaderPoint ps
             runChainSyncN2C
                 (EpochSlots (csByronEpochSlots cfg))
@@ -406,6 +409,17 @@ toHeaderPoint (SlotNo s, BlockHash bh) =
             )
         )
 
+{- | Chain-sync resume points for an empty indexer. With
+no configured start point the follower preserves the
+historical Origin cold boot; with a configured point the
+first intersection request names that concrete block.
+-}
+coldBootResumePoints :: ChainSyncConfig -> [HeaderPoint]
+coldBootResumePoints cfg =
+    case csStartPoint cfg of
+        Nothing -> [Network.Point Network.Point.Origin]
+        Just startPoint -> [toHeaderPoint startPoint]
+
 -- ---------------------------------------------------------------------------
 -- Intersector + per-roll Follower
 
@@ -434,7 +448,7 @@ mkIntersector bootMode cfg readinessVar idx = self
                 ColdBoot ->
                     pure
                         ( self
-                        , [Network.Point Network.Point.Origin]
+                        , coldBootResumePoints cfg
                         )
                 WarmBoot _ ->
                     -- Never origin-replay over a populated

--- a/lib/Cardano/Node/Client/UTxOIndexer/Follower.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Follower.hs
@@ -67,7 +67,9 @@ module Cardano.Node.Client.UTxOIndexer.Follower (
     FollowerHandle (..),
 
     -- * Bring-up
+    ChainSyncRunner,
     withChainSyncFollower,
+    withChainSyncFollowerUsing,
 ) where
 
 import Cardano.Chain.Slotting (EpochSlots (..))
@@ -84,6 +86,7 @@ import Cardano.Node.Client.N2C.Reconnect (
     runReconnectLoop,
  )
 import Cardano.Node.Client.N2C.Trace (N2CEvent)
+import Cardano.Node.Client.Types (Block)
 import Cardano.Node.Client.UTxOIndexer.BlockExtract (
     extractBlock,
  )
@@ -114,8 +117,9 @@ import Control.Concurrent.STM (
     readTVarIO,
     writeTVar,
  )
+import Control.Exception (SomeException)
 import Control.Monad (void, when)
-import Control.Tracer (Tracer, nullTracer)
+import Control.Tracer (Tracer)
 import Data.ByteString.Short qualified as SBS
 import Data.Set (Set)
 import Data.Set qualified as Set
@@ -181,8 +185,40 @@ data ChainSyncConfig = ChainSyncConfig
     -- set; 'UtxoSpend' is always processed (a spend on a
     -- previously-filtered create is a clean no-op
     -- because the 'TxInCol' entry never existed).
+    , csBlockTracer :: !(Tracer IO Block)
+    -- ^ Per-roll-forward block tracer supplied to
+    -- 'mkChainSyncN2C'. Use 'nullTracer' to preserve the
+    -- historical quiet behavior.
+    , csTipTracer :: !(Tracer IO Network.SlotNo)
+    -- ^ Per-roll-forward chain-tip slot tracer supplied
+    -- to 'mkChainSyncN2C'. Use 'nullTracer' to preserve
+    -- the historical quiet behavior.
     }
-    deriving stock (Show)
+
+instance Show ChainSyncConfig where
+    show cfg =
+        "ChainSyncConfig"
+            <> " { csRelaySocket = "
+            <> show (csRelaySocket cfg)
+            <> ", csNetworkMagic = "
+            <> show (csNetworkMagic cfg)
+            <> ", csByronEpochSlots = "
+            <> show (csByronEpochSlots cfg)
+            <> ", csStartPoint = "
+            <> show (csStartPoint cfg)
+            <> ", csReadyThresholdSlots = "
+            <> show (csReadyThresholdSlots cfg)
+            <> ", csSecurityParamK = "
+            <> show (csSecurityParamK cfg)
+            <> ", csReconnectPolicy = "
+            <> show (csReconnectPolicy cfg)
+            <> ", csProbeConfig = "
+            <> show (csProbeConfig cfg)
+            <> ", csInterestSet = "
+            <> show (csInterestSet cfg)
+            <> ", csBlockTracer = <tracer>"
+            <> ", csTipTracer = <tracer>"
+            <> " }"
 
 {- | Address filter applied to each @[UtxoOp]@ batch
 between 'extractBlock' and 'applyAtSlot'.
@@ -320,6 +356,21 @@ data FollowerHandle = FollowerHandle
 -- ---------------------------------------------------------------------------
 -- Bring-up
 
+{- | Transport seam used by 'withChainSyncFollowerUsing'.
+Production code uses 'defaultChainSyncRunner'; tests can
+inject a runner that observes the caller-provided tracers
+without opening a real node socket.
+-}
+type ChainSyncRunner =
+    EpochSlots ->
+    NetworkMagic ->
+    FilePath ->
+    Tracer IO Block ->
+    Tracer IO Network.SlotNo ->
+    Intersector HeaderPoint Network.SlotNo Fetched ->
+    [HeaderPoint] ->
+    IO (Either SomeException ())
+
 {- | Run the chain-sync follower against a caller-owned
 'IndexerHandle' under a reconnect supervisor, and hand
 the resulting 'FollowerHandle' to the action. The follower
@@ -338,7 +389,39 @@ withChainSyncFollower ::
     IndexerHandle ->
     (FollowerHandle -> IO a) ->
     IO a
-withChainSyncFollower tracer cfg idx action = do
+withChainSyncFollower =
+    withChainSyncFollowerCore True defaultChainSyncRunner
+
+{- | Variant of 'withChainSyncFollower' with an injectable
+chain-sync runner. The supplied runner is executed
+directly, without the reconnect supervisor's node-ready
+probe, so unit tests can deterministically verify that
+'csBlockTracer' and 'csTipTracer' are surfaced to the N2C
+chain-sync layer without opening a real node socket.
+-}
+withChainSyncFollowerUsing ::
+    ChainSyncRunner ->
+    -- | Tracer for reconnect-supervisor lifecycle events.
+    Tracer IO N2CEvent ->
+    ChainSyncConfig ->
+    -- | Caller-owned handle the follower writes into.
+    IndexerHandle ->
+    (FollowerHandle -> IO a) ->
+    IO a
+withChainSyncFollowerUsing =
+    withChainSyncFollowerCore False
+
+withChainSyncFollowerCore ::
+    Bool ->
+    ChainSyncRunner ->
+    -- | Tracer for reconnect-supervisor lifecycle events.
+    Tracer IO N2CEvent ->
+    ChainSyncConfig ->
+    -- | Caller-owned handle the follower writes into.
+    IndexerHandle ->
+    (FollowerHandle -> IO a) ->
+    IO a
+withChainSyncFollowerCore supervise chainSyncRunner tracer cfg idx action = do
     now <- getCurrentTime
     readinessVar <- newTVarIO (initialReadiness now)
     let chainSession = do
@@ -346,21 +429,19 @@ withChainSyncFollower tracer cfg idx action = do
             let resumePoints = case bootMode of
                     ColdBoot -> coldBootResumePoints cfg
                     WarmBoot ps -> fmap toHeaderPoint ps
-            runChainSyncN2C
+            chainSyncRunner
                 (EpochSlots (csByronEpochSlots cfg))
                 (csNetworkMagic cfg)
                 (csRelaySocket cfg)
-                ( mkChainSyncN2C
-                    nullTracer
-                    nullTracer
-                    ( mkIntersector
-                        bootMode
-                        cfg
-                        readinessVar
-                        idx
-                    )
-                    resumePoints
+                (csBlockTracer cfg)
+                (csTipTracer cfg)
+                ( mkIntersector
+                    bootMode
+                    cfg
+                    readinessVar
+                    idx
                 )
+                resumePoints
         setUpstreamStatus newStatus = do
             tNow <- getCurrentTime
             atomically $
@@ -379,12 +460,33 @@ withChainSyncFollower tracer cfg idx action = do
                 setUpstreamStatus
                 getProcessedSlot
                 chainSession
-    withAsync (void chainAction) $ \a ->
+        directChainAction =
+            void chainSession
+        followerAction =
+            if supervise
+                then void chainAction
+                else directChainAction
+    withAsync followerAction $ \a ->
         action
             FollowerHandle
                 { fhReadiness = readTVar readinessVar
                 , fhAsync = a
                 }
+
+defaultChainSyncRunner :: ChainSyncRunner
+defaultChainSyncRunner
+    epochSlots
+    magic
+    sock
+    blockTracer
+    tipTracer
+    intersector
+    points =
+        runChainSyncN2C
+            epochSlots
+            magic
+            sock
+            (mkChainSyncN2C blockTracer tipTracer intersector points)
 
 {- | Initial 'Readiness' value at bring-up: no slots
 applied yet, supervisor-reported state is

--- a/test/Cardano/Node/Client/E2E/ChainSyncSpec.hs
+++ b/test/Cardano/Node/Client/E2E/ChainSyncSpec.hs
@@ -237,6 +237,7 @@ mkTestFollower runTx phaseRef blockCountRef transitionVar =
                         tipSlot > 0 && slot >= tipSlot
                 phase' <-
                     processBlock
+                        nullTracer
                         atTip
                         runTx
                         RollbackCol

--- a/test/Cardano/Node/Client/UTxOIndexer/BlockExtractSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/BlockExtractSpec.hs
@@ -1,0 +1,173 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.Node.Client.UTxOIndexer.BlockExtractSpec (spec) where
+
+import Cardano.Chain.Block qualified as ByronBlock
+import Cardano.Chain.Common qualified as ByronCommon
+import Cardano.Chain.Delegation qualified as ByronDelegation
+import Cardano.Chain.Slotting qualified as ByronSlot
+import Cardano.Chain.Ssc qualified as ByronSsc
+import Cardano.Chain.UTxO qualified as ByronUTxO
+import Cardano.Chain.Update qualified as ByronUpdate
+import Cardano.Crypto qualified as ByronCrypto
+import Cardano.Crypto.Hashing qualified as ByronHashing
+import Cardano.Ledger.Address (
+    Addr (..),
+    BootstrapAddress (..),
+    serialiseAddr,
+ )
+import Cardano.Ledger.Api.Tx.Out (mkBasicTxOut)
+import Cardano.Ledger.Binary (serialize')
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core qualified as Ledger
+import Cardano.Ledger.Val (inject)
+import Cardano.Node.Client.Types (Block)
+import Cardano.Node.Client.UTxOIndexer.BlockExtract (extractBlock)
+import Cardano.Node.Client.UTxOIndexer.IndexerOp (UtxoOp (..))
+import Cardano.Node.Client.UTxOIndexer.Types (
+    Address (..),
+    SlotNo (..),
+    TxIn (..),
+    TxOut (..),
+ )
+import Data.ByteString qualified as BS
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Word (Word64)
+import Ouroboros.Consensus.Byron.Ledger qualified as ConsensusByron
+import Ouroboros.Consensus.Cardano.Block qualified as ConsensusCardano
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec =
+    describe "Cardano.Node.Client.UTxOIndexer.BlockExtract" $
+        it "extracts Byron transaction inputs and outputs" $ do
+            let inputTxId =
+                    ByronHashing.unsafeHashFromBytes
+                        (BS.replicate 32 0x11)
+                input = ByronUTxO.TxInUtxo inputTxId 3
+                tx =
+                    ByronUTxO.UnsafeTx
+                        (input :| [])
+                        (byronOutput :| [])
+                        (ByronCommon.mkAttributes ())
+                txAux = ByronUTxO.mkTxAux tx mempty
+                (slot, ops) = extractBlock (byronBlock txAux)
+
+            slot `shouldBe` SlotNo 42
+            ops
+                `shouldBe` [ UtxoSpend
+                                TxIn
+                                    { txInId =
+                                        ByronHashing.hashToBytes inputTxId
+                                    , txInIx = 3
+                                    }
+                           , UtxoCreate
+                                TxIn
+                                    { txInId =
+                                        ByronHashing.hashToBytes
+                                            (ByronHashing.serializeCborHash tx)
+                                    , txInIx = 0
+                                    }
+                                expectedAddress
+                                expectedTxOut
+                           ]
+
+byronBlock :: ByronUTxO.TxAux -> Block
+byronBlock txAux =
+    ConsensusCardano.BlockByron
+        ( ConsensusByron.annotateByronBlock byronEpochSlots $
+            ByronBlock.mkBlockExplicit
+                protocolMagic
+                (ByronUpdate.ProtocolVersion 0 0 0)
+                ( ByronUpdate.SoftwareVersion
+                    (ByronUpdate.ApplicationName "cnc-test")
+                    0
+                )
+                (ByronHashing.unsafeHashFromBytes (BS.replicate 32 0x22))
+                (ByronCommon.ChainDifficulty 1)
+                byronEpochSlots
+                (ByronSlot.SlotNumber 42)
+                delegateSigningKey
+                delegationCertificate
+                (byronBody txAux)
+        )
+
+byronEpochSlots :: ByronSlot.EpochSlots
+byronEpochSlots = ByronSlot.EpochSlots 21_600
+
+protocolMagic :: ByronCrypto.ProtocolMagicId
+protocolMagic = ByronCrypto.ProtocolMagicId 764_824_073
+
+delegationCertificate :: ByronDelegation.Certificate
+delegationCertificate =
+    ByronDelegation.signCertificate
+        protocolMagic
+        delegateVerificationKey
+        0
+        (ByronCrypto.noPassSafeSigner issuerSigningKey)
+
+issuerSigningKey :: ByronCrypto.SigningKey
+issuerSigningKey = snd issuerKeyPair
+
+delegateVerificationKey :: ByronCrypto.VerificationKey
+delegateVerificationKey = fst delegateKeyPair
+
+delegateSigningKey :: ByronCrypto.SigningKey
+delegateSigningKey = snd delegateKeyPair
+
+issuerKeyPair :: (ByronCrypto.VerificationKey, ByronCrypto.SigningKey)
+issuerKeyPair =
+    ByronCrypto.deterministicKeyGen (BS.replicate 32 0xA1)
+
+delegateKeyPair :: (ByronCrypto.VerificationKey, ByronCrypto.SigningKey)
+delegateKeyPair =
+    ByronCrypto.deterministicKeyGen (BS.replicate 32 0xA2)
+
+byronBody :: ByronUTxO.TxAux -> ByronBlock.Body
+byronBody txAux =
+    ByronBlock.Body
+        (ByronUTxO.mkTxPayload [txAux])
+        ByronSsc.SscPayload
+        (ByronDelegation.unsafePayload [])
+        (ByronUpdate.payload Nothing [])
+
+byronOutput :: ByronUTxO.TxOut
+byronOutput = ByronUTxO.TxOut byronAddress lovelace
+
+expectedAddress :: Address
+expectedAddress =
+    Address
+        ( serialiseAddr
+            (AddrBootstrap (BootstrapAddress byronAddress))
+        )
+
+expectedTxOut :: TxOut
+expectedTxOut =
+    TxOut
+        ( serialize'
+            (Ledger.eraProtVerLow @ConwayEra)
+            ( mkBasicTxOut @ConwayEra
+                (AddrBootstrap (BootstrapAddress byronAddress))
+                (inject $ Coin $ toInteger lovelaceValue)
+            )
+        )
+
+byronAddress :: ByronCommon.Address
+byronAddress =
+    either
+        (error . show)
+        id
+        ( ByronCommon.decodeAddressBase58
+            "DdzFFzCqrhsq3KjLtT51mESbZ4RepiHPzLqEhamexVFTJpGbCXmh7qSxnHvaL88QmtVTD1E1sjx8Z1ZNDhYmcBV38ZjDST9kYVxSkhcw"
+        )
+
+lovelace :: ByronCommon.Lovelace
+lovelace =
+    either
+        (error . show)
+        id
+        (ByronCommon.mkLovelace lovelaceValue)
+
+lovelaceValue :: Word64
+lovelaceValue = 12_345_678

--- a/test/Cardano/Node/Client/UTxOIndexer/FollowerSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/FollowerSpec.hs
@@ -37,6 +37,7 @@ import Cardano.Node.Client.UTxOIndexer.Follower (
     coldBootResumePoints,
     filterBlockOps,
     withChainSyncFollower,
+    withChainSyncFollowerUsing,
  )
 import Cardano.Node.Client.UTxOIndexer.Indexer (
     ApplyConflict,
@@ -54,8 +55,16 @@ import Cardano.Node.Client.UTxOIndexer.Types (
     TxOut (..),
  )
 import Control.Concurrent.Async qualified as Async
-import Control.Concurrent.STM (atomically)
+import Control.Concurrent.STM (
+    atomically,
+    check,
+    modifyTVar',
+    newTVarIO,
+    readTVar,
+    writeTVar,
+ )
 import Control.Exception (try)
+import Control.Tracer (Tracer (..), nullTracer, traceWith)
 import Data.ByteString qualified as BS
 import Data.ByteString.Short qualified as SBS
 import Data.Set qualified as Set
@@ -161,6 +170,70 @@ spec =
                                             Async.Async ()
                                         _follower = fhAsync fh
                                     pure ()
+
+            it
+                "surfaces configured block and tip tracers\
+                \ to the chain-sync runner"
+                $ withInMemoryIndexer
+                $ \idx ->
+                    withSystemTempDirectory
+                        "follower-spec"
+                        $ \dir -> do
+                            blockSeen <- newTVarIO False
+                            tipSlots <- newTVarIO []
+                            let cfg =
+                                    (mkCfg (dir <> "/unused.sock"))
+                                        { csBlockTracer =
+                                            Tracer $
+                                                \_ ->
+                                                    atomically $
+                                                        writeTVar
+                                                            blockSeen
+                                                            True
+                                        , csTipTracer =
+                                            Tracer $
+                                                \slot ->
+                                                    atomically $
+                                                        modifyTVar'
+                                                            tipSlots
+                                                            (slot :)
+                                        }
+                                runner
+                                    _epochSlots
+                                    _magic
+                                    _sock
+                                    blockTracer
+                                    tipTracer
+                                    _intersector
+                                    _points = do
+                                        traceWith
+                                            blockTracer
+                                            ( error
+                                                "block tracer test\
+                                                \ payload is not\
+                                                \ evaluated"
+                                            )
+                                        traceWith
+                                            tipTracer
+                                            (Network.SlotNo 123)
+                                        pure (Right ())
+                            withChainSyncFollowerUsing
+                                runner
+                                nullN2CTracer
+                                cfg
+                                idx
+                                $ \_fh -> do
+                                    observedTips <-
+                                        atomically $ do
+                                            seen <- readTVar blockSeen
+                                            tips <- readTVar tipSlots
+                                            check
+                                                ( seen
+                                                    && not (null tips)
+                                                )
+                                            pure tips
+                                    observedTips
+                                        `shouldBe` [Network.SlotNo 123]
 
         describe "filterBlockOps (interest-set semantics)" $ do
             it
@@ -327,6 +400,8 @@ mkCfg sock =
         , csReconnectPolicy = defaultReconnectPolicy
         , csProbeConfig = defaultProbeConfig
         , csInterestSet = IndexAll
+        , csBlockTracer = nullTracer
+        , csTipTracer = nullTracer
         }
 
 toHeaderPoint :: SlotNo -> BlockHash -> HeaderPoint

--- a/test/Cardano/Node/Client/UTxOIndexer/FollowerSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/FollowerSpec.hs
@@ -33,11 +33,13 @@ import Cardano.Node.Client.UTxOIndexer.Follower (
     FollowerHandle (..),
     InterestSet (..),
     Readiness (..),
+    applyBlockOps,
     coldBootResumePoints,
     filterBlockOps,
     withChainSyncFollower,
  )
 import Cardano.Node.Client.UTxOIndexer.Indexer (
+    ApplyConflict,
     IndexerHandle (..),
     withInMemoryIndexer,
  )
@@ -53,9 +55,13 @@ import Cardano.Node.Client.UTxOIndexer.Types (
  )
 import Control.Concurrent.Async qualified as Async
 import Control.Concurrent.STM (atomically)
+import Control.Exception (try)
 import Data.ByteString qualified as BS
 import Data.ByteString.Short qualified as SBS
 import Data.Set qualified as Set
+import Ouroboros.Consensus.Block.EBB (
+    IsEBB (..),
+ )
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (
     OneEraHash (..),
  )
@@ -157,6 +163,31 @@ spec =
                                     pure ()
 
         describe "filterBlockOps (interest-set semantics)" $ do
+            it
+                "skips an EBB before a regular block at the\
+                \ same slot"
+                $ withInMemoryIndexer
+                $ \idx -> do
+                    result <- try @ApplyConflict $ do
+                        ebbApplied <-
+                            applyBlockOps
+                                idx
+                                IsEBB
+                                (SlotNo 0)
+                                blk1
+                                []
+                        blockApplied <-
+                            applyBlockOps
+                                idx
+                                IsNotEBB
+                                (SlotNo 0)
+                                blk2
+                                [UtxoCreate txInA addrA outA]
+                        pure (ebbApplied, blockApplied)
+                    result `shouldBe` Right (False, True)
+                    snapA <- snapshotAt idx addrA
+                    snapA `shouldBe` [(txInA, outA)]
+
             it
                 "keeps UtxoCreate ops at addresses in the\
                 \ interest set and drops the rest"

--- a/test/Cardano/Node/Client/UTxOIndexer/FollowerSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/FollowerSpec.hs
@@ -22,6 +22,7 @@ against a devnet node.
 -}
 module Cardano.Node.Client.UTxOIndexer.FollowerSpec (spec) where
 
+import Cardano.Node.Client.N2C.ChainSync (HeaderPoint)
 import Cardano.Node.Client.N2C.Probe (defaultProbeConfig)
 import Cardano.Node.Client.N2C.Reconnect (
     defaultReconnectPolicy,
@@ -32,6 +33,7 @@ import Cardano.Node.Client.UTxOIndexer.Follower (
     FollowerHandle (..),
     InterestSet (..),
     Readiness (..),
+    coldBootResumePoints,
     filterBlockOps,
     withChainSyncFollower,
  )
@@ -52,8 +54,14 @@ import Cardano.Node.Client.UTxOIndexer.Types (
 import Control.Concurrent.Async qualified as Async
 import Control.Concurrent.STM (atomically)
 import Data.ByteString qualified as BS
+import Data.ByteString.Short qualified as SBS
 import Data.Set qualified as Set
+import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (
+    OneEraHash (..),
+ )
+import Ouroboros.Network.Block qualified as Network
 import Ouroboros.Network.Magic (NetworkMagic (..))
+import Ouroboros.Network.Point qualified as Network.Point
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec (Spec, describe, it, shouldBe)
 
@@ -61,6 +69,21 @@ spec :: Spec
 spec =
     describe "Cardano.Node.Client.UTxOIndexer.Follower" $ do
         describe "withChainSyncFollower" $ do
+            it
+                "uses a configured start point for cold-boot\
+                \ intersection"
+                $ do
+                    let startSlot = SlotNo 5_000_000
+                        startHash =
+                            BlockHash (BS.replicate 32 0x42)
+                        cfg =
+                            (mkCfg "unused.sock")
+                                { csStartPoint =
+                                    Just (startSlot, startHash)
+                                }
+                    coldBootResumePoints cfg
+                        `shouldBe` [toHeaderPoint startSlot startHash]
+
             it
                 "brings up against a caller-owned\
                 \ in-memory IndexerHandle and exposes a\
@@ -267,12 +290,23 @@ mkCfg sock =
         { csRelaySocket = sock
         , csNetworkMagic = NetworkMagic 42
         , csByronEpochSlots = 86_400
+        , csStartPoint = Nothing
         , csReadyThresholdSlots = 5
         , csSecurityParamK = 432
         , csReconnectPolicy = defaultReconnectPolicy
         , csProbeConfig = defaultProbeConfig
         , csInterestSet = IndexAll
         }
+
+toHeaderPoint :: SlotNo -> BlockHash -> HeaderPoint
+toHeaderPoint (SlotNo slot) (BlockHash hashBytes) =
+    Network.Point
+        ( Network.Point.At
+            ( Network.Point.Block
+                (Network.SlotNo slot)
+                (OneEraHash (SBS.toShort hashBytes))
+            )
+        )
 
 -- Three distinct test addresses (1-byte tag plus padding
 -- so they're distinguishable on the wire).

--- a/test/Cardano/Node/Client/UTxOIndexer/FollowerSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/FollowerSpec.hs
@@ -54,6 +54,7 @@ import Cardano.Node.Client.UTxOIndexer.Types (
     TxIn (..),
     TxOut (..),
  )
+import ChainFollower.Rollbacks.Types (RollbackPoint (..))
 import Control.Concurrent.Async qualified as Async
 import Control.Concurrent.STM (
     atomically,
@@ -78,7 +79,7 @@ import Ouroboros.Network.Block qualified as Network
 import Ouroboros.Network.Magic (NetworkMagic (..))
 import Ouroboros.Network.Point qualified as Network.Point
 import System.IO.Temp (withSystemTempDirectory)
-import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldReturn)
 
 spec :: Spec
 spec =
@@ -380,6 +381,91 @@ spec =
                     snapB <- snapshotAt idx addrB
                     snapB `shouldBe` [(txInB, outB)]
 
+        describe "tip-distance phase transition" $ do
+            it
+                "writes sentinel rows while far from tip and\
+                \ full rollback rows once within k"
+                $ withInMemoryIndexer
+                $ \idx -> do
+                    let k = 2
+                        tip = Network.SlotNo 10
+                        withinWindow (SlotNo slot) =
+                            Network.unSlotNo tip >= slot
+                                && Network.unSlotNo tip - slot
+                                    <= fromIntegral k
+                        step slot bh ops state = do
+                            (state', _processed) <-
+                                processFollowerBlock
+                                    idx
+                                    state
+                                    k
+                                    (withinWindow slot)
+                                    slot
+                                    bh
+                                    ops
+                            pure state'
+
+                    state0 <- newFollowerState idx True
+                    state1 <-
+                        step
+                            (SlotNo 1)
+                            blk1
+                            [UtxoCreate txInA addrA outA]
+                            state0
+                    state2 <-
+                        step
+                            (SlotNo 2)
+                            blk2
+                            [UtxoCreate txInB addrB outB]
+                            state1
+                    restorationHistory <- getRollbackHistory idx
+                    fmap (rpInverses . snd) restorationHistory
+                        `shouldBe` [[], []]
+                    fmap (rpMeta . snd) restorationHistory
+                        `shouldBe` [Nothing, Nothing]
+                    snapshotAt idx addrA
+                        `shouldReturn` [(txInA, outA)]
+                    snapshotAt idx addrB
+                        `shouldReturn` [(txInB, outB)]
+
+                    state3 <-
+                        step
+                            (SlotNo 8)
+                            blk3
+                            [UtxoCreate txInC addrC outC]
+                            state2
+                    _state4 <-
+                        step
+                            (SlotNo 9)
+                            blk4
+                            [UtxoSpend txInC]
+                            state3
+
+                    history <- getRollbackHistory idx
+                    fmap (rpInverses . snd) history
+                        `shouldBe` [
+                                       [ [UtxoSpend txInC]
+                                       ]
+                                   ,
+                                       [
+                                           [ UtxoCreate
+                                                txInC
+                                                addrC
+                                                outC
+                                           ]
+                                       ]
+                                   ]
+                    fmap (rpMeta . snd) history
+                        `shouldBe` [ Just blk3
+                                   , Just blk4
+                                   ]
+                    snapshotAt idx addrA
+                        `shouldReturn` [(txInA, outA)]
+                    snapshotAt idx addrB
+                        `shouldReturn` [(txInB, outB)]
+                    snapshotAt idx addrC
+                        `shouldReturn` []
+
 -- ---------------------------------------------------------------------------
 -- Helpers + interest-set test fixtures
 
@@ -434,8 +520,10 @@ outA = TxOut "tag-A"
 outB = TxOut "tag-B"
 outC = TxOut "tag-C"
 
--- Two distinct block hashes for the two apply-block slots
--- used across the filter scenarios.
-blk1, blk2 :: BlockHash
+-- Distinct block hashes for the apply-block slots used
+-- across the filter and phase scenarios.
+blk1, blk2, blk3, blk4 :: BlockHash
 blk1 = BlockHash (BS.replicate 32 0xF1)
 blk2 = BlockHash (BS.replicate 32 0xF2)
+blk3 = BlockHash (BS.replicate 32 0xF3)
+blk4 = BlockHash (BS.replicate 32 0xF4)

--- a/test/Cardano/Node/Client/UTxOIndexer/MainnetSmokeSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/MainnetSmokeSpec.hs
@@ -99,11 +99,12 @@ runMainnetSmoke socketPath = do
                         , csBlockTracer = nullTracer
                         , csTipTracer = nullTracer
                         }
+                progressTarget = SlotNo 5_000_000
             withChainSyncFollower tracer cfg idx $ \fh ->
                 waitForMainnetProgress
                     fh
                     eventsVar
-                    (SlotNo 5_000_000)
+                    progressTarget
                     60_000_000
 
 resolveMainnetTipPoint :: FilePath -> IO (SlotNo, BlockHash)

--- a/test/Cardano/Node/Client/UTxOIndexer/MainnetSmokeSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/MainnetSmokeSpec.hs
@@ -43,7 +43,7 @@ import Control.Concurrent.STM (
     newTVarIO,
     readTVarIO,
  )
-import Control.Tracer (Tracer (..))
+import Control.Tracer (Tracer (..), nullTracer)
 import Data.ByteString.Short qualified as SBS
 import Data.Text qualified as Text
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (
@@ -96,6 +96,8 @@ runMainnetSmoke socketPath = do
                         , csReconnectPolicy = defaultReconnectPolicy
                         , csProbeConfig = defaultProbeConfig
                         , csInterestSet = IndexAll
+                        , csBlockTracer = nullTracer
+                        , csTipTracer = nullTracer
                         }
             withChainSyncFollower tracer cfg idx $ \fh ->
                 waitForMainnetProgress

--- a/test/Cardano/Node/Client/UTxOIndexer/MainnetSmokeSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/MainnetSmokeSpec.hs
@@ -1,0 +1,185 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+{- |
+Module      : Cardano.Node.Client.UTxOIndexer.MainnetSmokeSpec
+Description : Opt-in mainnet cold-boot smoke for the UTxO indexer
+License     : Apache-2.0
+
+Cold-boot smoke against a real mainnet node socket. The test is
+gated by @UTXO_INDEXER_MAINNET_SMOKE@ so CI remains self-contained.
+-}
+module Cardano.Node.Client.UTxOIndexer.MainnetSmokeSpec (spec) where
+
+import Cardano.Node.Client.N2C.Connection (
+    newLSQChannel,
+    newLTxSChannel,
+    runNodeClient,
+ )
+import Cardano.Node.Client.N2C.LocalStateQuery (queryLSQ)
+import Cardano.Node.Client.N2C.Probe (defaultProbeConfig)
+import Cardano.Node.Client.N2C.Reconnect (defaultReconnectPolicy)
+import Cardano.Node.Client.N2C.Trace (N2CEvent (..))
+import Cardano.Node.Client.UTxOIndexer.Follower (
+    ChainSyncConfig (..),
+    FollowerHandle (..),
+    InterestSet (..),
+    Readiness (..),
+    withChainSyncFollower,
+ )
+import Cardano.Node.Client.UTxOIndexer.Indexer (
+    withRocksDBIndexer,
+ )
+import Cardano.Node.Client.UTxOIndexer.Types (
+    BlockHash (..),
+    SlotNo (..),
+ )
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (poll, withAsync)
+import Control.Concurrent.STM (
+    TVar,
+    atomically,
+    modifyTVar',
+    newTVarIO,
+    readTVarIO,
+ )
+import Control.Tracer (Tracer (..))
+import Data.ByteString.Short qualified as SBS
+import Data.Text qualified as Text
+import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (
+    getOneEraHash,
+ )
+import Ouroboros.Consensus.Ledger.Query (Query (GetChainPoint))
+import Ouroboros.Network.Block qualified as Network
+import Ouroboros.Network.Magic (NetworkMagic (..))
+import Ouroboros.Network.Point qualified as Network.Point
+import System.Environment (lookupEnv)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Timeout (timeout)
+import Test.Hspec (
+    Spec,
+    describe,
+    expectationFailure,
+    it,
+    pendingWith,
+ )
+
+spec :: Spec
+spec =
+    describe "mainnet smoke" $
+        it "cold boots past Byron without ApplyConflict" $ do
+            lookupEnv "UTXO_INDEXER_MAINNET_SMOKE" >>= \case
+                Nothing ->
+                    pendingWith
+                        "set UTXO_INDEXER_MAINNET_SMOKE to a mainnet node socket"
+                Just socketPath ->
+                    runMainnetSmoke socketPath
+
+runMainnetSmoke :: FilePath -> IO ()
+runMainnetSmoke socketPath = do
+    startPoint <- resolveMainnetTipPoint socketPath
+    withSystemTempDirectory "utxo-indexer-mainnet-smoke" $ \tmp ->
+        withRocksDBIndexer (tmp </> "db") $ \idx -> do
+            eventsVar <- newTVarIO ([] :: [N2CEvent])
+            let tracer =
+                    Tracer $ \ev ->
+                        atomically (modifyTVar' eventsVar (ev :))
+                cfg =
+                    ChainSyncConfig
+                        { csRelaySocket = socketPath
+                        , csNetworkMagic = mainnetMagic
+                        , csByronEpochSlots = 21_600
+                        , csStartPoint = Just startPoint
+                        , csReadyThresholdSlots = 60
+                        , csSecurityParamK = 2_160
+                        , csReconnectPolicy = defaultReconnectPolicy
+                        , csProbeConfig = defaultProbeConfig
+                        , csInterestSet = IndexAll
+                        }
+            withChainSyncFollower tracer cfg idx $ \fh ->
+                waitForMainnetProgress
+                    fh
+                    eventsVar
+                    (SlotNo 5_000_000)
+                    60_000_000
+
+resolveMainnetTipPoint :: FilePath -> IO (SlotNo, BlockHash)
+resolveMainnetTipPoint socketPath = do
+    lsq <- newLSQChannel 16
+    ltxs <- newLTxSChannel 16
+    withAsync (runNodeClient mainnetMagic socketPath lsq ltxs) $ \_ -> do
+        mPoint <- timeout 10_000_000 (queryLSQ lsq GetChainPoint)
+        case mPoint of
+            Nothing ->
+                failResolve
+                    "mainnet smoke could not query the node tip within 10s"
+            Just (Network.Point Network.Point.Origin) ->
+                failResolve
+                    "mainnet smoke node tip is Origin"
+            Just
+                ( Network.Point
+                        ( Network.Point.At
+                                (Network.Point.Block slot hash)
+                            )
+                    ) ->
+                    pure
+                        ( SlotNo (Network.unSlotNo slot)
+                        , BlockHash
+                            (SBS.fromShort (getOneEraHash hash))
+                        )
+  where
+    failResolve msg =
+        expectationFailure msg >> pure (SlotNo 0, BlockHash mempty)
+
+waitForMainnetProgress ::
+    FollowerHandle ->
+    TVar [N2CEvent] ->
+    SlotNo ->
+    Int ->
+    IO ()
+waitForMainnetProgress fh eventsVar targetSlot =
+    go
+  where
+    stepMicros = 250_000
+
+    go remaining
+        | remaining <= 0 = do
+            events <- reverse <$> readTVarIO eventsVar
+            expectationFailure $
+                "mainnet smoke did not advance past "
+                    <> show targetSlot
+                    <> " within 60s; recent events: "
+                    <> show (take 8 (reverse events))
+        | otherwise = do
+            failOnApplyConflict eventsVar
+            poll (fhAsync fh) >>= \case
+                Just (Left e) ->
+                    expectationFailure $
+                        "mainnet smoke follower crashed: " <> show e
+                Just (Right ()) ->
+                    expectationFailure
+                        "mainnet smoke follower exited cleanly"
+                Nothing -> pure ()
+            readiness <- atomically (fhReadiness fh)
+            case rProcessedSlot readiness of
+                Just slot | slot > targetSlot -> pure ()
+                _ -> do
+                    threadDelay stepMicros
+                    go (remaining - stepMicros)
+
+failOnApplyConflict :: TVar [N2CEvent] -> IO ()
+failOnApplyConflict eventsVar = do
+    events <- readTVarIO eventsVar
+    case [reason | IndexerDisconnected reason <- events, isApplyConflict reason] of
+        reason : _ ->
+            expectationFailure $
+                "mainnet smoke observed ApplyConflict: "
+                    <> Text.unpack reason
+        [] -> pure ()
+
+isApplyConflict :: Text.Text -> Bool
+isApplyConflict = Text.isInfixOf "ApplyConflict"
+
+mainnetMagic :: NetworkMagic
+mainnetMagic = NetworkMagic 764_824_073

--- a/test/Cardano/Node/Client/UTxOIndexer/PersistenceSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/PersistenceSpec.hs
@@ -24,6 +24,7 @@ import Cardano.Node.Client.UTxOIndexer.Types (
     TxIn (..),
     TxOut (..),
  )
+import ChainFollower.Rollbacks.Types (RollbackPoint (..))
 import Control.Exception (try)
 import Data.ByteString qualified as BS
 import Data.Word (Word64)
@@ -45,6 +46,27 @@ spec =
                 withRocksDBIndexer dbPath $ \h -> do
                     pts <- getResumePoints h
                     pts `shouldBe` []
+
+        it "restoration sentinels survive close + reopen" $
+            withTempDB $ \dbPath -> do
+                withRocksDBIndexer dbPath $ \h -> do
+                    state <- newFollowerState h True
+                    (_state', processed) <-
+                        processFollowerBlock
+                            h
+                            state
+                            2
+                            False
+                            (SlotNo 1)
+                            (BlockHash (BS.replicate 32 0x11))
+                            []
+                    processed `shouldBe` True
+                withRocksDBIndexer dbPath $ \h -> do
+                    history <- getRollbackHistory h
+                    fmap (rpInverses . snd) history
+                        `shouldBe` [[]]
+                    fmap (rpMeta . snd) history
+                        `shouldBe` [Nothing]
 
         it "getResumePoints returns retained slots newest-first" $
             -- Three entries fit entirely under the Fibonacci

--- a/test/unit-main.hs
+++ b/test/unit-main.hs
@@ -8,6 +8,7 @@ import Cardano.Node.Client.N2C.TraceSpec qualified as N2CTraceSpec
 import Cardano.Node.Client.UTxOIndexer.DaemonSpec qualified as UTxOIndexerDaemonSpec
 import Cardano.Node.Client.UTxOIndexer.FollowerSpec qualified as UTxOIndexerFollowerSpec
 import Cardano.Node.Client.UTxOIndexer.IndexerSpec qualified as UTxOIndexerSpec
+import Cardano.Node.Client.UTxOIndexer.MainnetSmokeSpec qualified as UTxOIndexerMainnetSmokeSpec
 import Cardano.Node.Client.UTxOIndexer.PersistenceSpec qualified as UTxOIndexerPersistenceSpec
 import Cardano.Node.Client.UTxOIndexer.ServerSpec qualified as UTxOIndexerServerSpec
 import Cardano.Node.Client.UTxOIndexer.TypesSpec qualified as UTxOIndexerTypesSpec
@@ -24,6 +25,7 @@ main = hspec $ do
     UTxOIndexerPersistenceSpec.spec
     UTxOIndexerDaemonSpec.spec
     UTxOIndexerFollowerSpec.spec
+    UTxOIndexerMainnetSmokeSpec.spec
     N2CProbeSpec.spec
     N2CTraceSpec.spec
     ValiditySpec.spec

--- a/test/unit-main.hs
+++ b/test/unit-main.hs
@@ -5,6 +5,7 @@ import Test.Hspec (hspec)
 import Cardano.Node.Client.AddressSpec qualified as AddressSpec
 import Cardano.Node.Client.N2C.ProbeSpec qualified as N2CProbeSpec
 import Cardano.Node.Client.N2C.TraceSpec qualified as N2CTraceSpec
+import Cardano.Node.Client.UTxOIndexer.BlockExtractSpec qualified as UTxOIndexerBlockExtractSpec
 import Cardano.Node.Client.UTxOIndexer.DaemonSpec qualified as UTxOIndexerDaemonSpec
 import Cardano.Node.Client.UTxOIndexer.FollowerSpec qualified as UTxOIndexerFollowerSpec
 import Cardano.Node.Client.UTxOIndexer.IndexerSpec qualified as UTxOIndexerSpec
@@ -20,6 +21,7 @@ main = hspec $ do
     AddressSpec.spec
     SampleFibonacciSpec.spec
     UTxOIndexerTypesSpec.spec
+    UTxOIndexerBlockExtractSpec.spec
     UTxOIndexerSpec.spec
     UTxOIndexerServerSpec.spec
     UTxOIndexerPersistenceSpec.spec


### PR DESCRIPTION
## Summary

- Closes #162 by adding `csStartPoint :: Maybe (SlotNo, BlockHash)` to `ChainSyncConfig` and using it for cold-boot chain-sync intersection.
- Closes #163 by detecting consensus EBBs during follower roll-forward and skipping rollback-log application for them, avoiding same-slot Byron EBB/regular-block conflicts.
- Closes #164 by adding an env-gated mainnet smoke test with `UTXO_INDEXER_MAINNET_SMOKE=<socket>`.
- Extends `ChainSyncConfig` with optional `csBlockTracer` and `csTipTracer` for downstream visibility into per-block progress (additive; defaults preserve behavior).
- Adds `csSkipTargetSlot` + `csOnSkipComplete` to `ChainSyncConfig` by wrapping the tested chain-follower `Runner.processBlock`, so consumers can opt into a restoration phase that writes sentinel rollback rows only before switching to full following rows. References measured 118x N2C-vs-apply throughput gap.

## Verification

- `nix develop --quiet -c cabal build all -O0`
- `nix develop --quiet -c just unit`
- `nix build .#checks.x86_64-linux.build .#checks.x86_64-linux.unit .#checks.x86_64-linux.lint`
- `UTXO_INDEXER_MAINNET_SMOKE=/code/cardano-mainnet/ipc/node.socket nix develop --quiet -c cabal test unit-tests -O0 --test-options="--match=mainnet"`