### PR TITLE
fix(N2C): import Data.List.foldl' for May-stack build

### DIFF
--- a/lib/Cardano/Node/Client/N2C/Provider.hs
+++ b/lib/Cardano/Node/Client/N2C/Provider.hs
@@ -19,9 +19,12 @@ module Cardano.Node.Client.N2C.Provider (
     mkN2CProvider,
 ) where
 
+import Prelude hiding (foldl')
+
 import Data.Bifunctor (first)
 import Data.ByteString.Lazy qualified as LBS
 import Data.Coerce (coerce)
+import Data.List (foldl')
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as T


### PR DESCRIPTION
Context: lambdasistemi/cardano-mpfs-offchain#297 coordinated May-stack/index-state bump.

This is the surgical upstream unblocker found while preparing the downstream cardano-utxo-csmt May-stack bump. The CSMT PR is intentionally not open yet because its downstream build currently depends on this node-clients fix landing first.

Change:
- Hide foldl' from Prelude and import Data.List.foldl' explicitly so the module builds on both the downstream GHC 9.8 stack and this repo's GHC 9.12 gate.

Verification:
- nix develop -c cabal build all
- nix develop -c just ci