### PR TITLE
fix(N2C): qualify foldl' import for May stack

### DIFF
--- a/lib/Cardano/Node/Client/N2C/Provider.hs
+++ b/lib/Cardano/Node/Client/N2C/Provider.hs
@@ -19,12 +19,10 @@ module Cardano.Node.Client.N2C.Provider (
     mkN2CProvider,
 ) where
 
-import Prelude hiding (foldl')
-
 import Data.Bifunctor (first)
 import Data.ByteString.Lazy qualified as LBS
 import Data.Coerce (coerce)
-import Data.List (foldl')
+import Data.List qualified as List
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as T
@@ -452,7 +450,7 @@ groupUTxOByAddress addrs utxo =
     emptyRequested =
         Map.fromSet (const []) addrs
     grouped =
-        foldl' addEntry Map.empty $
+        List.foldl' addEntry Map.empty $
             Map.toAscList utxo
     addEntry acc (txIn, txOut)
         | Set.member addr addrs =


### PR DESCRIPTION
Context:
- Follow-up for lambdasistemi/cardano-mpfs-offchain#297 coordinated May-stack/index-state bump.
- Builds on lambdasistemi/cardano-node-clients#174; csmt exposed the remaining cross-GHC import warning as Werror.

Change:
- Remove stale Prelude hiding (foldl apostrophe).
- Qualify the Data.List.foldl apostrophe use so GHC 9.8 and 9.12 both avoid import warnings.

Verification:
- nix develop --quiet -c just ci
