### PR TITLE
feat(utxo-indexer): expose indexer transaction runner

### DIFF
--- a/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
+++ b/lib-utxo-indexer/Cardano/Node/Client/UTxOIndexer/Indexer.hs
@@ -68,7 +68,9 @@ module Cardano.Node.Client.UTxOIndexer.Indexer (
     withFollowerHandlers,
     withFollowerInterest,
     withInMemoryIndexer,
+    withInMemoryIndexerRunner,
     withRocksDBIndexer,
+    withRocksDBIndexerRunner,
 
     -- * UTxO operations and filters
     InterestSet (..),
@@ -376,9 +378,25 @@ RocksDB one.
 -}
 withInMemoryIndexer :: (IndexerHandle -> IO a) -> IO a
 withInMemoryIndexer action = do
+    withInMemoryIndexerRunner $ \handle _runner ->
+        action handle
+
+{- | Open an in-memory indexer and expose both the public
+'IndexerHandle' and the underlying transaction runner.
+
+Most callers should use 'withInMemoryIndexer'. Server-style callers
+that also need typed transactional reads through
+"Cardano.Node.Client.UTxOIndexer.Provider" use this variant to pass
+the same runner to @'Cardano.Node.Client.UTxOIndexer.Provider.withProvider'@.
+-}
+withInMemoryIndexerRunner ::
+    (forall cf op. IndexerHandle -> RunTransaction IO cf Cols op -> IO a) ->
+    IO a
+withInMemoryIndexerRunner action = do
     db <- mkInMemoryDatabase (mkColumns [0 :: Int ..] indexerCodecs)
     runner <- newRunTransaction db
-    bootHandle runner action
+    bootHandle runner $ \handle ->
+        action handle runner
 
 {- | Open a RocksDB-backed indexer at @path@ (creating
 the directory tree if missing) and run the action with
@@ -400,6 +418,22 @@ the names are paired with the right typed selector.
 withRocksDBIndexer ::
     FilePath -> (IndexerHandle -> IO a) -> IO a
 withRocksDBIndexer path action =
+    withRocksDBIndexerRunner path $ \handle _runner ->
+        action handle
+
+{- | Open a RocksDB-backed indexer and expose both the public
+'IndexerHandle' and the underlying transaction runner.
+
+The handle remains the mutation/follower surface; the runner is the
+read transaction surface used by the typed provider bridge. Returning
+them from the same bracket guarantees the HTTP/server layer reads from
+the exact store its chain-sync follower is mutating.
+-}
+withRocksDBIndexerRunner ::
+    FilePath ->
+    (forall cf op. IndexerHandle -> RunTransaction IO cf Cols op -> IO a) ->
+    IO a
+withRocksDBIndexerRunner path action =
     withDBCF
         path
         def{createIfMissing = True}
@@ -414,7 +448,8 @@ withRocksDBIndexer path action =
                         rdb
                         (mkColumns (columnFamilies rdb) indexerCodecs)
             runner <- newRunTransaction database
-            bootHandle runner action
+            bootHandle runner $ \handle ->
+                action handle runner
 
 {- | Final stage shared by both constructors: derive the
 initial rollback-log counter from the database, set up

--- a/test/Cardano/Node/Client/UTxOIndexer/ProviderSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/ProviderSpec.hs
@@ -24,10 +24,9 @@ import Cardano.Ledger.Val (inject)
 import Cardano.Node.Client.Provider qualified as LedgerProvider
 import Cardano.Node.Client.UTxOIndexer.Columns (
     Cols (..),
-    addressIndexCodecs,
-    observationColCodecs,
-    rollbackCodecs,
-    txInColCodecs,
+ )
+import Cardano.Node.Client.UTxOIndexer.Indexer (
+    withInMemoryIndexerRunner,
  )
 import Cardano.Node.Client.UTxOIndexer.Provider (
     Provider (..),
@@ -44,15 +43,10 @@ import Cardano.Node.Client.UTxOIndexer.Types qualified as Indexer
 import Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
 import Data.ByteString qualified as BS
 import Data.ByteString.Short qualified as SBS
-import Data.Dependent.Map (DMap)
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as Text
-import Database.KV.Database (mkColumns)
-import Database.KV.InMemory (mkInMemoryDatabase)
 import Database.KV.Transaction (
-    Codecs,
-    DSum ((:=>)),
     RunTransaction (..),
  )
 import Database.KV.Transaction qualified as KV
@@ -130,24 +124,14 @@ withIndexedOutput ::
     ) ->
     IO a
 withIndexedOutput action = do
-    db <- mkInMemoryDatabase (mkColumns [0 :: Int ..] testCodecs)
-    runner@RunTransaction{runTransaction} <- KV.newRunTransaction db
-    runTransaction $ do
-        KV.insert TxInCol testIndexerTxIn indexedAddr
-        KV.insert
-            AddressIndex
-            (Indexer.AddrKey indexedAddr testIndexerTxIn)
-            (Indexer.TxOut (serialize' conwayVersion testTxOut))
-    action runner testLedgerTxIn testTxOut
-
-testCodecs :: DMap Cols Codecs
-testCodecs =
-    KV.fromList
-        [ TxInCol :=> txInColCodecs
-        , AddressIndex :=> addressIndexCodecs
-        , ObservationCol :=> observationColCodecs
-        , RollbackCol :=> rollbackCodecs
-        ]
+    withInMemoryIndexerRunner $ \_handle runner@RunTransaction{runTransaction} -> do
+        runTransaction $ do
+            KV.insert TxInCol testIndexerTxIn indexedAddr
+            KV.insert
+                AddressIndex
+                (Indexer.AddrKey indexedAddr testIndexerTxIn)
+                (Indexer.TxOut (serialize' conwayVersion testTxOut))
+        action runner testLedgerTxIn testTxOut
 
 failingUtxoLedgerProvider :: LedgerProvider.Provider IO
 failingUtxoLedgerProvider =


### PR DESCRIPTION
## Summary
- add `withInMemoryIndexerRunner` and `withRocksDBIndexerRunner` so downstream code can receive the `RunTransaction IO cf Cols op` tied to the opened indexer store
- keep existing `withInMemoryIndexer` / `withRocksDBIndexer` compatibility by delegating to the runner variants
- update the typed provider test to prove ledger + indexer transaction scopes can be acquired together

## Downstream proof
- amaru-treasury-tx experiment branch `exp/254-typed-provider-integration` at `28618fb6` pins this branch at `4986c3f`
- ATX carries the runner through `ApiIndexer` and routes API build/inspect UTxO reads through the typed indexer provider for direct and acquired-handle paths

## Testing
- `nix develop --quiet -c just ci`
- downstream ATX: `nix develop --quiet -c cabal build amaru-treasury-tx:lib:amaru-treasury-tx amaru-treasury-tx:exe:amaru-treasury-tx-api amaru-treasury-tx:test:unit-tests -O0`
- downstream ATX: `nix develop --quiet -c just unit "Amaru.Treasury.Api handlers + indexer"`
- downstream ATX: `nix develop --quiet -c just devnet-api-smoke`
- downstream ATX: `nix develop --quiet -c just ci`