### PR TITLE
feat(utxo-indexer): add typed provider modes

### DIFF
--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -64,6 +64,7 @@ library
     Cardano.Node.Client.UTxOIndexer.BlockExtract
     Cardano.Node.Client.UTxOIndexer.Daemon
     Cardano.Node.Client.UTxOIndexer.Follower
+    Cardano.Node.Client.UTxOIndexer.Provider
     Cardano.Node.Client.UTxOIndexer.Server
     Cardano.Node.Client.Validity
 
@@ -117,6 +118,7 @@ library
     , process
     , random
     , retry
+    , rocksdb-kv-transactions:kv-transactions
     , serialise
     , stm
     , text
@@ -238,6 +240,7 @@ test-suite unit-tests
     Cardano.Node.Client.UTxOIndexer.IndexerSpec
     Cardano.Node.Client.UTxOIndexer.MainnetSmokeSpec
     Cardano.Node.Client.UTxOIndexer.PersistenceSpec
+    Cardano.Node.Client.UTxOIndexer.ProviderSpec
     Cardano.Node.Client.UTxOIndexer.ServerSpec
     Cardano.Node.Client.UTxOIndexer.TypesSpec
     Cardano.Node.Client.ValiditySpec

--- a/lib/Cardano/Node/Client/UTxOIndexer/Provider.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Provider.hs
@@ -1,0 +1,447 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{- |
+Module      : Cardano.Node.Client.UTxOIndexer.Provider
+Description : Typed provider modes for ledger and indexer reads
+License     : Apache-2.0
+
+The live node and the indexer expose different consistency
+boundaries:
+
+* ledger queries may run through an acquired N2C LocalStateQuery
+  snapshot;
+* indexed transaction and UTxO reads run inside a
+  @kv-transactions@ transaction over the indexer columns.
+
+This module keeps those boundaries separate in the type of the
+provider. CLI-style callers can open only the ledger side. HTTP or
+server callers that own the indexer store can open both: the N2C
+handle is acquired first, and the callback then runs inside the
+indexer transaction.
+-}
+module Cardano.Node.Client.UTxOIndexer.Provider (
+    -- * Provider modes
+    ProviderMode (..),
+    ProviderMonad,
+    ProviderSingleton (..),
+    Provider (..),
+
+    -- * Ledger side
+    LedgerQueryHandle (..),
+    LedgerProvider (..),
+    ledgerProviderFromProvider,
+    ledgerProviderFromAcquired,
+
+    -- * Indexer side
+    IndexerProvider (..),
+    indexerProvider,
+
+    -- * Opening providers
+    withProvider,
+
+    -- * Errors
+    IndexerProviderError (..),
+) where
+
+import Cardano.Crypto.Hash.Class (Hash (..), hashToBytes)
+import Cardano.Ledger.Address (AccountAddress, Addr, serialiseAddr)
+import Cardano.Ledger.Api.Tx.Out (TxOut)
+import Cardano.Ledger.BaseTypes (TxIx (..))
+import Cardano.Ledger.Binary (
+    DecoderError,
+    decodeFull',
+ )
+import Cardano.Ledger.Coin (Coin)
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core (PParams, eraProtVerLow)
+import Cardano.Ledger.Credential (Credential)
+import Cardano.Ledger.DRep (DRep)
+import Cardano.Ledger.Hashes (
+    extractHash,
+    unsafeMakeSafeHash,
+ )
+import Cardano.Ledger.Keys (KeyRole (Staking))
+import Cardano.Ledger.State (GovState)
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Node.Client.Ledger (ConwayTx)
+import Cardano.Node.Client.Provider qualified as Ledger
+import Cardano.Node.Client.UTxOIndexer.Columns (
+    Cols (..),
+ )
+import Cardano.Node.Client.UTxOIndexer.Types qualified as Indexer
+import Cardano.Slotting.Slot (SlotNo)
+import Control.Exception (Exception, throwIO)
+import Control.Monad.IO.Class (liftIO)
+import Data.ByteString qualified as BS
+import Data.ByteString.Short qualified as SBS
+import Data.Kind (Type)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Database.KV.Cursor (
+    Cursor,
+    Entry (..),
+    nextEntry,
+    seekKey,
+ )
+import Database.KV.Transaction (
+    KV,
+    RunTransaction (..),
+    Transaction,
+    iterating,
+    query,
+ )
+
+{- | Provider capability modes.
+
+The type parameters on 'LedgerAndIndexer' are the hidden
+@kv-transactions@ backend types carried by a 'RunTransaction'.
+-}
+data ProviderMode
+    = LedgerOnly
+    | LedgerAndIndexer Type Type
+
+{- | The callback monad selected by a provider mode.
+
+Ledger-only callers run in 'IO'. Callers that open the indexer run
+inside the indexer database transaction; N2C acquired reads are lifted
+into that transaction.
+-}
+type family ProviderMonad (mode :: ProviderMode) (a :: Type) :: Type where
+    ProviderMonad 'LedgerOnly a = IO a
+    ProviderMonad ('LedgerAndIndexer cf op) a =
+        Transaction IO cf Cols op a
+
+{- | Runtime witness for a provider mode.
+
+'SLedgerOnly' is the CLI shape. 'SLedgerAndIndexer' is the HTTP/server
+shape: it has both the N2C ledger provider and the indexer transaction
+runner.
+-}
+data ProviderSingleton mode where
+    SLedgerOnly ::
+        Ledger.Provider IO ->
+        ProviderSingleton 'LedgerOnly
+    SLedgerAndIndexer ::
+        Ledger.Provider IO ->
+        RunTransaction IO cf Cols op ->
+        ProviderSingleton ('LedgerAndIndexer cf op)
+
+-- | Provider value handed to the callback selected by a mode witness.
+data Provider mode where
+    LedgerOnlyProvider ::
+        LedgerProvider IO ->
+        Provider 'LedgerOnly
+    LedgerAndIndexerProvider ::
+        LedgerProvider (Transaction IO cf Cols op) ->
+        IndexerProvider cf op ->
+        Provider ('LedgerAndIndexer cf op)
+
+{- | Non-UTxO operations bound to one acquired ledger snapshot.
+
+The type intentionally has no UTxO selectors. Indexed UTxO and
+transaction reads belong to 'IndexerProvider'.
+-}
+data LedgerQueryHandle m = LedgerQueryHandle
+    { queryProtocolParamsLH ::
+        m (PParams ConwayEra)
+    , queryLedgerSnapshotLH ::
+        m Ledger.LedgerSnapshot
+    , queryStakeRewardsLH ::
+        Set (Credential Staking) ->
+        m (Map (Credential Staking) Coin)
+    , queryRewardAccountsLH ::
+        Set AccountAddress ->
+        m (Map AccountAddress Coin)
+    , queryVoteDelegateesLH ::
+        Set (Credential Staking) ->
+        m (Map (Credential Staking) DRep)
+    , queryTreasuryLH ::
+        m Coin
+    , queryGovernanceStateLH ::
+        m (GovState ConwayEra)
+    , evaluateTxLH ::
+        ConwayTx ->
+        m (Ledger.EvaluateTxResult ConwayEra)
+    , posixMsToSlotLH ::
+        Integer ->
+        m SlotNo
+    , posixMsCeilSlotLH ::
+        Integer ->
+        m SlotNo
+    }
+
+-- | Non-UTxO ledger provider surface.
+data LedgerProvider m = LedgerProvider
+    { withAcquiredLedger ::
+        forall a.
+        (LedgerQueryHandle m -> m a) ->
+        m a
+    , queryProtocolParamsL ::
+        m (PParams ConwayEra)
+    , queryLedgerSnapshotL ::
+        m Ledger.LedgerSnapshot
+    , queryStakeRewardsL ::
+        Set (Credential Staking) ->
+        m (Map (Credential Staking) Coin)
+    , queryRewardAccountsL ::
+        Set AccountAddress ->
+        m (Map AccountAddress Coin)
+    , queryVoteDelegateesL ::
+        Set (Credential Staking) ->
+        m (Map (Credential Staking) DRep)
+    , queryTreasuryL ::
+        m Coin
+    , queryGovernanceStateL ::
+        m (GovState ConwayEra)
+    , evaluateTxL ::
+        ConwayTx ->
+        m (Ledger.EvaluateTxResult ConwayEra)
+    , posixMsToSlotL ::
+        Integer ->
+        m SlotNo
+    , posixMsCeilSlotL ::
+        Integer ->
+        m SlotNo
+    }
+
+{- | Indexer-backed read surface.
+
+These operations are database transactions. They do not use N2C and do
+not pretend to be part of the acquired LSQ snapshot.
+-}
+data IndexerProvider cf op = IndexerProvider
+    { queryIndexedUTxOs ::
+        Addr ->
+        Transaction IO cf Cols op [(TxIn, TxOut ConwayEra)]
+    , queryIndexedUTxOsAt ::
+        Set Addr ->
+        Transaction IO cf Cols op (Map Addr [(TxIn, TxOut ConwayEra)])
+    , queryIndexedUTxOByTxIn ::
+        Set TxIn ->
+        Transaction IO cf Cols op (Map TxIn (TxOut ConwayEra))
+    }
+
+{- | Error raised when indexed bytes cannot be decoded back into the
+Conway-era ledger shape expected by transaction builders.
+-}
+data IndexerProviderError
+    = IndexerProviderTxOutDecodeError Indexer.TxIn DecoderError
+    deriving stock (Show)
+
+instance Exception IndexerProviderError
+
+-- | Open the provider selected by the mode witness.
+withProvider ::
+    ProviderSingleton mode ->
+    (Provider mode -> ProviderMonad mode a) ->
+    IO a
+withProvider (SLedgerOnly ledger) action =
+    action (LedgerOnlyProvider (ledgerProviderFromProvider ledger))
+withProvider (SLedgerAndIndexer ledger runner) action =
+    Ledger.withAcquired ledger $ \handle ->
+        runTransaction runner $
+            action $
+                LedgerAndIndexerProvider
+                    (ledgerProviderFromAcquired handle)
+                    indexerProvider
+
+-- | Drop UTxO selectors from a legacy ledger provider.
+ledgerProviderFromProvider ::
+    Ledger.Provider IO ->
+    LedgerProvider IO
+ledgerProviderFromProvider provider =
+    LedgerProvider
+        { withAcquiredLedger = \callback ->
+            Ledger.withAcquired provider $
+                callback . ledgerQueryHandleFromQueryHandle
+        , queryProtocolParamsL = Ledger.queryProtocolParams provider
+        , queryLedgerSnapshotL = Ledger.queryLedgerSnapshot provider
+        , queryStakeRewardsL = Ledger.queryStakeRewards provider
+        , queryRewardAccountsL = Ledger.queryRewardAccounts provider
+        , queryVoteDelegateesL = Ledger.queryVoteDelegatees provider
+        , queryTreasuryL = Ledger.queryTreasury provider
+        , queryGovernanceStateL = Ledger.queryGovernanceState provider
+        , evaluateTxL = Ledger.evaluateTx provider
+        , posixMsToSlotL = Ledger.posixMsToSlot provider
+        , posixMsCeilSlotL = Ledger.posixMsCeilSlot provider
+        }
+
+{- | Build a transaction-lifted ledger provider from an acquired N2C
+query handle.
+
+This is used by 'SLedgerAndIndexer': the acquired handle is opened once
+outside the indexer transaction, then every ledger read is lifted into
+the callback's transaction monad.
+-}
+ledgerProviderFromAcquired ::
+    Ledger.QueryHandle IO ->
+    LedgerProvider (Transaction IO cf Cols op)
+ledgerProviderFromAcquired handle =
+    LedgerProvider
+        { withAcquiredLedger = \callback ->
+            callback (ledgerQueryHandleFromAcquired handle)
+        , queryProtocolParamsL =
+            liftIO (Ledger.queryProtocolParamsH handle)
+        , queryLedgerSnapshotL =
+            liftIO (Ledger.queryLedgerSnapshotH handle)
+        , queryStakeRewardsL =
+            liftIO . Ledger.queryStakeRewardsH handle
+        , queryRewardAccountsL =
+            liftIO . Ledger.queryRewardAccountsH handle
+        , queryVoteDelegateesL =
+            liftIO . Ledger.queryVoteDelegateesH handle
+        , queryTreasuryL =
+            liftIO (Ledger.queryTreasuryH handle)
+        , queryGovernanceStateL =
+            liftIO (Ledger.queryGovernanceStateH handle)
+        , evaluateTxL =
+            liftIO . Ledger.evaluateTxH handle
+        , posixMsToSlotL =
+            liftIO . Ledger.posixMsToSlotH handle
+        , posixMsCeilSlotL =
+            liftIO . Ledger.posixMsCeilSlotH handle
+        }
+
+ledgerQueryHandleFromQueryHandle ::
+    Ledger.QueryHandle IO ->
+    LedgerQueryHandle IO
+ledgerQueryHandleFromQueryHandle =
+    hoistLedgerQueryHandle id
+
+ledgerQueryHandleFromAcquired ::
+    Ledger.QueryHandle IO ->
+    LedgerQueryHandle (Transaction IO cf Cols op)
+ledgerQueryHandleFromAcquired =
+    hoistLedgerQueryHandle liftIO
+
+hoistLedgerQueryHandle ::
+    (forall x. m x -> n x) ->
+    Ledger.QueryHandle m ->
+    LedgerQueryHandle n
+hoistLedgerQueryHandle nat handle =
+    LedgerQueryHandle
+        { queryProtocolParamsLH =
+            nat (Ledger.queryProtocolParamsH handle)
+        , queryLedgerSnapshotLH =
+            nat (Ledger.queryLedgerSnapshotH handle)
+        , queryStakeRewardsLH =
+            nat . Ledger.queryStakeRewardsH handle
+        , queryRewardAccountsLH =
+            nat . Ledger.queryRewardAccountsH handle
+        , queryVoteDelegateesLH =
+            nat . Ledger.queryVoteDelegateesH handle
+        , queryTreasuryLH =
+            nat (Ledger.queryTreasuryH handle)
+        , queryGovernanceStateLH =
+            nat (Ledger.queryGovernanceStateH handle)
+        , evaluateTxLH =
+            nat . Ledger.evaluateTxH handle
+        , posixMsToSlotLH =
+            nat . Ledger.posixMsToSlotH handle
+        , posixMsCeilSlotLH =
+            nat . Ledger.posixMsCeilSlotH handle
+        }
+
+-- | Indexer transaction provider over the standard UTxO indexer columns.
+indexerProvider :: IndexerProvider cf op
+indexerProvider =
+    IndexerProvider
+        { queryIndexedUTxOs = queryIndexerUTxOs
+        , queryIndexedUTxOsAt = queryIndexerUTxOsAt
+        , queryIndexedUTxOByTxIn = queryIndexerUTxOByTxIn
+        }
+
+queryIndexerUTxOs ::
+    Addr ->
+    Transaction IO cf Cols op [(TxIn, TxOut ConwayEra)]
+queryIndexerUTxOs addr =
+    traverse decodeIndexedUTxO
+        =<< iterating AddressIndex (scanAddress (toIndexerAddress addr))
+
+queryIndexerUTxOsAt ::
+    Set Addr ->
+    Transaction IO cf Cols op (Map Addr [(TxIn, TxOut ConwayEra)])
+queryIndexerUTxOsAt addrs =
+    foldr add Map.empty <$> traverse queryAddress (Set.toList addrs)
+  where
+    queryAddress addr =
+        (,) addr <$> queryIndexerUTxOs addr
+    add (addr, utxos) = Map.insert addr utxos
+
+queryIndexerUTxOByTxIn ::
+    Set TxIn ->
+    Transaction IO cf Cols op (Map TxIn (TxOut ConwayEra))
+queryIndexerUTxOByTxIn txIns =
+    Map.fromList . concat
+        <$> traverse queryOne (Set.toList txIns)
+  where
+    queryOne txIn = do
+        let indexedTxIn = toIndexerTxIn txIn
+        mAddr <- query TxInCol indexedTxIn
+        case mAddr of
+            Nothing -> pure []
+            Just addr -> do
+                mTxOut <- query AddressIndex (Indexer.AddrKey addr indexedTxIn)
+                case mTxOut of
+                    Nothing -> pure []
+                    Just indexedTxOut -> do
+                        txOut <-
+                            decodeIndexerTxOut indexedTxIn indexedTxOut
+                        pure [(txIn, txOut)]
+
+decodeIndexedUTxO ::
+    (Indexer.TxIn, Indexer.TxOut) ->
+    Transaction IO cf Cols op (TxIn, TxOut ConwayEra)
+decodeIndexedUTxO (txIn, txOut) = do
+    ledgerTxOut <- decodeIndexerTxOut txIn txOut
+    pure (fromIndexerTxIn txIn, ledgerTxOut)
+
+decodeIndexerTxOut ::
+    Indexer.TxIn ->
+    Indexer.TxOut ->
+    Transaction IO cf Cols op (TxOut ConwayEra)
+decodeIndexerTxOut txIn (Indexer.TxOut bytes) =
+    case decodeFull' @(TxOut ConwayEra) (eraProtVerLow @ConwayEra) bytes of
+        Right txOut -> pure txOut
+        Left err ->
+            liftIO $
+                throwIO (IndexerProviderTxOutDecodeError txIn err)
+
+scanAddress ::
+    (Monad m) =>
+    Indexer.Address ->
+    Cursor m (KV Indexer.AddrKey Indexer.TxOut) [(Indexer.TxIn, Indexer.TxOut)]
+scanAddress addr =
+    let seekTo =
+            Indexer.AddrKey
+                addr
+                (Indexer.TxIn (BS.replicate 32 0) 0)
+     in seekKey seekTo >>= go []
+  where
+    go acc Nothing = pure (reverse acc)
+    go acc (Just Entry{entryKey = key, entryValue = value})
+        | Indexer.addrKeyAddress key == addr =
+            nextEntry >>= go ((Indexer.addrKeyTxIn key, value) : acc)
+        | otherwise = pure (reverse acc)
+
+toIndexerAddress :: Addr -> Indexer.Address
+toIndexerAddress =
+    Indexer.Address . serialiseAddr
+
+toIndexerTxIn :: TxIn -> Indexer.TxIn
+toIndexerTxIn (TxIn (TxId safeHash) (TxIx ix)) =
+    Indexer.TxIn
+        { Indexer.txInId = hashToBytes (extractHash safeHash)
+        , Indexer.txInIx = fromIntegral ix
+        }
+
+fromIndexerTxIn :: Indexer.TxIn -> TxIn
+fromIndexerTxIn Indexer.TxIn{Indexer.txInId, Indexer.txInIx} =
+    TxIn
+        (TxId (unsafeMakeSafeHash (UnsafeHash (SBS.toShort txInId))))
+        (TxIx (fromIntegral txInIx))

--- a/test/Cardano/Node/Client/UTxOIndexer/ProviderSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/ProviderSpec.hs
@@ -1,0 +1,265 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Cardano.Node.Client.UTxOIndexer.ProviderSpec (spec) where
+
+import Cardano.Chain.Common qualified as ByronCommon
+import Cardano.Crypto.Hash.Class (Hash (..))
+import Cardano.Ledger.Address (
+    Addr (..),
+    BootstrapAddress (..),
+    serialiseAddr,
+ )
+import Cardano.Ledger.Api.Tx.Out (TxOut, mkBasicTxOut)
+import Cardano.Ledger.BaseTypes (TxIx (..))
+import Cardano.Ledger.Binary (serialize')
+import Cardano.Ledger.Binary qualified as LedgerBinary
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core (eraProtVerLow)
+import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
+import Cardano.Ledger.TxIn qualified as Ledger
+import Cardano.Ledger.Val (inject)
+import Cardano.Node.Client.Provider qualified as LedgerProvider
+import Cardano.Node.Client.UTxOIndexer.Columns (
+    Cols (..),
+    addressIndexCodecs,
+    observationColCodecs,
+    rollbackCodecs,
+    txInColCodecs,
+ )
+import Cardano.Node.Client.UTxOIndexer.Provider (
+    Provider (..),
+    ProviderSingleton (..),
+    queryIndexedUTxOByTxIn,
+    queryIndexedUTxOs,
+    queryIndexedUTxOsAt,
+    queryLedgerSnapshotL,
+    queryLedgerSnapshotLH,
+    withAcquiredLedger,
+    withProvider,
+ )
+import Cardano.Node.Client.UTxOIndexer.Types qualified as Indexer
+import Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
+import Data.ByteString qualified as BS
+import Data.ByteString.Short qualified as SBS
+import Data.Dependent.Map (DMap)
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Text qualified as Text
+import Database.KV.Database (mkColumns)
+import Database.KV.InMemory (mkInMemoryDatabase)
+import Database.KV.Transaction (
+    Codecs,
+    DSum ((:=>)),
+    RunTransaction (..),
+ )
+import Database.KV.Transaction qualified as KV
+import Ouroboros.Network.Block (pattern GenesisPoint)
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec =
+    describe "Cardano.Node.Client.UTxOIndexer.Provider" $ do
+        it "opens the CLI ledger-only provider without an indexer" $ do
+            (directEra, acquiredEra) <-
+                withProvider
+                    (SLedgerOnly failingUtxoLedgerProvider)
+                    $ \case
+                        LedgerOnlyProvider ledger -> do
+                            direct <- queryLedgerSnapshotL ledger
+                            acquired <-
+                                withAcquiredLedger
+                                    ledger
+                                    queryLedgerSnapshotLH
+                            pure
+                                ( LedgerProvider.ledgerCurrentEra direct
+                                , LedgerProvider.ledgerCurrentEra acquired
+                                )
+
+            directEra `shouldBe` Text.pack "Conway"
+            acquiredEra `shouldBe` Text.pack "Conway"
+
+        it "opens acquired ledger and indexer transaction scopes together" $
+            withIndexedOutput $ \runner txIn txOut -> do
+                (rows, byAddr, byTxIn, directEra, acquiredEra) <-
+                    withProvider
+                        (SLedgerAndIndexer failingUtxoLedgerProvider runner)
+                        $ \case
+                            LedgerAndIndexerProvider ledger indexer -> do
+                                direct <- queryLedgerSnapshotL ledger
+                                acquired <-
+                                    withAcquiredLedger
+                                        ledger
+                                        queryLedgerSnapshotLH
+                                (,,,,)
+                                    <$> queryIndexedUTxOs
+                                        indexer
+                                        testAddr
+                                    <*> queryIndexedUTxOsAt
+                                        indexer
+                                        (Set.singleton testAddr)
+                                    <*> queryIndexedUTxOByTxIn
+                                        indexer
+                                        (Set.singleton txIn)
+                                    <*> pure
+                                        ( LedgerProvider.ledgerCurrentEra
+                                            direct
+                                        )
+                                    <*> pure
+                                        ( LedgerProvider.ledgerCurrentEra
+                                            acquired
+                                        )
+
+                rows `shouldBe` [(txIn, txOut)]
+                byAddr
+                    `shouldBe` Map.singleton
+                        testAddr
+                        [(txIn, txOut)]
+                byTxIn `shouldBe` Map.singleton txIn txOut
+                directEra `shouldBe` Text.pack "Conway"
+                acquiredEra `shouldBe` Text.pack "Conway"
+
+withIndexedOutput ::
+    ( forall cf op.
+      RunTransaction IO cf Cols op ->
+      Ledger.TxIn ->
+      TxOut ConwayEra ->
+      IO a
+    ) ->
+    IO a
+withIndexedOutput action = do
+    db <- mkInMemoryDatabase (mkColumns [0 :: Int ..] testCodecs)
+    runner@RunTransaction{runTransaction} <- KV.newRunTransaction db
+    runTransaction $ do
+        KV.insert TxInCol testIndexerTxIn indexedAddr
+        KV.insert
+            AddressIndex
+            (Indexer.AddrKey indexedAddr testIndexerTxIn)
+            (Indexer.TxOut (serialize' conwayVersion testTxOut))
+    action runner testLedgerTxIn testTxOut
+
+testCodecs :: DMap Cols Codecs
+testCodecs =
+    KV.fromList
+        [ TxInCol :=> txInColCodecs
+        , AddressIndex :=> addressIndexCodecs
+        , ObservationCol :=> observationColCodecs
+        , RollbackCol :=> rollbackCodecs
+        ]
+
+failingUtxoLedgerProvider :: LedgerProvider.Provider IO
+failingUtxoLedgerProvider =
+    LedgerProvider.Provider
+        { LedgerProvider.withAcquired = \callback ->
+            callback $
+                LedgerProvider.mkQueryHandle
+                    LedgerProvider.QueryHandleBackend
+                        { LedgerProvider.backendQueryUTxOs =
+                            \_ -> failIO "base provider queryUTxOs used"
+                        , LedgerProvider.backendQueryUTxOsAt =
+                            \_ -> failIO "base provider queryUTxOsAt used"
+                        , LedgerProvider.backendQueryUTxOByTxIn =
+                            \_ ->
+                                failIO
+                                    "base provider queryUTxOByTxIn used"
+                        , LedgerProvider.backendQueryProtocolParams =
+                            failIO "unused queryProtocolParams"
+                        , LedgerProvider.backendQueryLedgerSnapshot =
+                            pure testLedgerSnapshot
+                        , LedgerProvider.backendQueryStakeRewards =
+                            \_ -> failIO "unused queryStakeRewards"
+                        , LedgerProvider.backendQueryRewardAccounts =
+                            \_ -> failIO "unused queryRewardAccounts"
+                        , LedgerProvider.backendQueryVoteDelegatees =
+                            \_ -> failIO "unused queryVoteDelegatees"
+                        , LedgerProvider.backendQueryTreasury =
+                            failIO "unused queryTreasury"
+                        , LedgerProvider.backendQueryGovernanceState =
+                            failIO "unused queryGovernanceState"
+                        , LedgerProvider.backendEvaluateTx =
+                            \_ -> failIO "unused evaluateTx"
+                        , LedgerProvider.backendPosixMsToSlot =
+                            \_ -> failIO "unused posixMsToSlot"
+                        , LedgerProvider.backendPosixMsCeilSlot =
+                            \_ -> failIO "unused posixMsCeilSlot"
+                        }
+        , LedgerProvider.queryUTxOs =
+            \_ -> failIO "base provider queryUTxOs used"
+        , LedgerProvider.queryUTxOByTxIn =
+            \_ -> failIO "base provider queryUTxOByTxIn used"
+        , LedgerProvider.queryProtocolParams =
+            failIO "unused queryProtocolParams"
+        , LedgerProvider.queryLedgerSnapshot = pure testLedgerSnapshot
+        , LedgerProvider.queryStakeRewards =
+            \_ -> failIO "unused queryStakeRewards"
+        , LedgerProvider.queryRewardAccounts =
+            \_ -> failIO "unused queryRewardAccounts"
+        , LedgerProvider.queryVoteDelegatees =
+            \_ -> failIO "unused queryVoteDelegatees"
+        , LedgerProvider.queryTreasury = failIO "unused queryTreasury"
+        , LedgerProvider.queryGovernanceState =
+            failIO "unused queryGovernanceState"
+        , LedgerProvider.evaluateTx = \_ -> failIO "unused evaluateTx"
+        , LedgerProvider.posixMsToSlot =
+            \_ -> failIO "unused posixMsToSlot"
+        , LedgerProvider.posixMsCeilSlot =
+            \_ -> failIO "unused posixMsCeilSlot"
+        , LedgerProvider.queryUpperBoundSlot =
+            \_ -> failIO "unused queryUpperBoundSlot"
+        }
+
+failIO :: String -> IO a
+failIO = ioError . userError
+
+testLedgerSnapshot :: LedgerProvider.LedgerSnapshot
+testLedgerSnapshot =
+    LedgerProvider.LedgerSnapshot
+        { LedgerProvider.ledgerCurrentEra = Text.pack "Conway"
+        , LedgerProvider.ledgerChainPoint = GenesisPoint
+        , LedgerProvider.ledgerTipSlot = SlotNo 44
+        , LedgerProvider.ledgerEpoch = EpochNo 2
+        }
+
+testIndexerTxIn :: Indexer.TxIn
+testIndexerTxIn =
+    Indexer.TxIn
+        { Indexer.txInId = testTxIdBytes
+        , Indexer.txInIx = 3
+        }
+
+testLedgerTxIn :: Ledger.TxIn
+testLedgerTxIn =
+    Ledger.TxIn
+        ( Ledger.TxId
+            (unsafeMakeSafeHash (UnsafeHash (SBS.toShort testTxIdBytes)))
+        )
+        (TxIx 3)
+
+testTxIdBytes :: BS.ByteString
+testTxIdBytes = BS.replicate 32 0x11
+
+indexedAddr :: Indexer.Address
+indexedAddr = Indexer.Address (serialiseAddr testAddr)
+
+testAddr :: Addr
+testAddr = AddrBootstrap (BootstrapAddress byronAddress)
+
+testTxOut :: TxOut ConwayEra
+testTxOut =
+    mkBasicTxOut @ConwayEra
+        testAddr
+        (inject $ Coin 42_000_000)
+
+byronAddress :: ByronCommon.Address
+byronAddress =
+    either
+        (error . show)
+        id
+        ( ByronCommon.decodeAddressBase58
+            "DdzFFzCqrhsq3KjLtT51mESbZ4RepiHPzLqEhamexVFTJpGbCXmh7qSxnHvaL88QmtVTD1E1sjx8Z1ZNDhYmcBV38ZjDST9kYVxSkhcw"
+        )
+
+conwayVersion :: LedgerBinary.Version
+conwayVersion = eraProtVerLow @ConwayEra

--- a/test/unit-main.hs
+++ b/test/unit-main.hs
@@ -12,6 +12,7 @@ import Cardano.Node.Client.UTxOIndexer.FollowerSpec qualified as UTxOIndexerFoll
 import Cardano.Node.Client.UTxOIndexer.IndexerSpec qualified as UTxOIndexerSpec
 import Cardano.Node.Client.UTxOIndexer.MainnetSmokeSpec qualified as UTxOIndexerMainnetSmokeSpec
 import Cardano.Node.Client.UTxOIndexer.PersistenceSpec qualified as UTxOIndexerPersistenceSpec
+import Cardano.Node.Client.UTxOIndexer.ProviderSpec qualified as UTxOIndexerProviderSpec
 import Cardano.Node.Client.UTxOIndexer.ServerSpec qualified as UTxOIndexerServerSpec
 import Cardano.Node.Client.UTxOIndexer.TypesSpec qualified as UTxOIndexerTypesSpec
 import Cardano.Node.Client.ValiditySpec qualified as ValiditySpec
@@ -27,6 +28,7 @@ main = hspec $ do
     UTxOIndexerSpec.spec
     UTxOIndexerServerSpec.spec
     UTxOIndexerPersistenceSpec.spec
+    UTxOIndexerProviderSpec.spec
     UTxOIndexerDaemonSpec.spec
     UTxOIndexerFollowerSpec.spec
     UTxOIndexerMainnetSmokeSpec.spec


### PR DESCRIPTION
## Summary
- add a type-indexed provider layer with LedgerOnly and LedgerAndIndexer modes
- keep CLI provider scope ledger-only while allowing HTTP/server scope to open acquired ledger and indexer transaction scopes together
- expose indexed UTxO lookup methods only through the indexer provider path

## Testing
- nix develop --quiet -c just ci
  - build passed
  - unit-tests: 116 examples, 0 failures, 1 pending
  - cabal-fmt, fourmolu, hlint passed
  - git diff --check passed
