### PR TITLE
feat: tx-history-indexer-lib for treasury history

### DIFF
--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -89,6 +89,7 @@ library
     , cardano-ledger-mary
     , cardano-ledger-read
     , cardano-node-clients:block-indexer
+    , cardano-node-clients:tx-history-indexer-lib
     , cardano-node-clients:utxo-indexer-lib
     , cardano-prelude
     , cardano-slotting
@@ -217,6 +218,7 @@ library tx-history-indexer-lib
   hs-source-dirs:   lib-tx-history-indexer
   default-language: GHC2021
   exposed-modules:
+    Cardano.Node.Client.TxHistoryIndexer.BlockExtract
     Cardano.Node.Client.TxHistoryIndexer.Columns
     Cardano.Node.Client.TxHistoryIndexer.Indexer
     Cardano.Node.Client.TxHistoryIndexer.Types
@@ -258,6 +260,7 @@ test-suite unit-tests
     Cardano.Node.Client.ConwayFixtures
     Cardano.Node.Client.N2C.ProbeSpec
     Cardano.Node.Client.N2C.TraceSpec
+    Cardano.Node.Client.TxHistoryIndexer.HistoryRollbackSpec
     Cardano.Node.Client.TxHistoryIndexer.IndexerSpec
     Cardano.Node.Client.UTxOIndexer.BlockExtractSpec
     Cardano.Node.Client.UTxOIndexer.DaemonSpec
@@ -267,6 +270,7 @@ test-suite unit-tests
     Cardano.Node.Client.UTxOIndexer.PersistenceSpec
     Cardano.Node.Client.UTxOIndexer.ProviderSpec
     Cardano.Node.Client.UTxOIndexer.ServerSpec
+    Cardano.Node.Client.UTxOIndexer.SharedFollowerSpec
     Cardano.Node.Client.UTxOIndexer.TypesSpec
     Cardano.Node.Client.ValiditySpec
     Data.List.SampleFibonacciSpec

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -211,6 +211,30 @@ library utxo-indexer-lib
     , some
     , stm
 
+library tx-history-indexer-lib
+  import:           warnings
+  visibility:       public
+  hs-source-dirs:   lib-tx-history-indexer
+  default-language: GHC2021
+  exposed-modules:
+    Cardano.Node.Client.TxHistoryIndexer.Columns
+    Cardano.Node.Client.TxHistoryIndexer.Indexer
+    Cardano.Node.Client.TxHistoryIndexer.Types
+
+  build-depends:
+    , base
+    , bytestring
+    , cardano-slotting
+    , containers
+    , data-default-class
+    , dependent-map
+    , dependent-sum
+    , lens
+    , rocksdb-haskell-jprupp
+    , rocksdb-kv-transactions
+    , rocksdb-kv-transactions:kv-transactions
+    , stm
+
 executable utxo-indexer
   import:           warnings
   hs-source-dirs:   app/utxo-indexer
@@ -234,6 +258,7 @@ test-suite unit-tests
     Cardano.Node.Client.ConwayFixtures
     Cardano.Node.Client.N2C.ProbeSpec
     Cardano.Node.Client.N2C.TraceSpec
+    Cardano.Node.Client.TxHistoryIndexer.IndexerSpec
     Cardano.Node.Client.UTxOIndexer.BlockExtractSpec
     Cardano.Node.Client.UTxOIndexer.DaemonSpec
     Cardano.Node.Client.UTxOIndexer.FollowerSpec
@@ -265,6 +290,7 @@ test-suite unit-tests
     , cardano-ledger-mary
     , cardano-node-clients
     , cardano-node-clients:block-indexer
+    , cardano-node-clients:tx-history-indexer-lib
     , cardano-node-clients:utxo-indexer-lib
     , cardano-slotting
     , cardano-strict-containers

--- a/gate.sh
+++ b/gate.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-git diff --check
-nix develop --quiet -c just ci

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix develop --quiet -c just ci

--- a/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/BlockExtract.hs
+++ b/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/BlockExtract.hs
@@ -1,0 +1,54 @@
+{- |
+Module      : Cardano.Node.Client.TxHistoryIndexer.BlockExtract
+Description : Treasury-neutral per-transaction payload and decoder seam
+License     : Apache-2.0
+
+The plug point that keeps transaction decoding /outside/ this
+repository. The shared chain-sync follower extracts each block into a
+list of 'BlockTx' — the raw, era-agnostic per-transaction bytes — and
+hands them to a caller-supplied 'DecodeTx'. Downstream applications
+(e.g. a treasury indexer) own the 'DecodeTx' and the meaning of any
+'Cardano.Node.Client.TxHistoryIndexer.Types.TxRole' /
+'Cardano.Node.Client.TxHistoryIndexer.Types.HistoryScope' it emits;
+this library never interprets the bytes.
+
+= Neutrality
+
+'BlockTx' carries opaque bytes only. There is deliberately no scope,
+role, redeemer, or any application-specific structure here: a
+'DecodeTx' is free to parse the bytes however it likes and emit
+'Cardano.Node.Client.TxHistoryIndexer.Types.TxSummaryEntry' values, or
+'Nothing' for transactions it does not care about.
+-}
+module Cardano.Node.Client.TxHistoryIndexer.BlockExtract (
+    -- * Per-transaction payload
+    BlockTx (..),
+    mkBlockTx,
+
+    -- * Decoder seam
+    DecodeTx,
+) where
+
+import Cardano.Node.Client.TxHistoryIndexer.Types (TxSummaryEntry)
+import Data.ByteString (ByteString)
+
+{- | Raw, treasury-neutral payload for a single transaction in a
+block: the transaction's serialised bytes, exactly as carried on
+chain. A 'DecodeTx' parses these bytes; this library never does.
+-}
+newtype BlockTx = BlockTx {unBlockTx :: ByteString}
+    deriving stock (Eq, Show)
+
+-- | Build a 'BlockTx' from a transaction's raw serialised bytes.
+mkBlockTx :: ByteString -> BlockTx
+mkBlockTx = BlockTx
+
+{- | The decoder plug point. A downstream application supplies a
+function that maps one transaction's raw bytes to the history entries
+it wants persisted, or 'Nothing' if the transaction is irrelevant.
+
+The decoder owns all application semantics; keeping it a function
+type (rather than a class or concrete decoder) is what keeps decoding
+out of this repository.
+-}
+type DecodeTx = BlockTx -> Maybe [TxSummaryEntry]

--- a/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/BlockExtract.hs
+++ b/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/BlockExtract.hs
@@ -30,6 +30,7 @@ module Cardano.Node.Client.TxHistoryIndexer.BlockExtract (
 ) where
 
 import Cardano.Node.Client.TxHistoryIndexer.Types (TxSummaryEntry)
+import Cardano.Slotting.Slot (SlotNo)
 import Data.ByteString (ByteString)
 
 {- | Raw, treasury-neutral payload for a single transaction in a
@@ -44,11 +45,20 @@ mkBlockTx :: ByteString -> BlockTx
 mkBlockTx = BlockTx
 
 {- | The decoder plug point. A downstream application supplies a
-function that maps one transaction's raw bytes to the history entries
-it wants persisted, or 'Nothing' if the transaction is irrelevant.
+function that maps the current block's slot plus one transaction's raw
+bytes to the history entries it wants persisted, or 'Nothing' if the
+transaction is irrelevant.
+
+The slot is the 'Cardano.Slotting.Slot.SlotNo' of the block the
+transaction was extracted from — the same slot type
+'Cardano.Node.Client.TxHistoryIndexer.Types.TxSummaryKey' keys on, so a
+decoder can build a well-keyed
+'Cardano.Node.Client.TxHistoryIndexer.Types.TxSummaryEntry' without
+guessing or hardcoding the slot. The shared follower supplies the slot
+of the block being processed; the decoder never has to infer it.
 
 The decoder owns all application semantics; keeping it a function
 type (rather than a class or concrete decoder) is what keeps decoding
 out of this repository.
 -}
-type DecodeTx = BlockTx -> Maybe [TxSummaryEntry]
+type DecodeTx = SlotNo -> BlockTx -> Maybe [TxSummaryEntry]

--- a/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Columns.hs
+++ b/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Columns.hs
@@ -9,7 +9,7 @@ Database layout for the multi-tenant tx-history indexer expressed
 against the 'Database.KV.Transaction' abstraction from
 @kv-transactions@.
 
-One column:
+Two columns:
 
 * 'HistoryCol' :: @KV TxSummaryKey ByteString@ — entries filed
   under the ordered composite key
@@ -19,6 +19,15 @@ One column:
   @(tenant, scope)@ in @(slot, txid, role)@ order. The value is
   the opaque payload blob, stored verbatim.
 
+* 'HistoryBlockCol' :: @KV SlotNo HistoryBlock@ — the per-block
+  rollback/resume log keyed by chain slot (big-endian, so a cursor
+  walks blocks in slot order). Each row records the block hash and
+  the composite keys filed for that block, so a roll-backward can
+  delete every entry above a target slot and a resume can report the
+  retained @(slot, blockHash)@ cursor. This is the history store's
+  half of the plan's cursor model 2: separate persisted cursors per
+  attached store.
+
 Both the in-memory and RocksDB backends share these column
 definitions verbatim — the backend choice happens at the
 'Database.KV.InMemory' / 'Database.KV.RocksDB' boundary, not here.
@@ -27,9 +36,13 @@ module Cardano.Node.Client.TxHistoryIndexer.Columns (
     -- * Column GADT
     Cols (..),
 
+    -- * Rollback/resume log row
+    HistoryBlock (..),
+
     -- * Codecs
     historyCodecs,
     historyColCodecs,
+    historyBlockColCodecs,
 ) where
 
 import Cardano.Node.Client.TxHistoryIndexer.Types (
@@ -37,8 +50,11 @@ import Cardano.Node.Client.TxHistoryIndexer.Types (
     summaryKeyFromBytes,
     summaryKeyToBytes,
  )
+import Cardano.Slotting.Slot (SlotNo (..))
 import Control.Lens (Prism', prism')
+import Data.Bits (shiftL, shiftR, (.&.), (.|.))
 import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
 import Data.Dependent.Map (DMap)
 import Data.GADT.Compare (
     GCompare (..),
@@ -46,12 +62,23 @@ import Data.GADT.Compare (
     GOrdering (..),
  )
 import Data.Type.Equality (type (:~:) (Refl))
+import Data.Word (Word16, Word64)
 import Database.KV.Transaction (
     Codecs (..),
     DSum ((:=>)),
     KV,
     fromList,
  )
+
+{- | One row of the per-block rollback/resume log: the block hash
+applied at a chain slot, and the composite keys filed for that block
+(so a roll-backward can delete them).
+-}
+data HistoryBlock = HistoryBlock
+    { hbBlockHash :: !ByteString
+    , hbEntryKeys :: ![TxSummaryKey]
+    }
+    deriving stock (Eq, Show)
 
 -- | The tx-history indexer database's column families.
 data Cols c where
@@ -61,12 +88,20 @@ data Cols c where
     -- yields every entry of one @(tenant, scope)@ in
     -- @(slot, txid, role)@ order.
     HistoryCol :: Cols (KV TxSummaryKey ByteString)
+    -- | Per-block rollback/resume log: @SlotNo → HistoryBlock@,
+    -- keyed by chain slot in big-endian byte order.
+    HistoryBlockCol :: Cols (KV SlotNo HistoryBlock)
 
 instance GEq Cols where
     geq HistoryCol HistoryCol = Just Refl
+    geq HistoryBlockCol HistoryBlockCol = Just Refl
+    geq _ _ = Nothing
 
 instance GCompare Cols where
     gcompare HistoryCol HistoryCol = GEQ
+    gcompare HistoryCol HistoryBlockCol = GLT
+    gcompare HistoryBlockCol HistoryCol = GGT
+    gcompare HistoryBlockCol HistoryBlockCol = GEQ
 
 -- | Codecs for 'HistoryCol'.
 historyColCodecs :: Codecs (KV TxSummaryKey ByteString)
@@ -76,21 +111,114 @@ historyColCodecs =
         , valueCodec = payloadPrism
         }
 
+-- | Codecs for 'HistoryBlockCol'.
+historyBlockColCodecs :: Codecs (KV SlotNo HistoryBlock)
+historyBlockColCodecs =
+    Codecs
+        { keyCodec = slotPrism
+        , valueCodec = historyBlockPrism
+        }
+
 -- | The full column-codec map for the tx-history database.
 historyCodecs :: DMap Cols Codecs
-historyCodecs = fromList [HistoryCol :=> historyColCodecs]
+historyCodecs =
+    fromList
+        [ HistoryCol :=> historyColCodecs
+        , HistoryBlockCol :=> historyBlockColCodecs
+        ]
 
 -- Internal --------------------------------------------------------
 
 summaryKeyPrism :: Prism' ByteString TxSummaryKey
-summaryKeyPrism = prism' encode summaryKeyFromBytes
-  where
-    encode k = case summaryKeyToBytes k of
-        Just bs -> bs
-        Nothing ->
-            error
-                "summaryKeyPrism: tenant or scope exceeds 255 \
-                \bytes — invariant violation"
+summaryKeyPrism = prism' encodeKey summaryKeyFromBytes
+
+encodeKey :: TxSummaryKey -> ByteString
+encodeKey k = case summaryKeyToBytes k of
+    Just bs -> bs
+    Nothing ->
+        error
+            "summaryKeyPrism: tenant or scope exceeds 255 \
+            \bytes — invariant violation"
 
 payloadPrism :: Prism' ByteString ByteString
 payloadPrism = prism' id Just
+
+slotPrism :: Prism' ByteString SlotNo
+slotPrism = prism' encode decode
+  where
+    encode (SlotNo s) = word64BE s
+    decode bs
+        | BS.length bs == 8 = Just (SlotNo (word64FromBE bs))
+        | otherwise = Nothing
+
+{- | Codec for a 'HistoryBlock' row:
+@len16 blockHash || count16 || (len16 key)*@.
+-}
+historyBlockPrism :: Prism' ByteString HistoryBlock
+historyBlockPrism = prism' encode decode
+  where
+    encode (HistoryBlock h keys) =
+        lenPrefixed16 h
+            <> word16BE (fromIntegral (length keys))
+            <> mconcat (lenPrefixed16 . encodeKey <$> keys)
+    decode bs0 = do
+        (h, rest0) <- readLenPrefixed16 bs0
+        (countBs, rest1) <- splitFixed 2 rest0
+        n <- word16FromBE countBs
+        (keys, rest2) <- readKeys (fromIntegral n) rest1
+        if BS.null rest2
+            then Just (HistoryBlock h keys)
+            else Nothing
+    readKeys 0 rest = Just ([], rest)
+    readKeys n rest = do
+        (kBytes, rest') <- readLenPrefixed16 rest
+        k <- summaryKeyFromBytes kBytes
+        (ks, rest'') <- readKeys (n - 1 :: Int) rest'
+        Just (k : ks, rest'')
+
+lenPrefixed16 :: ByteString -> ByteString
+lenPrefixed16 bs = word16BE (fromIntegral (BS.length bs)) <> bs
+
+readLenPrefixed16 :: ByteString -> Maybe (ByteString, ByteString)
+readLenPrefixed16 bs0 = do
+    (lenBs, rest0) <- splitFixed 2 bs0
+    n <- word16FromBE lenBs
+    splitFixed (fromIntegral n) rest0
+
+splitFixed :: Int -> ByteString -> Maybe (ByteString, ByteString)
+splitFixed n bs
+    | BS.length bs < n = Nothing
+    | otherwise = Just (BS.splitAt n bs)
+
+word16BE :: Word16 -> ByteString
+word16BE w =
+    BS.pack
+        [ fromIntegral (w `shiftR` 8) .&. 0xFF
+        , fromIntegral w .&. 0xFF
+        ]
+
+word16FromBE :: ByteString -> Maybe Word16
+word16FromBE bs
+    | BS.length bs /= 2 = Nothing
+    | otherwise =
+        Just $
+            foldr (.|.) 0 $
+                zipWith
+                    (\b s -> fromIntegral b `shiftL` s)
+                    (BS.unpack bs)
+                    [8, 0 :: Int]
+
+word64BE :: Word64 -> ByteString
+word64BE w =
+    BS.pack
+        [ fromIntegral (w `shiftR` n) .&. 0xFF
+        | n <- [56, 48, 40, 32, 24, 16, 8, 0]
+        ]
+
+word64FromBE :: ByteString -> Word64
+word64FromBE =
+    foldr (.|.) 0
+        . zipWith
+            (\s b -> fromIntegral b `shiftL` s)
+            [56, 48, 40, 32, 24, 16, 8, 0]
+        . BS.unpack

--- a/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Columns.hs
+++ b/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Columns.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE GADTs #-}
+
+{- |
+Module      : Cardano.Node.Client.TxHistoryIndexer.Columns
+License     : Apache-2.0
+Description : Typed-column GADT for the tx-history indexer database
+
+Database layout for the multi-tenant tx-history indexer expressed
+against the 'Database.KV.Transaction' abstraction from
+@kv-transactions@.
+
+One column:
+
+* 'HistoryCol' :: @KV TxSummaryKey ByteString@ — entries filed
+  under the ordered composite key
+  @lenTenant || tenant || lenScope || scope || slotBE || txid ||
+  role@ (see "Cardano.Node.Client.TxHistoryIndexer.Types"), so a
+  cursor seek to 'scopePrefix' yields every entry of one
+  @(tenant, scope)@ in @(slot, txid, role)@ order. The value is
+  the opaque payload blob, stored verbatim.
+
+Both the in-memory and RocksDB backends share these column
+definitions verbatim — the backend choice happens at the
+'Database.KV.InMemory' / 'Database.KV.RocksDB' boundary, not here.
+-}
+module Cardano.Node.Client.TxHistoryIndexer.Columns (
+    -- * Column GADT
+    Cols (..),
+
+    -- * Codecs
+    historyCodecs,
+    historyColCodecs,
+) where
+
+import Cardano.Node.Client.TxHistoryIndexer.Types (
+    TxSummaryKey,
+    summaryKeyFromBytes,
+    summaryKeyToBytes,
+ )
+import Control.Lens (Prism', prism')
+import Data.ByteString (ByteString)
+import Data.Dependent.Map (DMap)
+import Data.GADT.Compare (
+    GCompare (..),
+    GEq (..),
+    GOrdering (..),
+ )
+import Data.Type.Equality (type (:~:) (Refl))
+import Database.KV.Transaction (
+    Codecs (..),
+    DSum ((:=>)),
+    KV,
+    fromList,
+ )
+
+-- | The tx-history indexer database's column families.
+data Cols c where
+    -- | Entries table: @TxSummaryKey → payload@. Key is the
+    -- ordered composite key; a cursor prefix-scan by
+    -- 'Cardano.Node.Client.TxHistoryIndexer.Types.scopePrefix'
+    -- yields every entry of one @(tenant, scope)@ in
+    -- @(slot, txid, role)@ order.
+    HistoryCol :: Cols (KV TxSummaryKey ByteString)
+
+instance GEq Cols where
+    geq HistoryCol HistoryCol = Just Refl
+
+instance GCompare Cols where
+    gcompare HistoryCol HistoryCol = GEQ
+
+-- | Codecs for 'HistoryCol'.
+historyColCodecs :: Codecs (KV TxSummaryKey ByteString)
+historyColCodecs =
+    Codecs
+        { keyCodec = summaryKeyPrism
+        , valueCodec = payloadPrism
+        }
+
+-- | The full column-codec map for the tx-history database.
+historyCodecs :: DMap Cols Codecs
+historyCodecs = fromList [HistoryCol :=> historyColCodecs]
+
+-- Internal --------------------------------------------------------
+
+summaryKeyPrism :: Prism' ByteString TxSummaryKey
+summaryKeyPrism = prism' encode summaryKeyFromBytes
+  where
+    encode k = case summaryKeyToBytes k of
+        Just bs -> bs
+        Nothing ->
+            error
+                "summaryKeyPrism: tenant or scope exceeds 255 \
+                \bytes — invariant violation"
+
+payloadPrism :: Prism' ByteString ByteString
+payloadPrism = prism' id Just

--- a/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Indexer.hs
+++ b/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Indexer.hs
@@ -7,29 +7,44 @@ License     : Apache-2.0
 Description : Multi-tenant tx-history indexer state and API
 
 Holds the tx-history indexer's state behind a backend-agnostic
-'HistoryIndexer' handle and exposes the operations Slice 1 needs:
+'HistoryIndexer' handle.
+
+Slice 1 operations:
 
 * 'appendHistory' files a batch of 'TxSummaryEntry' under their
   ordered composite keys.
 * 'queryHistory' returns every entry of a single
   @(tenant, scope)@, ordered by @(slot, txid, role)@.
 
-Two backends share the same handle and therefore the same
-'appendHistory' / 'queryHistory' surface:
+Slice 2 adds the slot-aware, resumable surface the shared chain-sync
+follower drives (the plan's cursor model 2: a same chain-sync session
+drives the UTxO indexer and the history indexer through /separate
+persisted cursors/, and resume picks the oldest safe point across both
+stores):
 
-* 'withInMemoryHistoryIndexer' keeps a 'TVar' over a 'Map' from
-  the ordered composite-key bytes ('summaryKeyToBytes') to the
-  entry — ascending 'Map' key order is exactly the storage order
-  and a byte-prefix range restricts the scan to one
-  @(tenant, scope)@ bucket.
+* 'processHistoryBlock' files a block's entries and records a
+  @(slot, blockHash)@ rollback/resume point in the same write.
+* 'rollbackHistoryTo' drops every entry filed strictly above a target
+  slot, reversing the blocks above it.
+* 'getHistoryResumePoints' returns the retained @(slot, blockHash)@
+  points newest-first, for the follower's resume negotiation.
+
+Because the history store is a separate RocksDB database from the UTxO
+store, a per-block write across the two stores is not atomic. The
+cursor model tolerates this: 'processHistoryBlock' is idempotent in the
+block slot (replaying an already-applied block overwrites the same
+keys), and resume from the oldest safe point re-applies any block a
+mid-write crash left in only one store.
+
+Two backends share the same handle and surface:
+
+* 'withInMemoryHistoryIndexer' keeps a 'TVar' over a 'Map' from the
+  ordered composite-key bytes ('summaryKeyToBytes') to the entry, plus
+  a 'Map' from chain slot to the block's 'HistoryBlock' rollback row.
 * 'withRocksDBHistoryIndexer' uses a @kv-transactions@ RocksDB
   'Database' keyed by the 'Cols' GADT; the same ordered key codec
-  drives the on-disk byte order, so a cursor prefix-scan over
-  'scopePrefix' yields the identical ordered result.
-
-The length-prefixed variable-length parts keep strict
-byte-prefix tenants/scopes (@"a"@ vs @"ab"@) from bleeding into
-one another in both backends.
+  drives the on-disk byte order, and the 'HistoryBlockCol' column
+  persists the rollback/resume log.
 -}
 module Cardano.Node.Client.TxHistoryIndexer.Indexer (
     -- * Indexer handle
@@ -37,13 +52,19 @@ module Cardano.Node.Client.TxHistoryIndexer.Indexer (
     withInMemoryHistoryIndexer,
     withRocksDBHistoryIndexer,
 
-    -- * Operations
+    -- * Slice 1 operations
     appendHistory,
     queryHistory,
+
+    -- * Slice 2 block/rollback/resume operations
+    processHistoryBlock,
+    rollbackHistoryTo,
+    getHistoryResumePoints,
 ) where
 
 import Cardano.Node.Client.TxHistoryIndexer.Columns (
     Cols (..),
+    HistoryBlock (..),
     historyCodecs,
  )
 import Cardano.Node.Client.TxHistoryIndexer.Types (
@@ -64,6 +85,7 @@ import Control.Concurrent.STM (
     newTVarIO,
     readTVarIO,
  )
+import Control.Monad (forM_, when)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.Default.Class (def)
@@ -72,6 +94,7 @@ import Data.Map.Strict qualified as Map
 import Database.KV.Cursor (
     Cursor,
     Entry (..),
+    firstEntry,
     nextEntry,
     seekKey,
  )
@@ -79,6 +102,7 @@ import Database.KV.Database (KV, mkColumns)
 import Database.KV.RocksDB (mkRocksDBDatabase)
 import Database.KV.Transaction (
     RunTransaction (..),
+    delete,
     insert,
     iterating,
     newRunTransaction,
@@ -90,8 +114,7 @@ import Database.RocksDB (
  )
 
 {- | Backend-agnostic handle to a tx-history indexer. Both the
-in-memory and RocksDB backends provide the same two operations,
-so 'appendHistory' / 'queryHistory' work uniformly across them.
+in-memory and RocksDB backends provide the same operations.
 -}
 data HistoryIndexer = HistoryIndexer
     { hiAppend :: [TxSummaryEntry] -> IO ()
@@ -99,6 +122,17 @@ data HistoryIndexer = HistoryIndexer
     , hiQuery :: TenantId -> HistoryScope -> IO [TxSummaryEntry]
     -- ^ Return every entry of @(tenant, scope)@, ordered by
     -- @(slot, txid, role)@.
+    , hiProcessBlock ::
+        SlotNo ->
+        ByteString ->
+        [TxSummaryEntry] ->
+        IO ()
+    -- ^ File a block's entries and record its
+    -- @(slot, blockHash)@ rollback/resume point.
+    , hiRollbackTo :: SlotNo -> IO ()
+    -- ^ Drop every entry filed strictly above a target slot.
+    , hiResumePoints :: IO [(SlotNo, ByteString)]
+    -- ^ Retained @(slot, blockHash)@ resume points, newest-first.
     }
 
 {- | File a batch of history entries. Each entry is keyed by its
@@ -118,7 +152,44 @@ queryHistory ::
     IO [TxSummaryEntry]
 queryHistory = hiQuery
 
+{- | File a block's history entries and record a @(slot, blockHash)@
+rollback/resume point in the same write. Idempotent in the block slot:
+re-applying an already-applied block overwrites the same keys and the
+same rollback row, so a query result is unchanged.
+-}
+processHistoryBlock ::
+    HistoryIndexer ->
+    SlotNo ->
+    ByteString ->
+    [TxSummaryEntry] ->
+    IO ()
+processHistoryBlock = hiProcessBlock
+
+{- | Drop every history entry filed strictly above the target slot,
+reversing the blocks above it. Entries filed at or below the target
+remain.
+-}
+rollbackHistoryTo :: HistoryIndexer -> SlotNo -> IO ()
+rollbackHistoryTo = hiRollbackTo
+
+{- | The retained @(slot, blockHash)@ resume points, newest-first.
+@[]@ on a fresh store (cold boot).
+-}
+getHistoryResumePoints :: HistoryIndexer -> IO [(SlotNo, ByteString)]
+getHistoryResumePoints = hiResumePoints
+
 -- In-memory backend ------------------------------------------------
+
+{- | In-memory store: the ordered entry map plus the per-block
+rollback/resume log.
+-}
+data MemState = MemState
+    { msEntries :: !(Map ByteString TxSummaryEntry)
+    , msBlocks :: !(Map SlotNo HistoryBlock)
+    }
+
+emptyMemState :: MemState
+emptyMemState = MemState Map.empty Map.empty
 
 {- | Open an in-memory tx-history indexer, run the action with
 the handle, and discard the store on exit. The store starts
@@ -126,38 +197,86 @@ empty.
 -}
 withInMemoryHistoryIndexer :: (HistoryIndexer -> IO a) -> IO a
 withInMemoryHistoryIndexer action = do
-    store <- newTVarIO Map.empty
+    store <- newTVarIO emptyMemState
     action
         HistoryIndexer
             { hiAppend = memAppend store
             , hiQuery = memQuery store
+            , hiProcessBlock = memProcessBlock store
+            , hiRollbackTo = memRollbackTo store
+            , hiResumePoints = memResumePoints store
             }
 
-memAppend ::
-    TVar (Map ByteString TxSummaryEntry) ->
+insertEntry ::
+    Map ByteString TxSummaryEntry ->
+    TxSummaryEntry ->
+    Map ByteString TxSummaryEntry
+insertEntry m entry =
+    case summaryKeyToBytes (tseKey entry) of
+        Nothing -> m
+        Just k -> Map.insert k entry m
+
+memAppend :: TVar MemState -> [TxSummaryEntry] -> IO ()
+memAppend store entries =
+    atomically $ modifyTVar' store $ \st ->
+        st{msEntries = foldl insertEntry (msEntries st) entries}
+
+memProcessBlock ::
+    TVar MemState ->
+    SlotNo ->
+    ByteString ->
     [TxSummaryEntry] ->
     IO ()
-memAppend store entries =
-    atomically $ modifyTVar' store insertAll
-  where
-    insertAll m = foldl insertOne m entries
-    insertOne m entry =
-        case summaryKeyToBytes (tseKey entry) of
-            Nothing -> m
-            Just k -> Map.insert k entry m
+memProcessBlock store slot hash entries =
+    atomically $ modifyTVar' store $ \st ->
+        st
+            { msEntries = foldl insertEntry (msEntries st) entries
+            , msBlocks =
+                Map.insert
+                    slot
+                    (HistoryBlock hash (tseKey <$> entries))
+                    (msBlocks st)
+            }
+
+memRollbackTo :: TVar MemState -> SlotNo -> IO ()
+memRollbackTo store target =
+    atomically $ modifyTVar' store $ \st ->
+        let (keep, stale) =
+                Map.partitionWithKey
+                    (\s _ -> s <= target)
+                    (msBlocks st)
+            staleKeyBytes =
+                [ kb
+                | hb <- Map.elems stale
+                , k <- hbEntryKeys hb
+                , Just kb <- [summaryKeyToBytes k]
+                ]
+         in st
+                { msEntries =
+                    foldl (flip Map.delete) (msEntries st) staleKeyBytes
+                , msBlocks = keep
+                }
+
+memResumePoints :: TVar MemState -> IO [(SlotNo, ByteString)]
+memResumePoints store = do
+    st <- readTVarIO store
+    pure
+        [ (slot, hbBlockHash hb)
+        | (slot, hb) <- Map.toDescList (msBlocks st)
+        ]
 
 memQuery ::
-    TVar (Map ByteString TxSummaryEntry) ->
+    TVar MemState ->
     TenantId ->
     HistoryScope ->
     IO [TxSummaryEntry]
 memQuery store tenant scope = do
-    m <- readTVarIO store
+    st <- readTVarIO store
     pure $ case scopePrefix tenant scope of
         Nothing -> []
         Just prefix ->
             [ entry
-            | (k, entry) <- Map.toAscList m
+            | (k, entry) <- Map.toAscList (msEntries st)
             , prefix `BS.isPrefixOf` k
             ]
 
@@ -167,10 +286,9 @@ memQuery store tenant scope = do
 the directory tree if missing) and run the action with the
 handle. The on-disk store survives process restart.
 
-One column family is created: @tx-history.entries@ — the
-'HistoryCol' table. Entries are filed under the same ordered
-composite key as the in-memory backend, so 'queryHistory'
-returns byte-for-byte identical ordered results.
+Two column families are created: @tx-history.entries@ (the
+'HistoryCol' table) and @tx-history.blocks@ (the 'HistoryBlockCol'
+rollback/resume log).
 -}
 withRocksDBHistoryIndexer ::
     FilePath -> (HistoryIndexer -> IO a) -> IO a
@@ -178,7 +296,9 @@ withRocksDBHistoryIndexer path action =
     withDBCF
         path
         def{createIfMissing = True}
-        [("tx-history.entries", def)]
+        [ ("tx-history.entries", def)
+        , ("tx-history.blocks", def)
+        ]
         $ \rdb -> do
             let database =
                     mkRocksDBDatabase
@@ -189,6 +309,9 @@ withRocksDBHistoryIndexer path action =
                 HistoryIndexer
                     { hiAppend = rocksAppend runner
                     , hiQuery = rocksQuery runner
+                    , hiProcessBlock = rocksProcessBlock runner
+                    , hiRollbackTo = rocksRollbackTo runner
+                    , hiResumePoints = rocksResumePoints runner
                     }
 
 rocksAppend ::
@@ -201,6 +324,42 @@ rocksAppend RunTransaction{runTransaction} entries =
             (\e -> insert HistoryCol (tseKey e) (tsePayload e))
             entries
 
+rocksProcessBlock ::
+    RunTransaction IO cf Cols op ->
+    SlotNo ->
+    ByteString ->
+    [TxSummaryEntry] ->
+    IO ()
+rocksProcessBlock RunTransaction{runTransaction} slot hash entries =
+    runTransaction $ do
+        mapM_
+            (\e -> insert HistoryCol (tseKey e) (tsePayload e))
+            entries
+        insert
+            HistoryBlockCol
+            slot
+            (HistoryBlock hash (tseKey <$> entries))
+
+rocksRollbackTo ::
+    RunTransaction IO cf Cols op ->
+    SlotNo ->
+    IO ()
+rocksRollbackTo RunTransaction{runTransaction} target =
+    runTransaction $ do
+        rows <- iterating HistoryBlockCol collectAllBlocks
+        forM_ rows $ \(slot, hb) ->
+            when (slot > target) $ do
+                mapM_ (delete HistoryCol) (hbEntryKeys hb)
+                delete HistoryBlockCol slot
+
+rocksResumePoints ::
+    RunTransaction IO cf Cols op ->
+    IO [(SlotNo, ByteString)]
+rocksResumePoints RunTransaction{runTransaction} =
+    runTransaction $ do
+        rows <- iterating HistoryBlockCol collectAllBlocks
+        pure $ reverse [(slot, hbBlockHash hb) | (slot, hb) <- rows]
+
 rocksQuery ::
     RunTransaction IO cf Cols op ->
     TenantId ->
@@ -209,6 +368,18 @@ rocksQuery ::
 rocksQuery RunTransaction{runTransaction} tenant scope =
     runTransaction $
         iterating HistoryCol (scanHistory tenant scope)
+
+{- | Cursor program: collect every row of the per-block
+rollback/resume log in ascending slot order.
+-}
+collectAllBlocks ::
+    (Monad m) =>
+    Cursor m (KV SlotNo HistoryBlock) [(SlotNo, HistoryBlock)]
+collectAllBlocks = firstEntry >>= go []
+  where
+    go acc Nothing = pure (reverse acc)
+    go acc (Just Entry{entryKey = k, entryValue = v}) =
+        nextEntry >>= go ((k, v) : acc)
 
 {- | Cursor program: seek to the synthetic minimum key under
 @(tenant, scope)@ and walk forward, collecting every entry whose

--- a/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Indexer.hs
+++ b/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Indexer.hs
@@ -1,0 +1,240 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+
+{- |
+Module      : Cardano.Node.Client.TxHistoryIndexer.Indexer
+License     : Apache-2.0
+Description : Multi-tenant tx-history indexer state and API
+
+Holds the tx-history indexer's state behind a backend-agnostic
+'HistoryIndexer' handle and exposes the operations Slice 1 needs:
+
+* 'appendHistory' files a batch of 'TxSummaryEntry' under their
+  ordered composite keys.
+* 'queryHistory' returns every entry of a single
+  @(tenant, scope)@, ordered by @(slot, txid, role)@.
+
+Two backends share the same handle and therefore the same
+'appendHistory' / 'queryHistory' surface:
+
+* 'withInMemoryHistoryIndexer' keeps a 'TVar' over a 'Map' from
+  the ordered composite-key bytes ('summaryKeyToBytes') to the
+  entry — ascending 'Map' key order is exactly the storage order
+  and a byte-prefix range restricts the scan to one
+  @(tenant, scope)@ bucket.
+* 'withRocksDBHistoryIndexer' uses a @kv-transactions@ RocksDB
+  'Database' keyed by the 'Cols' GADT; the same ordered key codec
+  drives the on-disk byte order, so a cursor prefix-scan over
+  'scopePrefix' yields the identical ordered result.
+
+The length-prefixed variable-length parts keep strict
+byte-prefix tenants/scopes (@"a"@ vs @"ab"@) from bleeding into
+one another in both backends.
+-}
+module Cardano.Node.Client.TxHistoryIndexer.Indexer (
+    -- * Indexer handle
+    HistoryIndexer (..),
+    withInMemoryHistoryIndexer,
+    withRocksDBHistoryIndexer,
+
+    -- * Operations
+    appendHistory,
+    queryHistory,
+) where
+
+import Cardano.Node.Client.TxHistoryIndexer.Columns (
+    Cols (..),
+    historyCodecs,
+ )
+import Cardano.Node.Client.TxHistoryIndexer.Types (
+    HistoryScope,
+    TenantId,
+    TxId (..),
+    TxRole (..),
+    TxSummaryEntry (..),
+    TxSummaryKey (..),
+    scopePrefix,
+    summaryKeyToBytes,
+ )
+import Cardano.Slotting.Slot (SlotNo (..))
+import Control.Concurrent.STM (
+    TVar,
+    atomically,
+    modifyTVar',
+    newTVarIO,
+    readTVarIO,
+ )
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.Default.Class (def)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Database.KV.Cursor (
+    Cursor,
+    Entry (..),
+    nextEntry,
+    seekKey,
+ )
+import Database.KV.Database (KV, mkColumns)
+import Database.KV.RocksDB (mkRocksDBDatabase)
+import Database.KV.Transaction (
+    RunTransaction (..),
+    insert,
+    iterating,
+    newRunTransaction,
+ )
+import Database.RocksDB (
+    Config (..),
+    columnFamilies,
+    withDBCF,
+ )
+
+{- | Backend-agnostic handle to a tx-history indexer. Both the
+in-memory and RocksDB backends provide the same two operations,
+so 'appendHistory' / 'queryHistory' work uniformly across them.
+-}
+data HistoryIndexer = HistoryIndexer
+    { hiAppend :: [TxSummaryEntry] -> IO ()
+    -- ^ File a batch of entries under their ordered keys.
+    , hiQuery :: TenantId -> HistoryScope -> IO [TxSummaryEntry]
+    -- ^ Return every entry of @(tenant, scope)@, ordered by
+    -- @(slot, txid, role)@.
+    }
+
+{- | File a batch of history entries. Each entry is keyed by its
+ordered composite-key bytes ('summaryKeyToBytes').
+-}
+appendHistory :: HistoryIndexer -> [TxSummaryEntry] -> IO ()
+appendHistory = hiAppend
+
+{- | Return every entry filed under @(tenant, scope)@, ordered
+by @(slot, txid, role)@. Entries of other tenants or scopes —
+including strict byte-prefix neighbours — are excluded.
+-}
+queryHistory ::
+    HistoryIndexer ->
+    TenantId ->
+    HistoryScope ->
+    IO [TxSummaryEntry]
+queryHistory = hiQuery
+
+-- In-memory backend ------------------------------------------------
+
+{- | Open an in-memory tx-history indexer, run the action with
+the handle, and discard the store on exit. The store starts
+empty.
+-}
+withInMemoryHistoryIndexer :: (HistoryIndexer -> IO a) -> IO a
+withInMemoryHistoryIndexer action = do
+    store <- newTVarIO Map.empty
+    action
+        HistoryIndexer
+            { hiAppend = memAppend store
+            , hiQuery = memQuery store
+            }
+
+memAppend ::
+    TVar (Map ByteString TxSummaryEntry) ->
+    [TxSummaryEntry] ->
+    IO ()
+memAppend store entries =
+    atomically $ modifyTVar' store insertAll
+  where
+    insertAll m = foldl insertOne m entries
+    insertOne m entry =
+        case summaryKeyToBytes (tseKey entry) of
+            Nothing -> m
+            Just k -> Map.insert k entry m
+
+memQuery ::
+    TVar (Map ByteString TxSummaryEntry) ->
+    TenantId ->
+    HistoryScope ->
+    IO [TxSummaryEntry]
+memQuery store tenant scope = do
+    m <- readTVarIO store
+    pure $ case scopePrefix tenant scope of
+        Nothing -> []
+        Just prefix ->
+            [ entry
+            | (k, entry) <- Map.toAscList m
+            , prefix `BS.isPrefixOf` k
+            ]
+
+-- RocksDB backend --------------------------------------------------
+
+{- | Open a RocksDB-backed tx-history indexer at @path@ (creating
+the directory tree if missing) and run the action with the
+handle. The on-disk store survives process restart.
+
+One column family is created: @tx-history.entries@ — the
+'HistoryCol' table. Entries are filed under the same ordered
+composite key as the in-memory backend, so 'queryHistory'
+returns byte-for-byte identical ordered results.
+-}
+withRocksDBHistoryIndexer ::
+    FilePath -> (HistoryIndexer -> IO a) -> IO a
+withRocksDBHistoryIndexer path action =
+    withDBCF
+        path
+        def{createIfMissing = True}
+        [("tx-history.entries", def)]
+        $ \rdb -> do
+            let database =
+                    mkRocksDBDatabase
+                        rdb
+                        (mkColumns (columnFamilies rdb) historyCodecs)
+            runner <- newRunTransaction database
+            action
+                HistoryIndexer
+                    { hiAppend = rocksAppend runner
+                    , hiQuery = rocksQuery runner
+                    }
+
+rocksAppend ::
+    RunTransaction IO cf Cols op ->
+    [TxSummaryEntry] ->
+    IO ()
+rocksAppend RunTransaction{runTransaction} entries =
+    runTransaction $
+        mapM_
+            (\e -> insert HistoryCol (tseKey e) (tsePayload e))
+            entries
+
+rocksQuery ::
+    RunTransaction IO cf Cols op ->
+    TenantId ->
+    HistoryScope ->
+    IO [TxSummaryEntry]
+rocksQuery RunTransaction{runTransaction} tenant scope =
+    runTransaction $
+        iterating HistoryCol (scanHistory tenant scope)
+
+{- | Cursor program: seek to the synthetic minimum key under
+@(tenant, scope)@ and walk forward, collecting every entry whose
+ordered key still carries the @(tenant, scope)@ prefix.
+-}
+scanHistory ::
+    (Monad m) =>
+    TenantId ->
+    HistoryScope ->
+    Cursor m (KV TxSummaryKey ByteString) [TxSummaryEntry]
+scanHistory tenant scope =
+    let seekTo =
+            TxSummaryKey
+                { tskTenant = tenant
+                , tskScope = scope
+                , tskSlot = SlotNo 0
+                , tskTxId = TxId BS.empty
+                , tskRole = TxRole BS.empty
+                }
+     in seekKey seekTo >>= go []
+  where
+    mPrefix = scopePrefix tenant scope
+    go acc Nothing = pure (reverse acc)
+    go acc (Just Entry{entryKey = k, entryValue = v}) =
+        case (mPrefix, summaryKeyToBytes k) of
+            (Just prefix, Just kBytes)
+                | prefix `BS.isPrefixOf` kBytes ->
+                    nextEntry >>= go (TxSummaryEntry k v : acc)
+            _ -> pure (reverse acc)

--- a/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Types.hs
+++ b/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Types.hs
@@ -1,0 +1,212 @@
+{- |
+Module      : Cardano.Node.Client.TxHistoryIndexer.Types
+Description : Domain types and ordered key codec for tx-history storage
+License     : Apache-2.0
+
+Era-agnostic types for the multi-tenant transaction-history
+indexer. Every history entry is filed under a composite
+'TxSummaryKey' whose on-disk byte form orders entries by
+@(tenant, scope, slot, txid, role)@.
+
+= Composite-key encoding
+
+Tenant ids and history scopes are variable-length, user-chosen
+byte strings. To keep prefix scans correct across mixed
+lengths — so tenant @"a"@ never bleeds into tenant @"ab"@ — the
+variable-length parts are length-prefixed:
+
+@
+key = lenTenant || tenant || lenScope || scope
+        || slotBE(8) || txidLen(2 BE) || txid || roleLen(2 BE) || role
+@
+
+@lenTenant@ and @lenScope@ are single bytes (tenant/scope ids
+fit comfortably under 256 bytes). The slot is big-endian so
+byte ordering matches numeric ordering; the txid and role are
+length-prefixed so the codec round-trips exactly.
+-}
+module Cardano.Node.Client.TxHistoryIndexer.Types (
+    -- * Indexer domain types
+    TenantId (..),
+    HistoryScope (..),
+    TxId (..),
+    TxRole (..),
+    TxSummaryKey (..),
+    TxSummaryEntry (..),
+
+    -- * Composite-key encoding
+    summaryKeyToBytes,
+    summaryKeyFromBytes,
+    scopePrefix,
+) where
+
+import Cardano.Slotting.Slot (SlotNo (..))
+import Data.Bits (shiftL, shiftR, (.&.), (.|.))
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.Word (Word16, Word64)
+
+{- | Opaque tenant identifier. Each tenant's history is
+isolated: a query scoped to one tenant never observes
+another tenant's entries.
+-}
+newtype TenantId = TenantId {unTenantId :: ByteString}
+    deriving newtype (Eq, Ord, Show)
+
+{- | History scope within a tenant — for example an address
+or a logical partition. Queries are scoped to a single
+@(tenant, scope)@ pair.
+-}
+newtype HistoryScope = HistoryScope {unHistoryScope :: ByteString}
+    deriving newtype (Eq, Ord, Show)
+
+-- | Transaction id, raw bytes (typically 32).
+newtype TxId = TxId {unTxId :: ByteString}
+    deriving newtype (Eq, Ord, Show)
+
+{- | The role a transaction plays for the entry — for example
+@"input"@ or @"output"@. Kept as opaque bytes so the storage
+layer never interprets it.
+-}
+newtype TxRole = TxRole {unTxRole :: ByteString}
+    deriving newtype (Eq, Ord, Show)
+
+{- | Composite key under which a history entry is filed.
+
+The on-disk byte form orders entries by
+@(tenant, scope, slot, txid, role)@; see the module header for
+the length-prefix rationale.
+-}
+data TxSummaryKey = TxSummaryKey
+    { tskTenant :: !TenantId
+    , tskScope :: !HistoryScope
+    , tskSlot :: !SlotNo
+    , tskTxId :: !TxId
+    , tskRole :: !TxRole
+    }
+    deriving stock (Eq, Ord, Show)
+
+{- | A history entry: its composite key plus an opaque payload
+blob forwarded unchanged to consumers.
+-}
+data TxSummaryEntry = TxSummaryEntry
+    { tseKey :: !TxSummaryKey
+    , tsePayload :: !ByteString
+    }
+    deriving stock (Eq, Ord, Show)
+
+{- | Maximum length accepted for a tenant id or history scope.
+These fit comfortably under this bound; reject anything larger
+so the single-byte length prefix stays sufficient.
+-}
+maxKeyPartLength :: Int
+maxKeyPartLength = 255
+
+{- | Serialise a 'TxSummaryKey' to its ordered composite-key
+byte form. Returns 'Nothing' if the tenant or scope exceeds
+'maxKeyPartLength'.
+
+Inverse of 'summaryKeyFromBytes'.
+-}
+summaryKeyToBytes :: TxSummaryKey -> Maybe ByteString
+summaryKeyToBytes
+    (TxSummaryKey tenant scope (SlotNo slot) (TxId tid) (TxRole role)) = do
+        prefix <- scopePrefix tenant scope
+        pure $
+            prefix
+                <> word64BE slot
+                <> lenPrefixed16 tid
+                <> lenPrefixed16 role
+
+{- | Parse a composite key produced by 'summaryKeyToBytes'.
+Returns 'Nothing' on any structural mismatch or trailing
+garbage.
+-}
+summaryKeyFromBytes :: ByteString -> Maybe TxSummaryKey
+summaryKeyFromBytes bs0 = do
+    (tenant, rest0) <- readByteLenPrefixed bs0
+    (scope, rest1) <- readByteLenPrefixed rest0
+    (slotBs, rest2) <- splitFixed 8 rest1
+    (tid, rest3) <- readLenPrefixed16 rest2
+    (role, rest4) <- readLenPrefixed16 rest3
+    if BS.null rest4
+        then
+            Just $
+                TxSummaryKey
+                    (TenantId tenant)
+                    (HistoryScope scope)
+                    (SlotNo (word64FromBE slotBs))
+                    (TxId tid)
+                    (TxRole role)
+        else Nothing
+
+{- | The byte-string prefix corresponding to "all entries
+under this @(tenant, scope)@" — i.e.
+@lenTenant || tenant || lenScope || scope@. Pass to a cursor
+as the seek prefix for a scope scan.
+
+Returns 'Nothing' if the tenant or scope exceeds
+'maxKeyPartLength'.
+-}
+scopePrefix :: TenantId -> HistoryScope -> Maybe ByteString
+scopePrefix (TenantId tenant) (HistoryScope scope)
+    | BS.length tenant > maxKeyPartLength = Nothing
+    | BS.length scope > maxKeyPartLength = Nothing
+    | otherwise =
+        Just $
+            BS.cons (fromIntegral (BS.length tenant)) tenant
+                <> BS.cons (fromIntegral (BS.length scope)) scope
+
+-- Internal helpers --------------------------------------------------
+
+readByteLenPrefixed :: ByteString -> Maybe (ByteString, ByteString)
+readByteLenPrefixed bs0 = do
+    (lenByte, rest0) <- BS.uncons bs0
+    splitFixed (fromIntegral lenByte) rest0
+
+lenPrefixed16 :: ByteString -> ByteString
+lenPrefixed16 bs = word16BE (fromIntegral (BS.length bs)) <> bs
+
+readLenPrefixed16 :: ByteString -> Maybe (ByteString, ByteString)
+readLenPrefixed16 bs0 = do
+    (lenBs, rest0) <- splitFixed 2 bs0
+    n <- word16FromBE lenBs
+    splitFixed (fromIntegral n) rest0
+
+splitFixed :: Int -> ByteString -> Maybe (ByteString, ByteString)
+splitFixed n bs
+    | BS.length bs < n = Nothing
+    | otherwise = Just (BS.splitAt n bs)
+
+word16BE :: Word16 -> ByteString
+word16BE w =
+    BS.pack
+        [ fromIntegral (w `shiftR` 8) .&. 0xFF
+        , fromIntegral w .&. 0xFF
+        ]
+
+word64BE :: Word64 -> ByteString
+word64BE w =
+    BS.pack
+        [ fromIntegral (w `shiftR` n) .&. 0xFF
+        | n <- [56, 48, 40, 32, 24, 16, 8, 0]
+        ]
+
+word64FromBE :: ByteString -> Word64
+word64FromBE =
+    foldr (.|.) 0
+        . zipWith
+            (\s b -> fromIntegral b `shiftL` s)
+            [56, 48, 40, 32, 24, 16, 8, 0]
+        . BS.unpack
+
+word16FromBE :: ByteString -> Maybe Word16
+word16FromBE bs
+    | BS.length bs /= 2 = Nothing
+    | otherwise =
+        let shifted =
+                zipWith
+                    (\b s -> fromIntegral b `shiftL` s)
+                    (BS.unpack bs)
+                    [8, 0 :: Int]
+         in Just $ foldr (.|.) 0 shifted

--- a/lib/Cardano/Node/Client/UTxOIndexer/BlockExtract.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/BlockExtract.hs
@@ -19,6 +19,7 @@ live below 'cardano-ledger-read''s API surface.
 -}
 module Cardano.Node.Client.UTxOIndexer.BlockExtract (
     extractBlock,
+    extractBlockTxs,
 ) where
 
 import Cardano.Chain.Common (unsafeGetLovelace)
@@ -51,6 +52,10 @@ import Cardano.Ledger.Core qualified as Ledger
 import Cardano.Ledger.Hashes (extractHash, unsafeMakeSafeHash)
 import Cardano.Ledger.TxIn qualified as SH
 import Cardano.Ledger.Val (inject)
+import Cardano.Node.Client.TxHistoryIndexer.BlockExtract (
+    BlockTx,
+    mkBlockTx,
+ )
 import Cardano.Node.Client.Types (Block)
 import Cardano.Node.Client.UTxOIndexer.IndexerOp (UtxoOp (..))
 import Cardano.Node.Client.UTxOIndexer.Types (
@@ -98,6 +103,49 @@ extractBlock blk =
     ( blockSlot blk
     , applyEraFun (changes . getEraTransactions) (fromConsensusBlock blk)
     )
+
+{- | Extract the raw, treasury-neutral per-transaction payloads
+('BlockTx') from a Cardano consensus block, in transaction order.
+
+Each Shelley-family transaction is re-serialised to its on-chain
+CBOR bytes and wrapped in a 'BlockTx'; this library attaches no
+meaning to those bytes — a downstream
+'Cardano.Node.Client.TxHistoryIndexer.BlockExtract.DecodeTx' owns all
+interpretation. Byron transactions carry no treasury history and are
+skipped (history indexing targets the Shelley-and-later eras).
+-}
+extractBlockTxs :: Block -> [BlockTx]
+extractBlockTxs blk =
+    applyEraFun (blockTxs . getEraTransactions) (fromConsensusBlock blk)
+
+{- | Per-era serialisation of a transaction list into 'BlockTx'
+payloads. Byron yields none; every Shelley-family era re-serialises
+each transaction to its CBOR bytes.
+-}
+blockTxs :: forall era. (IsEra era) => [Tx era] -> [BlockTx]
+blockTxs txs = case theEra @era of
+    Byron -> []
+    Shelley -> shelleyBlockTxs (unTx <$> txs)
+    Allegra -> shelleyBlockTxs (unTx <$> txs)
+    Mary -> shelleyBlockTxs (unTx <$> txs)
+    Alonzo -> shelleyBlockTxs (unTx <$> txs)
+    Babbage -> shelleyBlockTxs (unTx <$> txs)
+    Conway -> shelleyBlockTxs (unTx <$> txs)
+    Dijkstra -> shelleyBlockTxs (unTx <$> txs)
+
+{- | Re-serialise each Shelley-family transaction to its CBOR bytes
+and wrap it as a 'BlockTx'. Takes the ledger transaction directly (the
+per-era @TxT era ~ Core.Tx era@ refinement is applied at the call
+site), so the 'EraTx' superclass @EncCBOR (Tx era)@ supplies the
+encoder.
+-}
+shelleyBlockTxs ::
+    forall era.
+    (EraTx era) =>
+    [Ledger.Tx TopTx era] ->
+    [BlockTx]
+shelleyBlockTxs =
+    fmap (mkBlockTx . serialize' (eraProtVerLow @era))
 
 {- | Slot of the block. Cardano blocks are non-genesis;
 the @Origin@ case is structurally impossible here so

--- a/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Daemon.hs
@@ -158,6 +158,7 @@ toChainSyncCfg cfg =
         , csHandlers = liveUtxoHandler IndexAll :| []
         , csBlockTracer = nullTracer
         , csTipTracer = nullTracer
+        , csHistory = Nothing
         }
 
 {- | Derive the bundled daemon's wire-format 'ReadyStatus'

--- a/lib/Cardano/Node/Client/UTxOIndexer/Follower.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Follower.hs
@@ -340,6 +340,8 @@ entries into. Build with 'historyAttachment'.
 data HistoryAttachment = HistoryAttachment
     { haDecode :: DecodeTx
     -- ^ Caller-supplied decoder; owns all application semantics.
+    -- Called with the current block's slot plus each transaction's
+    -- raw bytes (see 'DecodeTx').
     , haIndexer :: HistoryIndexer
     -- ^ History store driven by the shared follower path.
     }
@@ -377,9 +379,12 @@ history store in a single follower pass.
 
 The UTxO operations and the 'BlockTx' list are both extracted from the
 same block upstream. UTxO state is applied first (preserving the
-historical follower behavior), then the decoded history entries are
-filed under the block's slot via 'processHistoryBlock'. The returned
-state/flag are exactly the UTxO 'processFollowerBlock' result.
+historical follower behavior), then the 'DecodeTx' is called with this
+block's slot (@toHistorySlot slot@) and each transaction's raw bytes,
+so the decoder keys its entries on the actual block slot rather than
+guessing it; the decoded history entries are filed under the same slot
+via 'processHistoryBlock'. The returned state/flag are exactly the
+UTxO 'processFollowerBlock' result.
 -}
 processSharedFollowerBlock ::
     IndexerHandle ->
@@ -411,7 +416,9 @@ processSharedFollowerBlock
                 slot
                 bh
                 ops
-        let entries = concat (mapMaybe (haDecode att) blockTxs)
+        let entries =
+                concat
+                    (mapMaybe (haDecode att (toHistorySlot slot)) blockTxs)
         processHistoryBlock
             (haIndexer att)
             (toHistorySlot slot)

--- a/lib/Cardano/Node/Client/UTxOIndexer/Follower.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Follower.hs
@@ -82,6 +82,13 @@ module Cardano.Node.Client.UTxOIndexer.Follower (
     ChainSyncConfig (..),
     coldBootResumePoints,
 
+    -- * Same-session history attachment (cursor model 2)
+    -- $cursorModel
+    HistoryAttachment (..),
+    historyAttachment,
+    sharedResumePoint,
+    processSharedFollowerBlock,
+
     -- * Interest-set filter
     -- $interestSet
     InterestSet (..),
@@ -119,9 +126,20 @@ import Cardano.Node.Client.N2C.Reconnect (
     runReconnectLoop,
  )
 import Cardano.Node.Client.N2C.Trace (N2CEvent)
+import Cardano.Node.Client.TxHistoryIndexer.BlockExtract (
+    BlockTx,
+    DecodeTx,
+ )
+import Cardano.Node.Client.TxHistoryIndexer.Indexer (
+    HistoryIndexer,
+    getHistoryResumePoints,
+    processHistoryBlock,
+    rollbackHistoryTo,
+ )
 import Cardano.Node.Client.Types (Block)
 import Cardano.Node.Client.UTxOIndexer.BlockExtract (
     extractBlock,
+    extractBlockTxs,
  )
 import Cardano.Node.Client.UTxOIndexer.Columns (
     Cols,
@@ -140,6 +158,7 @@ import Cardano.Node.Client.UTxOIndexer.Types (
     BlockHash (..),
     SlotNo (..),
  )
+import Cardano.Slotting.Slot qualified as Slot
 import ChainFollower (
     Follower (..),
     Intersector (..),
@@ -159,8 +178,10 @@ import Control.Concurrent.STM (
 import Control.Exception (SomeException)
 import Control.Monad (void)
 import Control.Tracer (Tracer)
+import Data.ByteString (ByteString)
 import Data.ByteString.Short qualified as SBS
 import Data.List.NonEmpty (NonEmpty)
+import Data.Maybe (mapMaybe)
 import Data.Time.Clock (UTCTime, getCurrentTime)
 import Data.Word (Word64)
 import Ouroboros.Consensus.Block.Abstract (
@@ -240,6 +261,17 @@ data ChainSyncConfig = ChainSyncConfig
     -- ^ Per-roll-forward chain-tip slot tracer supplied
     -- to 'mkChainSyncN2C'. Use 'nullTracer' to preserve
     -- the historical quiet behavior.
+    , csHistory :: !(Maybe HistoryAttachment)
+    -- ^ Optional same-session tx-history attachment. When
+    -- 'Just', the follower extracts each block's
+    -- 'BlockTx' list from the /same/ @fetchedBlock@ it
+    -- extracts UTxO operations from and drives the
+    -- history store through 'processSharedFollowerBlock'
+    -- on the one chain-sync session — never through
+    -- 'csHandlers' (which stays @[UtxoOp]@-only) or
+    -- 'csBlockTracer' (a tracer, not a data path), and
+    -- never via a second chain-sync runner. 'Nothing'
+    -- preserves the historical UTxO-only follower.
     }
 
 instance Show ChainSyncConfig where
@@ -266,7 +298,138 @@ instance Show ChainSyncConfig where
             <> ", csHandlers = <handlers>"
             <> ", csBlockTracer = <tracer>"
             <> ", csTipTracer = <tracer>"
+            <> ", csHistory = "
+            <> maybe "Nothing" (const "Just <history>") (csHistory cfg)
             <> " }"
+
+{- $cursorModel
+The same-session tx-history attachment implements cursor model 2 from
+the implementation plan: /one/ chain-sync session drives both the UTxO
+indexer and the tx-history indexer, each through its own persisted
+cursor, and resume picks the oldest safe point across both stores.
+
+* Roll-forward: 'mkFollower' extracts the block's 'BlockTx' list from
+  the same @fetchedBlock@ it extracts UTxO operations from and applies
+  both through 'processSharedFollowerBlock' — there is no second
+  chain-sync runner and no @csBlockTracer@ data path. @csHandlers@
+  stays @[UtxoOp]@-only.
+* Roll-backward: the same path rolls the history store back via
+  'rollbackHistoryTo' alongside the UTxO rollback, so a chain switch
+  drops history entries above the target slot.
+* Resume: 'sharedResumePoint' negotiates the intersection from the
+  oldest safe point across the UTxO and history persisted cursors, so
+  neither store is asked to skip a block it never saw.
+
+The two stores are separate RocksDB databases, so a per-block write
+across them is not atomic. The model tolerates this: history applies
+are idempotent in the block slot, and resuming from the oldest safe
+point re-applies any block a mid-write crash left in only one store.
+
+= HistoryAttachment
+
+A 'HistoryAttachment' bundles the treasury-neutral 'DecodeTx' plug
+point with the 'HistoryIndexer' the follower writes into. The decoder
+is supplied by the downstream application; this module never inspects
+a 'BlockTx'.
+-}
+
+{- | The same-session tx-history attachment: a treasury-neutral
+'DecodeTx' plug point plus the 'HistoryIndexer' to write decoded
+entries into. Build with 'historyAttachment'.
+-}
+data HistoryAttachment = HistoryAttachment
+    { haDecode :: DecodeTx
+    -- ^ Caller-supplied decoder; owns all application semantics.
+    , haIndexer :: HistoryIndexer
+    -- ^ History store driven by the shared follower path.
+    }
+
+-- | Both fields are functions; show an opaque placeholder.
+instance Show HistoryAttachment where
+    show _ = "HistoryAttachment <decode> <indexer>"
+
+-- | Build a 'HistoryAttachment' from a decoder and a history store.
+historyAttachment :: DecodeTx -> HistoryIndexer -> HistoryAttachment
+historyAttachment = HistoryAttachment
+
+{- | Choose the same-session resume intersection: the oldest safe
+point across the UTxO and history persisted cursors.
+
+Both argument lists are newest-first (as returned by
+@getResumePoints@ / 'getHistoryResumePoints'). The result is whichever
+store's newest retained point has the /smaller/ slot — resuming any
+newer would ask the lagging store to skip blocks it never saw.
+'Nothing' (cold boot) when either store has no retained point.
+-}
+sharedResumePoint ::
+    [(SlotNo, BlockHash)] ->
+    [(SlotNo, BlockHash)] ->
+    Maybe (SlotNo, BlockHash)
+sharedResumePoint utxoPoints historyPoints =
+    case (utxoPoints, historyPoints) of
+        (u@(us, _) : _, h@(hs, _) : _)
+            | us <= hs -> Just u
+            | otherwise -> Just h
+        _ -> Nothing
+
+{- | Apply one block to both the UTxO indexer and the attached
+history store in a single follower pass.
+
+The UTxO operations and the 'BlockTx' list are both extracted from the
+same block upstream. UTxO state is applied first (preserving the
+historical follower behavior), then the decoded history entries are
+filed under the block's slot via 'processHistoryBlock'. The returned
+state/flag are exactly the UTxO 'processFollowerBlock' result.
+-}
+processSharedFollowerBlock ::
+    IndexerHandle ->
+    HistoryAttachment ->
+    IndexerFollowerState ->
+    Int ->
+    Bool ->
+    SlotNo ->
+    BlockHash ->
+    [UtxoOp] ->
+    [BlockTx] ->
+    IO (IndexerFollowerState, Bool)
+processSharedFollowerBlock
+    idx
+    att
+    followerState
+    securityParamK
+    withinWindow
+    slot
+    bh
+    ops
+    blockTxs = do
+        result <-
+            processFollowerBlock
+                idx
+                followerState
+                securityParamK
+                withinWindow
+                slot
+                bh
+                ops
+        let entries = concat (mapMaybe (haDecode att) blockTxs)
+        processHistoryBlock
+            (haIndexer att)
+            (toHistorySlot slot)
+            (unBlockHash bh)
+            entries
+        pure result
+
+{- | Convert the follower's 'SlotNo' to the history store's
+'Cardano.Slotting.Slot.SlotNo'.
+-}
+toHistorySlot :: SlotNo -> Slot.SlotNo
+toHistorySlot (SlotNo s) = Slot.SlotNo s
+
+{- | Adapt a history resume point to the follower's
+@(SlotNo, BlockHash)@ shape for 'sharedResumePoint'.
+-}
+historyResumePoint :: (Slot.SlotNo, ByteString) -> (SlotNo, BlockHash)
+historyResumePoint (Slot.SlotNo s, hash) = (SlotNo s, BlockHash hash)
 
 {- $interestSet
 Address filter applied to each @[UtxoOp]@ batch by the
@@ -450,9 +613,27 @@ withChainSyncFollowerCore supervise chainSyncRunner tracer cfg idx action = do
     readinessVar <- newTVarIO (initialReadiness now)
     let chainSession = do
             bootMode <- detectBootMode idx
+            historyPts <- case csHistory cfg of
+                Nothing -> pure []
+                Just att ->
+                    fmap historyResumePoint
+                        <$> getHistoryResumePoints (haIndexer att)
             let resumePoints = case bootMode of
                     ColdBoot -> coldBootResumePoints cfg
-                    WarmBoot ps -> fmap toHeaderPoint ps
+                    WarmBoot ps -> case csHistory cfg of
+                        Nothing -> fmap toHeaderPoint ps
+                        -- Same-session resume (cursor model 2):
+                        -- intersect at the oldest safe point across
+                        -- the UTxO and history persisted cursors.
+                        -- If either store has no cursor,
+                        -- 'sharedResumePoint' is 'Nothing' and we
+                        -- cold-boot — resuming at the UTxO warm
+                        -- points would skip the history blocks the
+                        -- empty history store never saw.
+                        Just _ ->
+                            case sharedResumePoint ps historyPts of
+                                Just p -> [toHeaderPoint p]
+                                Nothing -> coldBootResumePoints cfg
             chainSyncRunner
                 (EpochSlots (csByronEpochSlots cfg))
                 (csNetworkMagic cfg)
@@ -659,15 +840,32 @@ mkFollower cfg readinessVar idx = go
                             slot
                             tip
                 (nextFollowerState, _processed) <-
-                    applyBlockOpsWithPhase
-                        cfg
-                        idx
-                        followerState
-                        isEBB
-                        withinWindow
-                        slot
-                        bh
-                        ops
+                    case csHistory cfg of
+                        Nothing ->
+                            applyBlockOpsWithPhase
+                                cfg
+                                idx
+                                followerState
+                                isEBB
+                                withinWindow
+                                slot
+                                bh
+                                ops
+                        Just att ->
+                            -- Shared path: extract the history
+                            -- [BlockTx] from the SAME fetchedBlock
+                            -- and drive both stores in one pass.
+                            applySharedBlockWithPhase
+                                cfg
+                                idx
+                                att
+                                followerState
+                                isEBB
+                                withinWindow
+                                slot
+                                bh
+                                ops
+                                (extractBlockTxs (fetchedBlock fetched))
                 updateReadiness readinessVar slot tip
                 pure (go nextFollowerState)
             , rollBackward = \point -> do
@@ -676,6 +874,14 @@ mkFollower cfg readinessVar idx = go
                         Network.Point.At s ->
                             SlotNo (Network.unSlotNo s)
                 state' <- rollbackFollowerState idx followerState slot
+                -- Roll the attached history store back on the same
+                -- path, dropping entries above the target slot.
+                case csHistory cfg of
+                    Nothing -> pure ()
+                    Just att ->
+                        rollbackHistoryTo
+                            (haIndexer att)
+                            (toHistorySlot slot)
                 pure (Progress (go state'))
             }
 
@@ -722,6 +928,49 @@ applyBlockOpsWithPhase
                     slot
                     bh
                     ops
+
+{- | Shared-path variant of 'applyBlockOpsWithPhase': applies the
+block to the UTxO indexer /and/ the attached history store in one
+pass via 'processSharedFollowerBlock'. EBBs carry no operations and
+are skipped for both stores, exactly as in 'applyBlockOpsWithPhase'.
+-}
+applySharedBlockWithPhase ::
+    ChainSyncConfig ->
+    IndexerHandle ->
+    HistoryAttachment ->
+    IndexerFollowerState ->
+    IsEBB ->
+    Bool ->
+    SlotNo ->
+    BlockHash ->
+    [UtxoOp] ->
+    [BlockTx] ->
+    IO (IndexerFollowerState, Bool)
+applySharedBlockWithPhase
+    cfg
+    idx
+    att
+    followerState
+    isEBB
+    withinWindow
+    slot
+    bh
+    ops
+    blockTxs =
+        case isEBB of
+            IsEBB ->
+                pure (followerState, False)
+            IsNotEBB ->
+                processSharedFollowerBlock
+                    idx
+                    att
+                    followerState
+                    (csSecurityParamK cfg)
+                    withinWindow
+                    slot
+                    bh
+                    ops
+                    blockTxs
 
 {- | Pull the block hash bytes out of an
 'OneEraHash'-shaped 'HeaderPoint'. Origin (no block) maps

--- a/specs/172-tx-history-indexer/plan.md
+++ b/specs/172-tx-history-indexer/plan.md
@@ -1,0 +1,35 @@
+# Implementation Plan: Tx History Indexer Library
+
+## Modules
+
+- `lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Types.hs`
+- `lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Columns.hs`
+- `lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Indexer.hs`
+- `lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/BlockExtract.hs`
+- Follower integration in the existing indexer path as narrowly as
+  needed to share one chain-sync session.
+
+## Cursor Model
+
+The implementation must choose and document one safe model:
+
+- shared cursor/rollback log with a combined inverse, or
+- same chain-sync session with separate persisted cursors whose resume
+  point is the oldest safe point across attached stores.
+
+If the safe model requires a public API expansion outside this issue,
+stop with a Q-file before implementing it.
+
+## Testing
+
+- Unit tests for tenant-prefix codecs and ordered scans.
+- Unit tests for rollback deleting history entries above the target.
+- Reopen/restart test showing entries are not duplicated.
+- A follower-level test proving the new history path is driven from the
+  same chain-sync roll-forward path rather than a second runner.
+
+## Gate
+
+```bash
+./gate.sh
+```

--- a/specs/172-tx-history-indexer/spec.md
+++ b/specs/172-tx-history-indexer/spec.md
@@ -1,0 +1,28 @@
+# Feature Spec: Tx History Indexer Library
+
+## User Story
+
+As a downstream treasury application, I can attach a decoder-agnostic
+transaction-history indexer to the existing indexer chain-sync path and
+query `(slot, txid, role)` entries by tenant and scope after restart and
+rollback.
+
+## Acceptance
+
+- Add public sublibrary `tx-history-indexer-lib`.
+- Store history in RocksDB-compatible typed columns.
+- Prefix every persisted history key by tenant id.
+- Provide one ordered query key:
+  `(tenant_id, scope, slot, txid) -> role`.
+- Expose a `BlockTx` payload and a
+  `DecodeTx = BlockTx -> Maybe [TxSummaryEntry]` plug point.
+- Drive history from the same chain-sync session as the UTxO indexer in
+  the downstream service; no second chain-sync runner.
+- Prove tenant isolation, rollback above a slot, and restart/resume.
+
+## Constraint
+
+The existing `csHandlers :: NonEmpty (IndexerHandler Cols [UtxoOp])`
+fanout cannot decode treasury redeemers because it only receives UTxO
+operations and only writes UTxO columns. This ticket must introduce the
+missing shared-follower shape rather than abusing `csBlockTracer`.

--- a/specs/172-tx-history-indexer/tasks.md
+++ b/specs/172-tx-history-indexer/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: Tx History Indexer Library
+
+## Slice 1 — Storage Foundation
+
+- [ ] T172-S1 Add cabal sublibrary stanza.
+- [ ] T172-S1 Add history types and tenant-prefixed key codecs.
+- [ ] T172-S1 Add in-memory and RocksDB open/query API.
+- [ ] T172-S1 Prove tenant isolation and ordered scope scans.
+- [ ] T172-S1 Commit:
+  `feat(tx-history): add tenant-prefixed history storage`.
+
+## Slice 2 — Shared Follower
+
+- [ ] T172-S2 Add Conway `BlockTx` extraction.
+- [ ] T172-S2 Add the same-chain-sync history integration.
+- [ ] T172-S2 Prove rollback above slot N drops history entries.
+- [ ] T172-S2 Prove restart/resume does not duplicate entries.
+- [ ] T172-S2 Document the selected cursor model.
+- [ ] T172-S2 Commit:
+  `feat(tx-history): share chain-sync with history indexing`.
+
+## Slice 3 — Finalization
+
+- [ ] T172-S3 Run `./gate.sh`.
+- [ ] T172-S3 Update PR body with downstream proof link.
+- [ ] T172-S3 Drop `gate.sh` before ready.

--- a/specs/172-tx-history-indexer/tasks.md
+++ b/specs/172-tx-history-indexer/tasks.md
@@ -22,6 +22,6 @@
 
 ## Slice 3 — Finalization
 
-- [ ] T172-S3 Run `./gate.sh`.
-- [ ] T172-S3 Update PR body with downstream proof link.
-- [ ] T172-S3 Drop `gate.sh` before ready.
+- [X] T172-S3 Run `./gate.sh`.
+- [X] T172-S3 Update PR body with downstream proof link.
+- [X] T172-S3 Drop `gate.sh` before ready.

--- a/specs/172-tx-history-indexer/tasks.md
+++ b/specs/172-tx-history-indexer/tasks.md
@@ -2,11 +2,11 @@
 
 ## Slice 1 — Storage Foundation
 
-- [ ] T172-S1 Add cabal sublibrary stanza.
-- [ ] T172-S1 Add history types and tenant-prefixed key codecs.
-- [ ] T172-S1 Add in-memory and RocksDB open/query API.
-- [ ] T172-S1 Prove tenant isolation and ordered scope scans.
-- [ ] T172-S1 Commit:
+- [X] T172-S1 Add cabal sublibrary stanza.
+- [X] T172-S1 Add history types and tenant-prefixed key codecs.
+- [X] T172-S1 Add in-memory and RocksDB open/query API.
+- [X] T172-S1 Prove tenant isolation and ordered scope scans.
+- [X] T172-S1 Commit:
   `feat(tx-history): add tenant-prefixed history storage`.
 
 ## Slice 2 — Shared Follower

--- a/specs/172-tx-history-indexer/tasks.md
+++ b/specs/172-tx-history-indexer/tasks.md
@@ -16,6 +16,7 @@
 - [X] T172-S2 Prove rollback above slot N drops history entries.
 - [X] T172-S2 Prove restart/resume does not duplicate entries.
 - [X] T172-S2 Document the selected cursor model.
+- [X] T172-S2 Make the downstream `DecodeTx` contract slot-aware.
 - [X] T172-S2 Commit:
   `feat(tx-history): share chain-sync with history indexing`.
 

--- a/specs/172-tx-history-indexer/tasks.md
+++ b/specs/172-tx-history-indexer/tasks.md
@@ -11,12 +11,12 @@
 
 ## Slice 2 — Shared Follower
 
-- [ ] T172-S2 Add Conway `BlockTx` extraction.
-- [ ] T172-S2 Add the same-chain-sync history integration.
-- [ ] T172-S2 Prove rollback above slot N drops history entries.
-- [ ] T172-S2 Prove restart/resume does not duplicate entries.
-- [ ] T172-S2 Document the selected cursor model.
-- [ ] T172-S2 Commit:
+- [X] T172-S2 Add Conway `BlockTx` extraction.
+- [X] T172-S2 Add the same-chain-sync history integration.
+- [X] T172-S2 Prove rollback above slot N drops history entries.
+- [X] T172-S2 Prove restart/resume does not duplicate entries.
+- [X] T172-S2 Document the selected cursor model.
+- [X] T172-S2 Commit:
   `feat(tx-history): share chain-sync with history indexing`.
 
 ## Slice 3 — Finalization

--- a/test/Cardano/Node/Client/BlockIndexer/HandlerSpec.hs
+++ b/test/Cardano/Node/Client/BlockIndexer/HandlerSpec.hs
@@ -309,4 +309,5 @@ testChainSyncConfig =
         , csHandlers = liveUtxoHandler IndexAll :| []
         , csBlockTracer = nullTracer
         , csTipTracer = nullTracer
+        , csHistory = Nothing
         }

--- a/test/Cardano/Node/Client/TxHistoryIndexer/HistoryRollbackSpec.hs
+++ b/test/Cardano/Node/Client/TxHistoryIndexer/HistoryRollbackSpec.hs
@@ -1,0 +1,140 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Cardano.Node.Client.TxHistoryIndexer.HistoryRollbackSpec
+Description : Slot-aware apply, rollback, and resume for tx-history storage
+License     : Apache-2.0
+
+Focused unit tests for Slice 2 of the tx-history indexer. Slice 1
+proved tenant/scope isolation and ordered scans for a flat
+'appendHistory'; Slice 2 adds the slot-aware, rollback-aware,
+resumable surface the shared chain-sync follower drives:
+
+  * 'processHistoryBlock' files a block's entries under a
+    @(slot, blockHash)@ rollback point,
+  * 'rollbackHistoryTo' drops every entry filed strictly above a
+    target slot, and
+  * 'getHistoryResumePoints' reports the retained @(slot, blockHash)@
+    points so the follower can negotiate a resume intersection.
+
+These mirror the @applyAtSlot@ / @rollbackTo@ / @getResumePoints@
+contract the UTxO indexer already exposes, so a single chain-sync
+session can drive both stores with separate persisted cursors (the
+plan's cursor model 2).
+-}
+module Cardano.Node.Client.TxHistoryIndexer.HistoryRollbackSpec (spec) where
+
+import Cardano.Node.Client.TxHistoryIndexer.Indexer (
+    getHistoryResumePoints,
+    processHistoryBlock,
+    queryHistory,
+    rollbackHistoryTo,
+    withInMemoryHistoryIndexer,
+    withRocksDBHistoryIndexer,
+ )
+import Cardano.Node.Client.TxHistoryIndexer.Types (
+    HistoryScope (..),
+    TenantId (..),
+    TxId (..),
+    TxRole (..),
+    TxSummaryEntry (..),
+    TxSummaryKey (..),
+ )
+import Cardano.Slotting.Slot (SlotNo (..))
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.Word (Word8)
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldReturn)
+
+spec :: Spec
+spec =
+    describe
+        "Cardano.Node.Client.TxHistoryIndexer history rollback/resume"
+        $ do
+            describe "rollback above a slot" $
+                it "drops history entries filed above the rollback slot" $
+                    withInMemoryHistoryIndexer $ \ix -> do
+                        processHistoryBlock
+                            ix
+                            (SlotNo 1)
+                            (blockHash 1)
+                            [entryAt 1 0x11]
+                        processHistoryBlock
+                            ix
+                            (SlotNo 2)
+                            (blockHash 2)
+                            [entryAt 2 0x22]
+                        processHistoryBlock
+                            ix
+                            (SlotNo 3)
+                            (blockHash 3)
+                            [entryAt 3 0x33]
+                        rollbackHistoryTo ix (SlotNo 1)
+                        queryHistory ix tenantA scopeX
+                            `shouldReturn` [entryAt 1 0x11]
+
+            describe "resume points" $
+                it "reports the newest applied block as the head point" $
+                    withInMemoryHistoryIndexer $ \ix -> do
+                        processHistoryBlock
+                            ix
+                            (SlotNo 1)
+                            (blockHash 1)
+                            [entryAt 1 0x11]
+                        processHistoryBlock
+                            ix
+                            (SlotNo 2)
+                            (blockHash 2)
+                            [entryAt 2 0x22]
+                        pts <- getHistoryResumePoints ix
+                        take 1 pts `shouldBe` [(SlotNo 2, blockHash 2)]
+
+            describe "idempotent replay across restart" $
+                it "replaying an applied block does not duplicate entries" $
+                    withSystemTempDirectory "tx-history-resume" $ \dir -> do
+                        withRocksDBHistoryIndexer dir $ \ix ->
+                            processHistoryBlock
+                                ix
+                                (SlotNo 1)
+                                (blockHash 1)
+                                [entryAt 1 0x11]
+                        before <-
+                            withRocksDBHistoryIndexer dir $ \ix ->
+                                queryHistory ix tenantA scopeX
+                        after <-
+                            withRocksDBHistoryIndexer dir $ \ix -> do
+                                processHistoryBlock
+                                    ix
+                                    (SlotNo 1)
+                                    (blockHash 1)
+                                    [entryAt 1 0x11]
+                                queryHistory ix tenantA scopeX
+                        before `shouldBe` [entryAt 1 0x11]
+                        after `shouldBe` before
+
+tenantA :: TenantId
+tenantA = TenantId "tenant-a"
+
+scopeX :: HistoryScope
+scopeX = HistoryScope "scope-x"
+
+roleInput :: TxRole
+roleInput = TxRole "input"
+
+blockHash :: Word8 -> ByteString
+blockHash = BS.replicate 32
+
+entryAt :: Word8 -> Word8 -> TxSummaryEntry
+entryAt slot tx =
+    TxSummaryEntry
+        { tseKey =
+            TxSummaryKey
+                { tskTenant = tenantA
+                , tskScope = scopeX
+                , tskSlot = SlotNo (fromIntegral slot)
+                , tskTxId = TxId (BS.replicate 32 tx)
+                , tskRole = roleInput
+                }
+        , tsePayload = BS.singleton tx
+        }

--- a/test/Cardano/Node/Client/TxHistoryIndexer/IndexerSpec.hs
+++ b/test/Cardano/Node/Client/TxHistoryIndexer/IndexerSpec.hs
@@ -1,0 +1,186 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Cardano.Node.Client.TxHistoryIndexer.IndexerSpec
+Description : Tenant/scope isolation and ordered scans for tx-history storage
+License     : Apache-2.0
+
+Focused unit tests for Slice 1 of the tx-history indexer storage
+foundation. Proves that the in-memory indexer:
+
+  * scopes every query by @(tenant, scope)@ so one tenant's
+    appended entries never leak into another tenant's query
+    (tenant isolation) and one scope's entries never leak into
+    another scope's query (scope isolation),
+  * keeps strict byte-prefix tenants/scopes (@"a"@ vs @"ab"@,
+    @"x"@ vs @"xy"@) from bleeding into one another, forcing the
+    ordered key codec to length-prefix the variable-length parts,
+    and
+  * returns the entries of a single @(tenant, scope)@ query
+    ordered by @(slot, txid, role)@ regardless of append order.
+-}
+module Cardano.Node.Client.TxHistoryIndexer.IndexerSpec (spec) where
+
+import Cardano.Node.Client.TxHistoryIndexer.Indexer (
+    appendHistory,
+    queryHistory,
+    withInMemoryHistoryIndexer,
+    withRocksDBHistoryIndexer,
+ )
+import Cardano.Node.Client.TxHistoryIndexer.Types (
+    HistoryScope (..),
+    TenantId (..),
+    TxId (..),
+    TxRole (..),
+    TxSummaryEntry (..),
+    TxSummaryKey (..),
+ )
+import Cardano.Slotting.Slot (SlotNo (..))
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.Word (Word8)
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldReturn)
+
+spec :: Spec
+spec =
+    describe "Cardano.Node.Client.TxHistoryIndexer.Indexer" $ do
+        describe "tenant isolation" $
+            it "a query returns only entries of its own tenant" $
+                withInMemoryHistoryIndexer $
+                    \indexer -> do
+                        let entA = mkEntry tenantA scopeX 1 0x11 roleInput
+                            entB = mkEntry tenantB scopeX 1 0x22 roleInput
+                        appendHistory indexer [entA, entB]
+                        queryHistory indexer tenantA scopeX
+                            `shouldReturn` [entA]
+
+        describe "scope isolation" $
+            it "a query returns only entries of its own scope" $
+                withInMemoryHistoryIndexer $
+                    \indexer -> do
+                        let entX = mkEntry tenantA scopeX 1 0x11 roleInput
+                            entY = mkEntry tenantA scopeY 1 0x22 roleInput
+                        appendHistory indexer [entX, entY]
+                        queryHistory indexer tenantA scopeY
+                            `shouldReturn` [entY]
+
+        describe "strict-prefix bleed prevention" $ do
+            it "tenant \"a\" does not bleed into tenant \"ab\"" $
+                withInMemoryHistoryIndexer $
+                    \indexer -> do
+                        let entShort =
+                                mkEntry (TenantId "a") scopeX 1 0x11 roleInput
+                            entLong =
+                                mkEntry (TenantId "ab") scopeX 1 0x22 roleInput
+                        appendHistory indexer [entShort, entLong]
+                        queryHistory indexer (TenantId "a") scopeX
+                            `shouldReturn` [entShort]
+                        queryHistory indexer (TenantId "ab") scopeX
+                            `shouldReturn` [entLong]
+
+            it "scope \"x\" does not bleed into scope \"xy\"" $
+                withInMemoryHistoryIndexer $
+                    \indexer -> do
+                        let entShort =
+                                mkEntry tenantA (HistoryScope "x") 1 0x11 roleInput
+                            entLong =
+                                mkEntry tenantA (HistoryScope "xy") 1 0x22 roleInput
+                        appendHistory indexer [entShort, entLong]
+                        queryHistory indexer tenantA (HistoryScope "x")
+                            `shouldReturn` [entShort]
+                        queryHistory indexer tenantA (HistoryScope "xy")
+                            `shouldReturn` [entLong]
+
+        describe "ordered scope scans"
+            $ it
+                "returns entries ordered by (slot, txid, role) \
+                \regardless of append order"
+            $ withInMemoryHistoryIndexer
+            $ \indexer -> do
+                let early = mkEntry tenantA scopeX 1 0x11 roleInput
+                    sameSlotLowTx =
+                        mkEntry tenantA scopeX 2 0x01 roleInput
+                    sameSlotHighTx =
+                        mkEntry tenantA scopeX 2 0x02 roleInput
+                    sameTxInput =
+                        mkEntry tenantA scopeX 3 0x33 roleInput
+                    sameTxOutput =
+                        mkEntry tenantA scopeX 3 0x33 roleOutput
+                -- Appended deliberately out of order.
+                appendHistory
+                    indexer
+                    [ sameTxOutput
+                    , sameSlotHighTx
+                    , early
+                    , sameTxInput
+                    , sameSlotLowTx
+                    ]
+                queryHistory indexer tenantA scopeX
+                    `shouldReturn` [ early
+                                   , sameSlotLowTx
+                                   , sameSlotHighTx
+                                   , sameTxInput
+                                   , sameTxOutput
+                                   ]
+
+        describe "backend parity (in-memory vs RocksDB)"
+            $ it
+                "both backends return the same ordered result \
+                \for the same appended entries"
+            $ do
+                let entries =
+                        [ mkEntry tenantA scopeX 3 0x33 roleOutput
+                        , mkEntry tenantA scopeX 2 0x02 roleInput
+                        , mkEntry tenantA scopeX 1 0x11 roleInput
+                        , mkEntry tenantA scopeX 3 0x33 roleInput
+                        , mkEntry tenantA scopeX 2 0x01 roleInput
+                        , mkEntry tenantB scopeY 5 0x55 roleInput
+                        ]
+                inMem <-
+                    withInMemoryHistoryIndexer $ \indexer -> do
+                        appendHistory indexer entries
+                        queryHistory indexer tenantA scopeX
+                onDisk <-
+                    withSystemTempDirectory "tx-history-rocks" $
+                        \dir ->
+                            withRocksDBHistoryIndexer dir $
+                                \indexer -> do
+                                    appendHistory indexer entries
+                                    queryHistory indexer tenantA scopeX
+                onDisk `shouldBe` inMem
+
+tenantA, tenantB :: TenantId
+tenantA = TenantId "tenant-a"
+tenantB = TenantId "tenant-b"
+
+scopeX, scopeY :: HistoryScope
+scopeX = HistoryScope "scope-x"
+scopeY = HistoryScope "scope-y"
+
+roleInput, roleOutput :: TxRole
+roleInput = TxRole "input"
+roleOutput = TxRole "output"
+
+mkEntry ::
+    TenantId ->
+    HistoryScope ->
+    Word8 ->
+    Word8 ->
+    TxRole ->
+    TxSummaryEntry
+mkEntry tenant scope slot tx role =
+    TxSummaryEntry
+        { tseKey =
+            TxSummaryKey
+                { tskTenant = tenant
+                , tskScope = scope
+                , tskSlot = SlotNo (fromIntegral slot)
+                , tskTxId = TxId (BS.replicate 32 tx)
+                , tskRole = role
+                }
+        , tsePayload = payload tx
+        }
+
+payload :: Word8 -> ByteString
+payload = BS.singleton

--- a/test/Cardano/Node/Client/UTxOIndexer/FollowerSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/FollowerSpec.hs
@@ -491,6 +491,7 @@ mkCfg sock =
         , csHandlers = liveUtxoHandler IndexAll :| []
         , csBlockTracer = nullTracer
         , csTipTracer = nullTracer
+        , csHistory = Nothing
         }
 
 toHeaderPoint :: SlotNo -> BlockHash -> HeaderPoint

--- a/test/Cardano/Node/Client/UTxOIndexer/MainnetSmokeSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/MainnetSmokeSpec.hs
@@ -101,6 +101,7 @@ runMainnetSmoke socketPath = do
                         , csHandlers = liveUtxoHandler IndexAll :| []
                         , csBlockTracer = nullTracer
                         , csTipTracer = nullTracer
+                        , csHistory = Nothing
                         }
                 progressTarget = SlotNo 5_000_000
             withChainSyncFollower tracer cfg idx $ \fh ->

--- a/test/Cardano/Node/Client/UTxOIndexer/SharedFollowerSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/SharedFollowerSpec.hs
@@ -1,0 +1,217 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Cardano.Node.Client.UTxOIndexer.SharedFollowerSpec
+Description : Same-session history attachment + shared resume contract
+License     : Apache-2.0
+
+Focused unit tests for the Slice 2 follower seam. The downstream
+requirement is one chain-sync session that drives both the UTxO
+indexer and the tx-history indexer. This suite pins the shape that
+makes that possible without abusing @csHandlers@ (which is
+@[UtxoOp]@-only) or @csBlockTracer@ (a tracer, not a data path):
+
+  * 'ChainSyncConfig' carries an explicit, optional history
+    attachment ('csHistory') that bundles a treasury-neutral
+    'DecodeTx' plug point with a 'HistoryIndexer' to write into, and
+
+  * 'sharedResumePoint' chooses the same-session resume intersection
+    by taking the oldest safe point across the attached stores'
+    persisted cursors — the plan's cursor model 2. Resuming any newer
+    than the lagging store's head would skip blocks that store never
+    saw; an empty store forces a cold boot.
+-}
+module Cardano.Node.Client.UTxOIndexer.SharedFollowerSpec (spec) where
+
+import Cardano.Node.Client.N2C.Probe (defaultProbeConfig)
+import Cardano.Node.Client.N2C.Reconnect (defaultReconnectPolicy)
+import Cardano.Node.Client.TxHistoryIndexer.BlockExtract (
+    DecodeTx,
+    mkBlockTx,
+ )
+import Cardano.Node.Client.TxHistoryIndexer.Indexer (
+    queryHistory,
+    withInMemoryHistoryIndexer,
+ )
+import Cardano.Node.Client.TxHistoryIndexer.Types (
+    HistoryScope (..),
+    TenantId (..),
+    TxId (..),
+    TxRole (..),
+    TxSummaryEntry (..),
+    TxSummaryKey (..),
+ )
+import Cardano.Node.Client.UTxOIndexer.Follower (
+    ChainSyncConfig (..),
+    HistoryAttachment,
+    InterestSet (..),
+    historyAttachment,
+    processSharedFollowerBlock,
+    sharedResumePoint,
+ )
+import Cardano.Node.Client.UTxOIndexer.Indexer (
+    IndexerHandle (..),
+    liveUtxoHandler,
+    withInMemoryIndexer,
+ )
+import Cardano.Node.Client.UTxOIndexer.IndexerOp (
+    UtxoOp (..),
+ )
+import Cardano.Node.Client.UTxOIndexer.Types (
+    Address (..),
+    BlockHash (..),
+    SlotNo (..),
+    TxIn (..),
+    TxOut (..),
+ )
+import Cardano.Slotting.Slot qualified as Slot
+import Control.Tracer (nullTracer)
+import Data.ByteString qualified as BS
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Maybe (isJust, isNothing)
+import Data.Word (Word8)
+import Ouroboros.Network.Magic (NetworkMagic (..))
+import Test.Hspec (
+    Spec,
+    describe,
+    it,
+    shouldBe,
+    shouldReturn,
+    shouldSatisfy,
+ )
+
+spec :: Spec
+spec =
+    describe "Cardano.Node.Client.UTxOIndexer shared-session history" $ do
+        describe "shared-session resume point" $ do
+            it "is the oldest safe point across UTxO and history stores" $
+                -- UTxO applied through slot 10; history lags at slot 7.
+                -- The only point both stores can safely resume from is
+                -- the lagging store's head (slot 7).
+                sharedResumePoint utxoPoints historyPoints
+                    `shouldBe` Just (SlotNo 7, h 7)
+
+            it "cold-boots (Nothing) when either store has no points" $ do
+                sharedResumePoint [] historyPoints `shouldBe` Nothing
+                sharedResumePoint utxoPoints [] `shouldBe` Nothing
+
+        describe "history attachment seam on the follower config" $ do
+            it "defaults to no history attachment" $
+                csHistory (baseCfg Nothing) `shouldSatisfy` isNothing
+
+            it "carries a DecodeTx plug point and a history indexer" $
+                withInMemoryHistoryIndexer $ \ix -> do
+                    let att = historyAttachment decodeNothing ix
+                    csHistory (baseCfg (Just att)) `shouldSatisfy` isJust
+
+        describe "shared block-processing path drives both stores"
+            $ it
+                "one block populates history via a non-trivial DecodeTx \
+                \while preserving UTxO behavior"
+            $ withInMemoryIndexer
+            $ \utxoIdx ->
+                withInMemoryHistoryIndexer $ \histIdx -> do
+                    let att = historyAttachment decodeOne histIdx
+                    state0 <- newFollowerState utxoIdx True
+                    -- Single pass over one block: the UTxO ops and
+                    -- the history [BlockTx] extracted from the SAME
+                    -- block are applied through one shared seam — no
+                    -- second chain-sync runner, no csHandlers/tracer
+                    -- abuse.
+                    _ <-
+                        processSharedFollowerBlock
+                            utxoIdx
+                            att
+                            state0
+                            2 -- security param k
+                            True -- within stability window
+                            (SlotNo 8)
+                            (BlockHash (BS.replicate 32 0xBB))
+                            [UtxoCreate txInA addrA outA]
+                            [mkBlockTx (BS.replicate 32 0xAB)]
+                    -- UTxO behavior preserved: the created output is
+                    -- visible at its address.
+                    snapshotAt utxoIdx addrA
+                        `shouldReturn` [(txInA, outA)]
+                    -- History populated through the decoder plug
+                    -- point on the same pass.
+                    queryHistory histIdx tenantA scopeX
+                        `shouldReturn` [decodedEntry]
+
+-- | A treasury-neutral decoder that never emits history entries.
+decodeNothing :: DecodeTx
+decodeNothing = const Nothing
+
+{- | A non-trivial, still treasury-neutral decoder: every transaction
+in the block yields one history entry. The decoder is defined in the
+test, not the library, so no scope/redeemer semantics leak into the
+plug point.
+-}
+decodeOne :: DecodeTx
+decodeOne = const (Just [decodedEntry])
+
+-- | The single entry 'decodeOne' emits for the integration block.
+decodedEntry :: TxSummaryEntry
+decodedEntry =
+    TxSummaryEntry
+        { tseKey =
+            TxSummaryKey
+                { tskTenant = tenantA
+                , tskScope = scopeX
+                , tskSlot = Slot.SlotNo 8
+                , tskTxId = TxId (BS.replicate 32 0xAB)
+                , tskRole = TxRole "output"
+                }
+        , tsePayload = "history-payload"
+        }
+
+tenantA :: TenantId
+tenantA = TenantId "tenant-a"
+
+scopeX :: HistoryScope
+scopeX = HistoryScope "scope-x"
+
+txInA :: TxIn
+txInA = TxIn (BS.replicate 32 0x01) 0
+
+addrA :: Address
+addrA = Address (BS.replicate 29 0xAA)
+
+outA :: TxOut
+outA = TxOut "tag-A"
+
+utxoPoints, historyPoints :: [(SlotNo, BlockHash)]
+utxoPoints =
+    [ (SlotNo 10, h 10)
+    , (SlotNo 9, h 9)
+    , (SlotNo 8, h 8)
+    , (SlotNo 7, h 7)
+    ]
+historyPoints =
+    [ (SlotNo 7, h 7)
+    , (SlotNo 6, h 6)
+    ]
+
+h :: Word8 -> BlockHash
+h = BlockHash . BS.replicate 32
+
+{- | A 'ChainSyncConfig' parameterised only on the optional history
+attachment; every other field is a fixed, side-effect-free default.
+-}
+baseCfg :: Maybe HistoryAttachment -> ChainSyncConfig
+baseCfg mHist =
+    ChainSyncConfig
+        { csRelaySocket = "/tmp/does-not-exist.sock"
+        , csNetworkMagic = NetworkMagic 42
+        , csByronEpochSlots = 86_400
+        , csStartPoint = Nothing
+        , csReadyThresholdSlots = 5
+        , csSecurityParamK = 432
+        , csReconnectPolicy = defaultReconnectPolicy
+        , csProbeConfig = defaultProbeConfig
+        , csInterestSet = IndexAll
+        , csHandlers = liveUtxoHandler IndexAll :| []
+        , csBlockTracer = nullTracer
+        , csTipTracer = nullTracer
+        , csHistory = mHist
+        }

--- a/test/Cardano/Node/Client/UTxOIndexer/SharedFollowerSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/SharedFollowerSpec.hs
@@ -106,18 +106,20 @@ spec =
 
         describe "shared block-processing path drives both stores"
             $ it
-                "one block populates history via a non-trivial DecodeTx \
+                "one block populates history via a slot-aware DecodeTx \
                 \while preserving UTxO behavior"
             $ withInMemoryIndexer
             $ \utxoIdx ->
                 withInMemoryHistoryIndexer $ \histIdx -> do
-                    let att = historyAttachment decodeOne histIdx
+                    let att = historyAttachment decodeAtSlot histIdx
                     state0 <- newFollowerState utxoIdx True
                     -- Single pass over one block: the UTxO ops and
                     -- the history [BlockTx] extracted from the SAME
                     -- block are applied through one shared seam — no
                     -- second chain-sync runner, no csHandlers/tracer
-                    -- abuse.
+                    -- abuse. The processed slot is supplied here, not
+                    -- baked into a fixture, so a decoder that hardcodes
+                    -- or guesses its slot cannot satisfy the assertion.
                     _ <-
                         processSharedFollowerBlock
                             utxoIdx
@@ -125,7 +127,7 @@ spec =
                             state0
                             2 -- security param k
                             True -- within stability window
-                            (SlotNo 8)
+                            processedSlot
                             (BlockHash (BS.replicate 32 0xBB))
                             [UtxoCreate txInA addrA outA]
                             [mkBlockTx (BS.replicate 32 0xAB)]
@@ -134,36 +136,50 @@ spec =
                     snapshotAt utxoIdx addrA
                         `shouldReturn` [(txInA, outA)]
                     -- History populated through the decoder plug
-                    -- point on the same pass.
+                    -- point on the same pass, keyed at the block slot
+                    -- the decoder received.
                     queryHistory histIdx tenantA scopeX
-                        `shouldReturn` [decodedEntry]
+                        `shouldReturn` [decodedEntryAt expectedHistorySlot]
 
 -- | A treasury-neutral decoder that never emits history entries.
 decodeNothing :: DecodeTx
-decodeNothing = const Nothing
+decodeNothing _ _ = Nothing
 
 {- | A non-trivial, still treasury-neutral decoder: every transaction
-in the block yields one history entry. The decoder is defined in the
-test, not the library, so no scope/redeemer semantics leak into the
-plug point.
+in the block yields one history entry keyed at the /block slot the
+follower passes in/. The decoder is defined in the test, not the
+library, so no scope/redeemer semantics leak into the plug point; and
+because it builds its entry from the received slot it pins the
+slot-aware contract — a decoder that hardcoded a slot would file the
+entry under the wrong key.
 -}
-decodeOne :: DecodeTx
-decodeOne = const (Just [decodedEntry])
+decodeAtSlot :: DecodeTx
+decodeAtSlot slot _ = Just [decodedEntryAt slot]
 
--- | The single entry 'decodeOne' emits for the integration block.
-decodedEntry :: TxSummaryEntry
-decodedEntry =
+{- | The single entry 'decodeAtSlot' emits for the integration block,
+keyed at the slot it received.
+-}
+decodedEntryAt :: Slot.SlotNo -> TxSummaryEntry
+decodedEntryAt slot =
     TxSummaryEntry
         { tseKey =
             TxSummaryKey
                 { tskTenant = tenantA
                 , tskScope = scopeX
-                , tskSlot = Slot.SlotNo 8
+                , tskSlot = slot
                 , tskTxId = TxId (BS.replicate 32 0xAB)
                 , tskRole = TxRole "output"
                 }
         , tsePayload = "history-payload"
         }
+
+-- | The block slot driven through the shared follower pass.
+processedSlot :: SlotNo
+processedSlot = SlotNo 12
+
+-- | The history-store slot the decoder must receive for 'processedSlot'.
+expectedHistorySlot :: Slot.SlotNo
+expectedHistorySlot = Slot.SlotNo 12
 
 tenantA :: TenantId
 tenantA = TenantId "tenant-a"

--- a/test/unit-main.hs
+++ b/test/unit-main.hs
@@ -6,6 +6,7 @@ import Cardano.Node.Client.AddressSpec qualified as AddressSpec
 import Cardano.Node.Client.BlockIndexer.HandlerSpec qualified as BlockIndexerHandlerSpec
 import Cardano.Node.Client.N2C.ProbeSpec qualified as N2CProbeSpec
 import Cardano.Node.Client.N2C.TraceSpec qualified as N2CTraceSpec
+import Cardano.Node.Client.TxHistoryIndexer.HistoryRollbackSpec qualified as TxHistoryRollbackSpec
 import Cardano.Node.Client.TxHistoryIndexer.IndexerSpec qualified as TxHistoryIndexerSpec
 import Cardano.Node.Client.UTxOIndexer.BlockExtractSpec qualified as UTxOIndexerBlockExtractSpec
 import Cardano.Node.Client.UTxOIndexer.DaemonSpec qualified as UTxOIndexerDaemonSpec
@@ -15,6 +16,7 @@ import Cardano.Node.Client.UTxOIndexer.MainnetSmokeSpec qualified as UTxOIndexer
 import Cardano.Node.Client.UTxOIndexer.PersistenceSpec qualified as UTxOIndexerPersistenceSpec
 import Cardano.Node.Client.UTxOIndexer.ProviderSpec qualified as UTxOIndexerProviderSpec
 import Cardano.Node.Client.UTxOIndexer.ServerSpec qualified as UTxOIndexerServerSpec
+import Cardano.Node.Client.UTxOIndexer.SharedFollowerSpec qualified as UTxOIndexerSharedFollowerSpec
 import Cardano.Node.Client.UTxOIndexer.TypesSpec qualified as UTxOIndexerTypesSpec
 import Cardano.Node.Client.ValiditySpec qualified as ValiditySpec
 import Data.List.SampleFibonacciSpec qualified as SampleFibonacciSpec
@@ -36,4 +38,6 @@ main = hspec $ do
     N2CProbeSpec.spec
     N2CTraceSpec.spec
     TxHistoryIndexerSpec.spec
+    TxHistoryRollbackSpec.spec
+    UTxOIndexerSharedFollowerSpec.spec
     ValiditySpec.spec

--- a/test/unit-main.hs
+++ b/test/unit-main.hs
@@ -6,6 +6,7 @@ import Cardano.Node.Client.AddressSpec qualified as AddressSpec
 import Cardano.Node.Client.BlockIndexer.HandlerSpec qualified as BlockIndexerHandlerSpec
 import Cardano.Node.Client.N2C.ProbeSpec qualified as N2CProbeSpec
 import Cardano.Node.Client.N2C.TraceSpec qualified as N2CTraceSpec
+import Cardano.Node.Client.TxHistoryIndexer.IndexerSpec qualified as TxHistoryIndexerSpec
 import Cardano.Node.Client.UTxOIndexer.BlockExtractSpec qualified as UTxOIndexerBlockExtractSpec
 import Cardano.Node.Client.UTxOIndexer.DaemonSpec qualified as UTxOIndexerDaemonSpec
 import Cardano.Node.Client.UTxOIndexer.FollowerSpec qualified as UTxOIndexerFollowerSpec
@@ -34,4 +35,5 @@ main = hspec $ do
     UTxOIndexerMainnetSmokeSpec.spec
     N2CProbeSpec.spec
     N2CTraceSpec.spec
+    TxHistoryIndexerSpec.spec
     ValiditySpec.spec


### PR DESCRIPTION
Closes #172

## Summary
- add tx-history-indexer-lib with tenant/scope/slot/txid keyed storage
- drive tx history from the same chain-sync follower as the UTxO indexer via `csHistory` / `historyAttachment`
- expose the slot-aware `DecodeTx` contract used downstream by amaru-treasury-tx

## Testing
- `./gate.sh` at cdcdab2: build PASS; unit 130 examples, 0 failures, 1 pending; format PASS; hlint PASS

## Downstream Proof
- Consumed by lambdasistemi/amaru-treasury-tx#305.
- ATX devnet proof passed at 2c65ad901537af537e1d79b3c69a9899c8970c36: `just devnet-api-smoke` observed indexed history rows for the submitted POST-built disburse tx and reorganize tx under `core_development`.
- Observed rows included disburse at slot 96 and reorganize at slot 105; older mint-registry history was tolerated.