### PR TITLE
feat(tx-history): add detailed transaction lookup

### DIFF
--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -301,6 +301,7 @@ test-suite unit-tests
     , chain-follower
     , containers
     , contra-tracer
+    , data-default-class
     , dependent-map
     , directory
     , filepath
@@ -313,6 +314,7 @@ test-suite unit-tests
     , plutus-core
     , QuickCheck
     , random
+    , rocksdb-haskell-jprupp
     , rocksdb-kv-transactions
     , rocksdb-kv-transactions:kv-transactions
     , sop-extras

--- a/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/BlockExtract.hs
+++ b/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/BlockExtract.hs
@@ -17,7 +17,7 @@ this library never interprets the bytes.
 'BlockTx' carries opaque bytes only. There is deliberately no scope,
 role, redeemer, or any application-specific structure here: a
 'DecodeTx' is free to parse the bytes however it likes and emit
-'Cardano.Node.Client.TxHistoryIndexer.Types.TxSummaryEntry' values, or
+'Cardano.Node.Client.TxHistoryIndexer.Types.TxSummary' values, or
 'Nothing' for transactions it does not care about.
 -}
 module Cardano.Node.Client.TxHistoryIndexer.BlockExtract (
@@ -29,7 +29,7 @@ module Cardano.Node.Client.TxHistoryIndexer.BlockExtract (
     DecodeTx,
 ) where
 
-import Cardano.Node.Client.TxHistoryIndexer.Types (TxSummaryEntry)
+import Cardano.Node.Client.TxHistoryIndexer.Types (TxSummary)
 import Cardano.Slotting.Slot (SlotNo)
 import Data.ByteString (ByteString)
 
@@ -53,7 +53,7 @@ The slot is the 'Cardano.Slotting.Slot.SlotNo' of the block the
 transaction was extracted from — the same slot type
 'Cardano.Node.Client.TxHistoryIndexer.Types.TxSummaryKey' keys on, so a
 decoder can build a well-keyed
-'Cardano.Node.Client.TxHistoryIndexer.Types.TxSummaryEntry' without
+'Cardano.Node.Client.TxHistoryIndexer.Types.TxSummary' without
 guessing or hardcoding the slot. The shared follower supplies the slot
 of the block being processed; the decoder never has to infer it.
 
@@ -61,4 +61,4 @@ The decoder owns all application semantics; keeping it a function
 type (rather than a class or concrete decoder) is what keeps decoding
 out of this repository.
 -}
-type DecodeTx = SlotNo -> BlockTx -> Maybe [TxSummaryEntry]
+type DecodeTx = SlotNo -> BlockTx -> Maybe [TxSummary]

--- a/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Columns.hs
+++ b/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Columns.hs
@@ -11,13 +11,13 @@ against the 'Database.KV.Transaction' abstraction from
 
 Two columns:
 
-* 'HistoryCol' :: @KV TxSummaryKey ByteString@ — entries filed
+* 'HistoryCol' :: @KV TxSummaryKey TxSummaryValue@ — entries filed
   under the ordered composite key
   @lenTenant || tenant || lenScope || scope || slotBE || txid ||
   role@ (see "Cardano.Node.Client.TxHistoryIndexer.Types"), so a
   cursor seek to 'scopePrefix' yields every entry of one
   @(tenant, scope)@ in @(slot, txid, role)@ order. The value is
-  the opaque payload blob, stored verbatim.
+  the decoder-supplied summary detail, stored verbatim.
 
 * 'HistoryBlockCol' :: @KV SlotNo HistoryBlock@ — the per-block
   rollback/resume log keyed by chain slot (big-endian, so a cursor
@@ -47,8 +47,11 @@ module Cardano.Node.Client.TxHistoryIndexer.Columns (
 
 import Cardano.Node.Client.TxHistoryIndexer.Types (
     TxSummaryKey,
+    TxSummaryValue,
     summaryKeyFromBytes,
     summaryKeyToBytes,
+    summaryValueFromBytes,
+    summaryValueToBytes,
  )
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.Lens (Prism', prism')
@@ -82,12 +85,12 @@ data HistoryBlock = HistoryBlock
 
 -- | The tx-history indexer database's column families.
 data Cols c where
-    -- | Entries table: @TxSummaryKey → payload@. Key is the
+    -- | Entries table: @TxSummaryKey → TxSummaryValue@. Key is the
     -- ordered composite key; a cursor prefix-scan by
     -- 'Cardano.Node.Client.TxHistoryIndexer.Types.scopePrefix'
     -- yields every entry of one @(tenant, scope)@ in
     -- @(slot, txid, role)@ order.
-    HistoryCol :: Cols (KV TxSummaryKey ByteString)
+    HistoryCol :: Cols (KV TxSummaryKey TxSummaryValue)
     -- | Per-block rollback/resume log: @SlotNo → HistoryBlock@,
     -- keyed by chain slot in big-endian byte order.
     HistoryBlockCol :: Cols (KV SlotNo HistoryBlock)
@@ -104,11 +107,11 @@ instance GCompare Cols where
     gcompare HistoryBlockCol HistoryBlockCol = GEQ
 
 -- | Codecs for 'HistoryCol'.
-historyColCodecs :: Codecs (KV TxSummaryKey ByteString)
+historyColCodecs :: Codecs (KV TxSummaryKey TxSummaryValue)
 historyColCodecs =
     Codecs
         { keyCodec = summaryKeyPrism
-        , valueCodec = payloadPrism
+        , valueCodec = summaryValuePrism
         }
 
 -- | Codecs for 'HistoryBlockCol'.
@@ -140,8 +143,8 @@ encodeKey k = case summaryKeyToBytes k of
             "summaryKeyPrism: tenant or scope exceeds 255 \
             \bytes — invariant violation"
 
-payloadPrism :: Prism' ByteString ByteString
-payloadPrism = prism' id Just
+summaryValuePrism :: Prism' ByteString TxSummaryValue
+summaryValuePrism = prism' summaryValueToBytes summaryValueFromBytes
 
 slotPrism :: Prism' ByteString SlotNo
 slotPrism = prism' encode decode

--- a/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Indexer.hs
+++ b/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Indexer.hs
@@ -279,17 +279,22 @@ memProcessBlock ::
     ByteString ->
     [TxSummary] ->
     IO ()
-memProcessBlock store slot hash summaries =
-    atomically $ modifyTVar' store $ \st ->
-        st
-            { msEntries = foldl insertSummary (msEntries st) summaries
-            , msByTxId = foldl insertTxIdSummary (msByTxId st) summaries
-            , msBlocks =
-                Map.insert
-                    slot
-                    (HistoryBlock hash (txsKey <$> summaries))
-                    (msBlocks st)
-            }
+memProcessBlock store slot hash summaries0 =
+    let summaries = stampBlockHash hash summaries0
+     in atomically $ modifyTVar' store $ \st ->
+            st
+                { msEntries = foldl insertSummary (msEntries st) summaries
+                , msByTxId = foldl insertTxIdSummary (msByTxId st) summaries
+                , msBlocks =
+                    Map.insert
+                        slot
+                        (HistoryBlock hash (txsKey <$> summaries))
+                        (msBlocks st)
+                }
+
+stampBlockHash :: ByteString -> [TxSummary] -> [TxSummary]
+stampBlockHash hash =
+    fmap $ \summary -> summary{txsBlockHash = Just hash}
 
 memRollbackTo :: TVar MemState -> SlotNo -> IO ()
 memRollbackTo store target =
@@ -401,13 +406,14 @@ rocksProcessBlock ::
     ByteString ->
     [TxSummary] ->
     IO ()
-rocksProcessBlock RunTransaction{runTransaction} slot hash summaries =
-    runTransaction $ do
-        forM_ summaries insertSummaryRows
-        insert
-            HistoryBlockCol
-            slot
-            (HistoryBlock hash (txsKey <$> summaries))
+rocksProcessBlock RunTransaction{runTransaction} slot hash summaries0 =
+    let summaries = stampBlockHash hash summaries0
+     in runTransaction $ do
+            forM_ summaries insertSummaryRows
+            insert
+                HistoryBlockCol
+                slot
+                (HistoryBlock hash (txsKey <$> summaries))
 
 insertSummaryRows ::
     TxSummary ->

--- a/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Indexer.hs
+++ b/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Indexer.hs
@@ -107,6 +107,7 @@ import Data.ByteString qualified as BS
 import Data.Default.Class (def)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
 import Database.KV.Cursor (
     Cursor,
     Entry (..),
@@ -487,7 +488,7 @@ txIdLookupKey (TenantId tenant) txid =
 summaryKeyRefValue :: TxSummaryKey -> TxSummaryValue
 summaryKeyRefValue key =
     TxSummaryValue
-        { tsvPayload = maybe BS.empty id (summaryKeyToBytes key)
+        { tsvPayload = fromMaybe BS.empty (summaryKeyToBytes key)
         , tsvInputs = []
         , tsvOutputs = []
         , tsvRedeemer = Nothing

--- a/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Indexer.hs
+++ b/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Indexer.hs
@@ -11,8 +11,11 @@ Holds the tx-history indexer's state behind a backend-agnostic
 
 Slice 1 operations:
 
-* 'appendHistory' files a batch of 'TxSummaryEntry' under their
-  ordered composite keys.
+* 'appendSummaries' files a batch of detailed 'TxSummary' rows under
+  their ordered composite keys and maintains a tenant-local tx-id
+  lookup.
+* 'appendHistory' is the legacy empty-detail wrapper over
+  'appendSummaries'.
 * 'queryHistory' returns every entry of a single
   @(tenant, scope)@, ordered by @(slot, txid, role)@.
 
@@ -43,8 +46,9 @@ Two backends share the same handle and surface:
   a 'Map' from chain slot to the block's 'HistoryBlock' rollback row.
 * 'withRocksDBHistoryIndexer' uses a @kv-transactions@ RocksDB
   'Database' keyed by the 'Cols' GADT; the same ordered key codec
-  drives the on-disk byte order, and the 'HistoryBlockCol' column
-  persists the rollback/resume log.
+  drives the on-disk byte order. Direct tx-id lookup rows live in the
+  entries column under an internal reserved key namespace, and the
+  'HistoryBlockCol' column persists the rollback/resume log.
 -}
 module Cardano.Node.Client.TxHistoryIndexer.Indexer (
     -- * Indexer handle
@@ -54,7 +58,9 @@ module Cardano.Node.Client.TxHistoryIndexer.Indexer (
 
     -- * Slice 1 operations
     appendHistory,
+    appendSummaries,
     queryHistory,
+    getByTxId,
 
     -- * Slice 2 block/rollback/resume operations
     processHistoryBlock,
@@ -68,14 +74,24 @@ import Cardano.Node.Client.TxHistoryIndexer.Columns (
     historyCodecs,
  )
 import Cardano.Node.Client.TxHistoryIndexer.Types (
-    HistoryScope,
-    TenantId,
+    HistoryScope (..),
+    TenantId (..),
     TxId (..),
+    TxIdKey (..),
     TxRole (..),
+    TxSummary (..),
     TxSummaryEntry (..),
     TxSummaryKey (..),
+    TxSummaryValue (..),
+    entryToSummary,
     scopePrefix,
+    summaryFromValue,
+    summaryKeyFromBytes,
     summaryKeyToBytes,
+    summaryToEntry,
+    summaryValueOf,
+    txIdKeyOf,
+    txIdKeyToBytes,
  )
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.Concurrent.STM (
@@ -102,10 +118,12 @@ import Database.KV.Database (KV, mkColumns)
 import Database.KV.RocksDB (mkRocksDBDatabase)
 import Database.KV.Transaction (
     RunTransaction (..),
+    Transaction,
     delete,
     insert,
     iterating,
     newRunTransaction,
+    query,
  )
 import Database.RocksDB (
     Config (..),
@@ -117,15 +135,17 @@ import Database.RocksDB (
 in-memory and RocksDB backends provide the same operations.
 -}
 data HistoryIndexer = HistoryIndexer
-    { hiAppend :: [TxSummaryEntry] -> IO ()
-    -- ^ File a batch of entries under their ordered keys.
+    { hiAppendSummaries :: [TxSummary] -> IO ()
+    -- ^ File a batch of detailed summaries under their ordered keys.
     , hiQuery :: TenantId -> HistoryScope -> IO [TxSummaryEntry]
     -- ^ Return every entry of @(tenant, scope)@, ordered by
     -- @(slot, txid, role)@.
+    , hiGetByTxId :: TenantId -> TxId -> IO (Maybe TxSummary)
+    -- ^ Directly look up a detailed summary by tenant-local tx id.
     , hiProcessBlock ::
         SlotNo ->
         ByteString ->
-        [TxSummaryEntry] ->
+        [TxSummary] ->
         IO ()
     -- ^ File a block's entries and record its
     -- @(slot, blockHash)@ rollback/resume point.
@@ -139,7 +159,14 @@ data HistoryIndexer = HistoryIndexer
 ordered composite-key bytes ('summaryKeyToBytes').
 -}
 appendHistory :: HistoryIndexer -> [TxSummaryEntry] -> IO ()
-appendHistory = hiAppend
+appendHistory indexer = appendSummaries indexer . fmap entryToSummary
+
+{- | File a batch of detailed history summaries. Each summary is keyed
+by its ordered composite-key bytes ('summaryKeyToBytes') and is also
+available through 'getByTxId'.
+-}
+appendSummaries :: HistoryIndexer -> [TxSummary] -> IO ()
+appendSummaries = hiAppendSummaries
 
 {- | Return every entry filed under @(tenant, scope)@, ordered
 by @(slot, txid, role)@. Entries of other tenants or scopes —
@@ -152,6 +179,17 @@ queryHistory ::
     IO [TxSummaryEntry]
 queryHistory = hiQuery
 
+{- | Return the detailed summary for a tenant-local transaction id.
+This is a direct lookup via the secondary index; it does not scan
+scopes or call a node.
+-}
+getByTxId ::
+    HistoryIndexer ->
+    TenantId ->
+    TxId ->
+    IO (Maybe TxSummary)
+getByTxId = hiGetByTxId
+
 {- | File a block's history entries and record a @(slot, blockHash)@
 rollback/resume point in the same write. Idempotent in the block slot:
 re-applying an already-applied block overwrites the same keys and the
@@ -161,7 +199,7 @@ processHistoryBlock ::
     HistoryIndexer ->
     SlotNo ->
     ByteString ->
-    [TxSummaryEntry] ->
+    [TxSummary] ->
     IO ()
 processHistoryBlock = hiProcessBlock
 
@@ -184,12 +222,13 @@ getHistoryResumePoints = hiResumePoints
 rollback/resume log.
 -}
 data MemState = MemState
-    { msEntries :: !(Map ByteString TxSummaryEntry)
+    { msEntries :: !(Map ByteString TxSummary)
+    , msByTxId :: !(Map ByteString TxSummary)
     , msBlocks :: !(Map SlotNo HistoryBlock)
     }
 
 emptyMemState :: MemState
-emptyMemState = MemState Map.empty Map.empty
+emptyMemState = MemState Map.empty Map.empty Map.empty
 
 {- | Open an in-memory tx-history indexer, run the action with
 the handle, and discard the store on exit. The store starts
@@ -200,41 +239,55 @@ withInMemoryHistoryIndexer action = do
     store <- newTVarIO emptyMemState
     action
         HistoryIndexer
-            { hiAppend = memAppend store
+            { hiAppendSummaries = memAppendSummaries store
             , hiQuery = memQuery store
+            , hiGetByTxId = memGetByTxId store
             , hiProcessBlock = memProcessBlock store
             , hiRollbackTo = memRollbackTo store
             , hiResumePoints = memResumePoints store
             }
 
-insertEntry ::
-    Map ByteString TxSummaryEntry ->
-    TxSummaryEntry ->
-    Map ByteString TxSummaryEntry
-insertEntry m entry =
-    case summaryKeyToBytes (tseKey entry) of
+insertSummary ::
+    Map ByteString TxSummary ->
+    TxSummary ->
+    Map ByteString TxSummary
+insertSummary m summary =
+    case summaryKeyToBytes (txsKey summary) of
         Nothing -> m
-        Just k -> Map.insert k entry m
+        Just k -> Map.insert k summary m
 
-memAppend :: TVar MemState -> [TxSummaryEntry] -> IO ()
-memAppend store entries =
+insertTxIdSummary ::
+    Map ByteString TxSummary ->
+    TxSummary ->
+    Map ByteString TxSummary
+insertTxIdSummary m summary =
+    case txIdKeyToBytes (txIdKeyOf (txsKey summary)) of
+        Nothing -> m
+        Just k -> Map.insert k summary m
+
+memAppendSummaries :: TVar MemState -> [TxSummary] -> IO ()
+memAppendSummaries store summaries =
     atomically $ modifyTVar' store $ \st ->
-        st{msEntries = foldl insertEntry (msEntries st) entries}
+        st
+            { msEntries = foldl insertSummary (msEntries st) summaries
+            , msByTxId = foldl insertTxIdSummary (msByTxId st) summaries
+            }
 
 memProcessBlock ::
     TVar MemState ->
     SlotNo ->
     ByteString ->
-    [TxSummaryEntry] ->
+    [TxSummary] ->
     IO ()
-memProcessBlock store slot hash entries =
+memProcessBlock store slot hash summaries =
     atomically $ modifyTVar' store $ \st ->
         st
-            { msEntries = foldl insertEntry (msEntries st) entries
+            { msEntries = foldl insertSummary (msEntries st) summaries
+            , msByTxId = foldl insertTxIdSummary (msByTxId st) summaries
             , msBlocks =
                 Map.insert
                     slot
-                    (HistoryBlock hash (tseKey <$> entries))
+                    (HistoryBlock hash (txsKey <$> summaries))
                     (msBlocks st)
             }
 
@@ -251,9 +304,17 @@ memRollbackTo store target =
                 , k <- hbEntryKeys hb
                 , Just kb <- [summaryKeyToBytes k]
                 ]
+            staleTxIdKeyBytes =
+                [ kb
+                | hb <- Map.elems stale
+                , k <- hbEntryKeys hb
+                , Just kb <- [txIdKeyToBytes (txIdKeyOf k)]
+                ]
          in st
                 { msEntries =
                     foldl (flip Map.delete) (msEntries st) staleKeyBytes
+                , msByTxId =
+                    foldl (flip Map.delete) (msByTxId st) staleTxIdKeyBytes
                 , msBlocks = keep
                 }
 
@@ -275,10 +336,21 @@ memQuery store tenant scope = do
     pure $ case scopePrefix tenant scope of
         Nothing -> []
         Just prefix ->
-            [ entry
-            | (k, entry) <- Map.toAscList (msEntries st)
+            [ summaryToEntry summary
+            | (k, summary) <- Map.toAscList (msEntries st)
             , prefix `BS.isPrefixOf` k
             ]
+
+memGetByTxId ::
+    TVar MemState ->
+    TenantId ->
+    TxId ->
+    IO (Maybe TxSummary)
+memGetByTxId store tenant txid = do
+    st <- readTVarIO store
+    pure $ do
+        keyBytes <- txIdKeyToBytes (TxIdKey tenant txid)
+        Map.lookup keyBytes (msByTxId st)
 
 -- RocksDB backend --------------------------------------------------
 
@@ -287,8 +359,8 @@ the directory tree if missing) and run the action with the
 handle. The on-disk store survives process restart.
 
 Two column families are created: @tx-history.entries@ (the
-'HistoryCol' table) and @tx-history.blocks@ (the 'HistoryBlockCol'
-rollback/resume log).
+'HistoryCol' table, including reserved direct-lookup rows) and
+@tx-history.blocks@ (the 'HistoryBlockCol' rollback/resume log).
 -}
 withRocksDBHistoryIndexer ::
     FilePath -> (HistoryIndexer -> IO a) -> IO a
@@ -307,38 +379,42 @@ withRocksDBHistoryIndexer path action =
             runner <- newRunTransaction database
             action
                 HistoryIndexer
-                    { hiAppend = rocksAppend runner
+                    { hiAppendSummaries = rocksAppendSummaries runner
                     , hiQuery = rocksQuery runner
+                    , hiGetByTxId = rocksGetByTxId runner
                     , hiProcessBlock = rocksProcessBlock runner
                     , hiRollbackTo = rocksRollbackTo runner
                     , hiResumePoints = rocksResumePoints runner
                     }
 
-rocksAppend ::
+rocksAppendSummaries ::
     RunTransaction IO cf Cols op ->
-    [TxSummaryEntry] ->
+    [TxSummary] ->
     IO ()
-rocksAppend RunTransaction{runTransaction} entries =
+rocksAppendSummaries RunTransaction{runTransaction} summaries =
     runTransaction $
-        mapM_
-            (\e -> insert HistoryCol (tseKey e) (tsePayload e))
-            entries
+        forM_ summaries insertSummaryRows
 
 rocksProcessBlock ::
     RunTransaction IO cf Cols op ->
     SlotNo ->
     ByteString ->
-    [TxSummaryEntry] ->
+    [TxSummary] ->
     IO ()
-rocksProcessBlock RunTransaction{runTransaction} slot hash entries =
+rocksProcessBlock RunTransaction{runTransaction} slot hash summaries =
     runTransaction $ do
-        mapM_
-            (\e -> insert HistoryCol (tseKey e) (tsePayload e))
-            entries
+        forM_ summaries insertSummaryRows
         insert
             HistoryBlockCol
             slot
-            (HistoryBlock hash (tseKey <$> entries))
+            (HistoryBlock hash (txsKey <$> summaries))
+
+insertSummaryRows ::
+    TxSummary ->
+    Transaction IO cf Cols op ()
+insertSummaryRows summary = do
+    insert HistoryCol (txsKey summary) (summaryValueOf summary)
+    insert HistoryCol (txIdLookupKeyOf (txsKey summary)) (summaryKeyRefValue (txsKey summary))
 
 rocksRollbackTo ::
     RunTransaction IO cf Cols op ->
@@ -349,7 +425,9 @@ rocksRollbackTo RunTransaction{runTransaction} target =
         rows <- iterating HistoryBlockCol collectAllBlocks
         forM_ rows $ \(slot, hb) ->
             when (slot > target) $ do
-                mapM_ (delete HistoryCol) (hbEntryKeys hb)
+                forM_ (hbEntryKeys hb) $ \key -> do
+                    delete HistoryCol key
+                    delete HistoryCol (txIdLookupKeyOf key)
                 delete HistoryBlockCol slot
 
 rocksResumePoints ::
@@ -368,6 +446,49 @@ rocksQuery ::
 rocksQuery RunTransaction{runTransaction} tenant scope =
     runTransaction $
         iterating HistoryCol (scanHistory tenant scope)
+
+rocksGetByTxId ::
+    RunTransaction IO cf Cols op ->
+    TenantId ->
+    TxId ->
+    IO (Maybe TxSummary)
+rocksGetByTxId RunTransaction{runTransaction} tenant txid =
+    runTransaction $ do
+        mKeyValue <- query HistoryCol (txIdLookupKey tenant txid)
+        case mKeyValue >>= summaryKeyFromBytes . tsvPayload of
+            Nothing -> pure Nothing
+            Just key -> fmap (summaryFromValue key) <$> query HistoryCol key
+
+txIdLookupKeyOf :: TxSummaryKey -> TxSummaryKey
+txIdLookupKeyOf TxSummaryKey{tskTenant, tskTxId} =
+    txIdLookupKey tskTenant tskTxId
+
+{- | Reserved key namespace for the direct txid lookup row stored in
+'HistoryCol'. Keeping the lookup inside the existing entries column
+lets an already-created two-column RocksDB database open after this
+schema extension.
+-}
+txIdLookupKey :: TenantId -> TxId -> TxSummaryKey
+txIdLookupKey (TenantId tenant) txid =
+    TxSummaryKey
+        { tskTenant = TenantId "\NULtx-history-by-txid"
+        , tskScope = HistoryScope tenant
+        , tskSlot = SlotNo 0
+        , tskTxId = txid
+        , tskRole = TxRole "\NULlookup"
+        }
+
+summaryKeyRefValue :: TxSummaryKey -> TxSummaryValue
+summaryKeyRefValue key =
+    TxSummaryValue
+        { tsvPayload = maybe BS.empty id (summaryKeyToBytes key)
+        , tsvInputs = []
+        , tsvOutputs = []
+        , tsvRedeemer = Nothing
+        , tsvFee = Nothing
+        , tsvRequiredSigners = []
+        , tsvBlockHash = Nothing
+        }
 
 {- | Cursor program: collect every row of the per-block
 rollback/resume log in ascending slot order.
@@ -389,7 +510,7 @@ scanHistory ::
     (Monad m) =>
     TenantId ->
     HistoryScope ->
-    Cursor m (KV TxSummaryKey ByteString) [TxSummaryEntry]
+    Cursor m (KV TxSummaryKey TxSummaryValue) [TxSummaryEntry]
 scanHistory tenant scope =
     let seekTo =
             TxSummaryKey
@@ -407,5 +528,5 @@ scanHistory tenant scope =
         case (mPrefix, summaryKeyToBytes k) of
             (Just prefix, Just kBytes)
                 | prefix `BS.isPrefixOf` kBytes ->
-                    nextEntry >>= go (TxSummaryEntry k v : acc)
+                    nextEntry >>= go (summaryToEntry (summaryFromValue k v) : acc)
             _ -> pure (reverse acc)

--- a/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Types.hs
+++ b/lib-tx-history-indexer/Cardano/Node/Client/TxHistoryIndexer/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RecordWildCards #-}
+
 {- |
 Module      : Cardano.Node.Client.TxHistoryIndexer.Types
 Description : Domain types and ordered key codec for tx-history storage
@@ -31,13 +33,27 @@ module Cardano.Node.Client.TxHistoryIndexer.Types (
     HistoryScope (..),
     TxId (..),
     TxRole (..),
+    TxIdKey (..),
     TxSummaryKey (..),
+    TxSummaryInput (..),
+    TxSummaryOutput (..),
+    TxSummaryValue (..),
+    TxSummary (..),
     TxSummaryEntry (..),
+    entryToSummary,
+    summaryToEntry,
+    summaryValueOf,
+    summaryFromValue,
+    txIdKeyOf,
 
     -- * Composite-key encoding
     summaryKeyToBytes,
     summaryKeyFromBytes,
     scopePrefix,
+    txIdKeyToBytes,
+    txIdKeyFromBytes,
+    summaryValueToBytes,
+    summaryValueFromBytes,
 ) where
 
 import Cardano.Slotting.Slot (SlotNo (..))
@@ -71,6 +87,16 @@ layer never interprets it.
 newtype TxRole = TxRole {unTxRole :: ByteString}
     deriving newtype (Eq, Ord, Show)
 
+{- | Secondary lookup key for a tenant-local transaction id.
+The tx-history store uses this to resolve @tenant + txid@ to the
+canonical ordered 'TxSummaryKey' without scanning scopes.
+-}
+data TxIdKey = TxIdKey
+    { tikTenant :: !TenantId
+    , tikTxId :: !TxId
+    }
+    deriving stock (Eq, Ord, Show)
+
 {- | Composite key under which a history entry is filed.
 
 The on-disk byte form orders entries by
@@ -86,6 +112,57 @@ data TxSummaryKey = TxSummaryKey
     }
     deriving stock (Eq, Ord, Show)
 
+{- | One transaction input in a decoder-supplied detail view.
+The storage layer keeps all fields opaque; downstream decoders choose
+the exact rendering.
+-}
+data TxSummaryInput = TxSummaryInput
+    { tsiTxIn :: !ByteString
+    , tsiScope :: !(Maybe HistoryScope)
+    , tsiValue :: !ByteString
+    }
+    deriving stock (Eq, Ord, Show)
+
+{- | One transaction output in a decoder-supplied detail view. The
+datum field is a summary, not a typed ledger value.
+-}
+data TxSummaryOutput = TxSummaryOutput
+    { tsoAddress :: !ByteString
+    , tsoValue :: !ByteString
+    , tsoDatum :: !(Maybe ByteString)
+    }
+    deriving stock (Eq, Ord, Show)
+
+{- | The value stored under a 'TxSummaryKey'. This is the
+decoder-agnostic detail payload: the indexer persists it but never
+interprets it.
+-}
+data TxSummaryValue = TxSummaryValue
+    { tsvPayload :: !ByteString
+    , tsvInputs :: ![TxSummaryInput]
+    , tsvOutputs :: ![TxSummaryOutput]
+    , tsvRedeemer :: !(Maybe ByteString)
+    , tsvFee :: !(Maybe Word64)
+    , tsvRequiredSigners :: ![ByteString]
+    , tsvBlockHash :: !(Maybe ByteString)
+    }
+    deriving stock (Eq, Ord, Show)
+
+{- | A fully indexed transaction summary: ordered key plus the
+decoder-supplied detail value.
+-}
+data TxSummary = TxSummary
+    { txsKey :: !TxSummaryKey
+    , txsPayload :: !ByteString
+    , txsInputs :: ![TxSummaryInput]
+    , txsOutputs :: ![TxSummaryOutput]
+    , txsRedeemer :: !(Maybe ByteString)
+    , txsFee :: !(Maybe Word64)
+    , txsRequiredSigners :: ![ByteString]
+    , txsBlockHash :: !(Maybe ByteString)
+    }
+    deriving stock (Eq, Ord, Show)
+
 {- | A history entry: its composite key plus an opaque payload
 blob forwarded unchanged to consumers.
 -}
@@ -94,6 +171,63 @@ data TxSummaryEntry = TxSummaryEntry
     , tsePayload :: !ByteString
     }
     deriving stock (Eq, Ord, Show)
+
+-- | Convert a legacy list row to an empty-detail 'TxSummary'.
+entryToSummary :: TxSummaryEntry -> TxSummary
+entryToSummary TxSummaryEntry{tseKey, tsePayload} =
+    TxSummary
+        { txsKey = tseKey
+        , txsPayload = tsePayload
+        , txsInputs = []
+        , txsOutputs = []
+        , txsRedeemer = Nothing
+        , txsFee = Nothing
+        , txsRequiredSigners = []
+        , txsBlockHash = Nothing
+        }
+
+-- | Project a detailed summary back to the stable list-row shape.
+summaryToEntry :: TxSummary -> TxSummaryEntry
+summaryToEntry TxSummary{txsKey, txsPayload} =
+    TxSummaryEntry
+        { tseKey = txsKey
+        , tsePayload = txsPayload
+        }
+
+-- | Extract the stored value from a 'TxSummary'.
+summaryValueOf :: TxSummary -> TxSummaryValue
+summaryValueOf TxSummary{..} =
+    TxSummaryValue
+        { tsvPayload = txsPayload
+        , tsvInputs = txsInputs
+        , tsvOutputs = txsOutputs
+        , tsvRedeemer = txsRedeemer
+        , tsvFee = txsFee
+        , tsvRequiredSigners = txsRequiredSigners
+        , tsvBlockHash = txsBlockHash
+        }
+
+-- | Rebuild a 'TxSummary' from its ordered key and stored value.
+summaryFromValue :: TxSummaryKey -> TxSummaryValue -> TxSummary
+summaryFromValue txsKey TxSummaryValue{..} =
+    TxSummary
+        { txsKey
+        , txsPayload = tsvPayload
+        , txsInputs = tsvInputs
+        , txsOutputs = tsvOutputs
+        , txsRedeemer = tsvRedeemer
+        , txsFee = tsvFee
+        , txsRequiredSigners = tsvRequiredSigners
+        , txsBlockHash = tsvBlockHash
+        }
+
+-- | Build the tenant-local tx-id lookup key for a summary key.
+txIdKeyOf :: TxSummaryKey -> TxIdKey
+txIdKeyOf TxSummaryKey{tskTenant, tskTxId} =
+    TxIdKey
+        { tikTenant = tskTenant
+        , tikTxId = tskTxId
+        }
 
 {- | Maximum length accepted for a tenant id or history scope.
 These fit comfortably under this bound; reject anything larger
@@ -157,7 +291,174 @@ scopePrefix (TenantId tenant) (HistoryScope scope)
             BS.cons (fromIntegral (BS.length tenant)) tenant
                 <> BS.cons (fromIntegral (BS.length scope)) scope
 
+{- | Serialise a tenant-local tx-id lookup key.
+Returns 'Nothing' when the tenant id exceeds the supported one-byte
+length prefix.
+-}
+txIdKeyToBytes :: TxIdKey -> Maybe ByteString
+txIdKeyToBytes (TxIdKey (TenantId tenant) (TxId tid))
+    | BS.length tenant > maxKeyPartLength = Nothing
+    | otherwise =
+        Just $
+            BS.cons (fromIntegral (BS.length tenant)) tenant
+                <> lenPrefixed16 tid
+
+-- | Parse a key produced by 'txIdKeyToBytes'.
+txIdKeyFromBytes :: ByteString -> Maybe TxIdKey
+txIdKeyFromBytes bs0 = do
+    (tenant, rest0) <- readByteLenPrefixed bs0
+    (tid, rest1) <- readLenPrefixed16 rest0
+    if BS.null rest1
+        then Just (TxIdKey (TenantId tenant) (TxId tid))
+        else Nothing
+
+-- | Serialise a 'TxSummaryValue' for the RocksDB value codec.
+summaryValueToBytes :: TxSummaryValue -> ByteString
+summaryValueToBytes TxSummaryValue{..} =
+    summaryValueMagic
+        <> lenPrefixed16 tsvPayload
+        <> list16 encodeInput tsvInputs
+        <> list16 encodeOutput tsvOutputs
+        <> maybeBytes tsvRedeemer
+        <> maybeWord64 tsvFee
+        <> list16 lenPrefixed16 tsvRequiredSigners
+        <> maybeBytes tsvBlockHash
+
+-- | Parse a value produced by 'summaryValueToBytes'.
+summaryValueFromBytes :: ByteString -> Maybe TxSummaryValue
+summaryValueFromBytes bs0 =
+    case BS.stripPrefix summaryValueMagic bs0 of
+        Just rest ->
+            case readVersionedSummaryValue rest of
+                Just value -> Just value
+                Nothing -> Just (legacySummaryValue bs0)
+        Nothing -> Just (legacySummaryValue bs0)
+
 -- Internal helpers --------------------------------------------------
+
+summaryValueMagic :: ByteString
+summaryValueMagic = "\NULtx-summary-v1"
+
+legacySummaryValue :: ByteString -> TxSummaryValue
+legacySummaryValue payload =
+    TxSummaryValue
+        { tsvPayload = payload
+        , tsvInputs = []
+        , tsvOutputs = []
+        , tsvRedeemer = Nothing
+        , tsvFee = Nothing
+        , tsvRequiredSigners = []
+        , tsvBlockHash = Nothing
+        }
+
+readVersionedSummaryValue :: ByteString -> Maybe TxSummaryValue
+readVersionedSummaryValue bs0 = do
+    (payload, rest0) <- readLenPrefixed16 bs0
+    (inputs, rest1) <- readList16 readInput rest0
+    (outputs, rest2) <- readList16 readOutput rest1
+    (redeemer, rest3) <- readMaybeBytes rest2
+    (fee, rest4) <- readMaybeWord64 rest3
+    (signers, rest5) <- readList16 readLenPrefixed16 rest4
+    (blockHash, rest6) <- readMaybeBytes rest5
+    if BS.null rest6
+        then
+            Just
+                TxSummaryValue
+                    { tsvPayload = payload
+                    , tsvInputs = inputs
+                    , tsvOutputs = outputs
+                    , tsvRedeemer = redeemer
+                    , tsvFee = fee
+                    , tsvRequiredSigners = signers
+                    , tsvBlockHash = blockHash
+                    }
+        else Nothing
+
+encodeInput :: TxSummaryInput -> ByteString
+encodeInput TxSummaryInput{..} =
+    lenPrefixed16 tsiTxIn
+        <> maybeBytes (unHistoryScope <$> tsiScope)
+        <> lenPrefixed16 tsiValue
+
+readInput :: ByteString -> Maybe (TxSummaryInput, ByteString)
+readInput bs0 = do
+    (txin, rest0) <- readLenPrefixed16 bs0
+    (scope, rest1) <- readMaybeBytes rest0
+    (value, rest2) <- readLenPrefixed16 rest1
+    Just
+        ( TxSummaryInput
+            { tsiTxIn = txin
+            , tsiScope = HistoryScope <$> scope
+            , tsiValue = value
+            }
+        , rest2
+        )
+
+encodeOutput :: TxSummaryOutput -> ByteString
+encodeOutput TxSummaryOutput{..} =
+    lenPrefixed16 tsoAddress
+        <> lenPrefixed16 tsoValue
+        <> maybeBytes tsoDatum
+
+readOutput :: ByteString -> Maybe (TxSummaryOutput, ByteString)
+readOutput bs0 = do
+    (address, rest0) <- readLenPrefixed16 bs0
+    (value, rest1) <- readLenPrefixed16 rest0
+    (datum, rest2) <- readMaybeBytes rest1
+    Just
+        ( TxSummaryOutput
+            { tsoAddress = address
+            , tsoValue = value
+            , tsoDatum = datum
+            }
+        , rest2
+        )
+
+list16 :: (a -> ByteString) -> [a] -> ByteString
+list16 encode xs =
+    word16BE (fromIntegral (length xs)) <> mconcat (encode <$> xs)
+
+readList16 ::
+    (ByteString -> Maybe (a, ByteString)) ->
+    ByteString ->
+    Maybe ([a], ByteString)
+readList16 readOne bs0 = do
+    (countBs, rest0) <- splitFixed 2 bs0
+    n <- word16FromBE countBs
+    go (fromIntegral n) [] rest0
+  where
+    go 0 acc rest = Just (reverse acc, rest)
+    go n acc rest = do
+        (x, rest') <- readOne rest
+        go (n - 1 :: Int) (x : acc) rest'
+
+maybeBytes :: Maybe ByteString -> ByteString
+maybeBytes Nothing = BS.singleton 0
+maybeBytes (Just bs) = BS.singleton 1 <> lenPrefixed16 bs
+
+readMaybeBytes :: ByteString -> Maybe (Maybe ByteString, ByteString)
+readMaybeBytes bs0 = do
+    (tag, rest0) <- BS.uncons bs0
+    case tag of
+        0 -> Just (Nothing, rest0)
+        1 -> do
+            (bs, rest1) <- readLenPrefixed16 rest0
+            Just (Just bs, rest1)
+        _ -> Nothing
+
+maybeWord64 :: Maybe Word64 -> ByteString
+maybeWord64 Nothing = BS.singleton 0
+maybeWord64 (Just w) = BS.singleton 1 <> word64BE w
+
+readMaybeWord64 :: ByteString -> Maybe (Maybe Word64, ByteString)
+readMaybeWord64 bs0 = do
+    (tag, rest0) <- BS.uncons bs0
+    case tag of
+        0 -> Just (Nothing, rest0)
+        1 -> do
+            (w, rest1) <- splitFixed 8 rest0
+            Just (Just (word64FromBE w), rest1)
+        _ -> Nothing
 
 readByteLenPrefixed :: ByteString -> Maybe (ByteString, ByteString)
 readByteLenPrefixed bs0 = do

--- a/lib/Cardano/Node/Client/UTxOIndexer/Follower.hs
+++ b/lib/Cardano/Node/Client/UTxOIndexer/Follower.hs
@@ -335,7 +335,7 @@ a 'BlockTx'.
 
 {- | The same-session tx-history attachment: a treasury-neutral
 'DecodeTx' plug point plus the 'HistoryIndexer' to write decoded
-entries into. Build with 'historyAttachment'.
+summaries into. Build with 'historyAttachment'.
 -}
 data HistoryAttachment = HistoryAttachment
     { haDecode :: DecodeTx
@@ -381,8 +381,8 @@ The UTxO operations and the 'BlockTx' list are both extracted from the
 same block upstream. UTxO state is applied first (preserving the
 historical follower behavior), then the 'DecodeTx' is called with this
 block's slot (@toHistorySlot slot@) and each transaction's raw bytes,
-so the decoder keys its entries on the actual block slot rather than
-guessing it; the decoded history entries are filed under the same slot
+so the decoder keys its summaries on the actual block slot rather than
+guessing it; the decoded history summaries are filed under the same slot
 via 'processHistoryBlock'. The returned state/flag are exactly the
 UTxO 'processFollowerBlock' result.
 -}
@@ -416,14 +416,14 @@ processSharedFollowerBlock
                 slot
                 bh
                 ops
-        let entries =
+        let summaries =
                 concat
                     (mapMaybe (haDecode att (toHistorySlot slot)) blockTxs)
         processHistoryBlock
             (haIndexer att)
             (toHistorySlot slot)
             (unBlockHash bh)
-            entries
+            summaries
         pure result
 
 {- | Convert the follower's 'SlotNo' to the history store's

--- a/test/Cardano/Node/Client/TxHistoryIndexer/HistoryRollbackSpec.hs
+++ b/test/Cardano/Node/Client/TxHistoryIndexer/HistoryRollbackSpec.hs
@@ -37,8 +37,10 @@ import Cardano.Node.Client.TxHistoryIndexer.Types (
     TenantId (..),
     TxId (..),
     TxRole (..),
+    TxSummary,
     TxSummaryEntry (..),
     TxSummaryKey (..),
+    entryToSummary,
  )
 import Cardano.Slotting.Slot (SlotNo (..))
 import Data.ByteString (ByteString)
@@ -59,17 +61,17 @@ spec =
                             ix
                             (SlotNo 1)
                             (blockHash 1)
-                            [entryAt 1 0x11]
+                            [summaryAt 1 0x11]
                         processHistoryBlock
                             ix
                             (SlotNo 2)
                             (blockHash 2)
-                            [entryAt 2 0x22]
+                            [summaryAt 2 0x22]
                         processHistoryBlock
                             ix
                             (SlotNo 3)
                             (blockHash 3)
-                            [entryAt 3 0x33]
+                            [summaryAt 3 0x33]
                         rollbackHistoryTo ix (SlotNo 1)
                         queryHistory ix tenantA scopeX
                             `shouldReturn` [entryAt 1 0x11]
@@ -81,12 +83,12 @@ spec =
                             ix
                             (SlotNo 1)
                             (blockHash 1)
-                            [entryAt 1 0x11]
+                            [summaryAt 1 0x11]
                         processHistoryBlock
                             ix
                             (SlotNo 2)
                             (blockHash 2)
-                            [entryAt 2 0x22]
+                            [summaryAt 2 0x22]
                         pts <- getHistoryResumePoints ix
                         take 1 pts `shouldBe` [(SlotNo 2, blockHash 2)]
 
@@ -98,7 +100,7 @@ spec =
                                 ix
                                 (SlotNo 1)
                                 (blockHash 1)
-                                [entryAt 1 0x11]
+                                [summaryAt 1 0x11]
                         before <-
                             withRocksDBHistoryIndexer dir $ \ix ->
                                 queryHistory ix tenantA scopeX
@@ -108,7 +110,7 @@ spec =
                                     ix
                                     (SlotNo 1)
                                     (blockHash 1)
-                                    [entryAt 1 0x11]
+                                    [summaryAt 1 0x11]
                                 queryHistory ix tenantA scopeX
                         before `shouldBe` [entryAt 1 0x11]
                         after `shouldBe` before
@@ -138,3 +140,6 @@ entryAt slot tx =
                 }
         , tsePayload = BS.singleton tx
         }
+
+summaryAt :: Word8 -> Word8 -> TxSummary
+summaryAt slot tx = entryToSummary (entryAt slot tx)

--- a/test/Cardano/Node/Client/TxHistoryIndexer/IndexerSpec.hs
+++ b/test/Cardano/Node/Client/TxHistoryIndexer/IndexerSpec.hs
@@ -25,6 +25,7 @@ import Cardano.Node.Client.TxHistoryIndexer.Indexer (
     appendHistory,
     appendSummaries,
     getByTxId,
+    processHistoryBlock,
     queryHistory,
     withInMemoryHistoryIndexer,
     withRocksDBHistoryIndexer,
@@ -186,6 +187,20 @@ spec =
                     appendSummaries indexer [summary]
                     queryHistory indexer tenantA scopeX
                         `shouldReturn` [summaryToEntry summary]
+
+            it "stamps block-processed summaries with the block hash" $
+                withInMemoryHistoryIndexer $ \indexer -> do
+                    let summary =
+                            (mkSummary tenantA scopeX 9 0x47 roleOutput)
+                                { txsBlockHash = Nothing
+                                }
+                        expected = summary{txsBlockHash = Just "block-9"}
+                    processHistoryBlock indexer (SlotNo 9) "block-9" [summary]
+                    getByTxId
+                        indexer
+                        tenantA
+                        (TxId (BS.replicate 32 0x47))
+                        `shouldReturn` Just expected
 
             it
                 "round-trips detailed summaries through the RocksDB \

--- a/test/Cardano/Node/Client/TxHistoryIndexer/IndexerSpec.hs
+++ b/test/Cardano/Node/Client/TxHistoryIndexer/IndexerSpec.hs
@@ -23,6 +23,8 @@ module Cardano.Node.Client.TxHistoryIndexer.IndexerSpec (spec) where
 
 import Cardano.Node.Client.TxHistoryIndexer.Indexer (
     appendHistory,
+    appendSummaries,
+    getByTxId,
     queryHistory,
     withInMemoryHistoryIndexer,
     withRocksDBHistoryIndexer,
@@ -32,13 +34,21 @@ import Cardano.Node.Client.TxHistoryIndexer.Types (
     TenantId (..),
     TxId (..),
     TxRole (..),
+    TxSummary (..),
     TxSummaryEntry (..),
+    TxSummaryInput (..),
     TxSummaryKey (..),
+    TxSummaryOutput (..),
+    TxSummaryValue (..),
+    summaryToEntry,
+    summaryValueFromBytes,
  )
 import Cardano.Slotting.Slot (SlotNo (..))
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
+import Data.Default.Class (def)
 import Data.Word (Word8)
+import Database.RocksDB (Config (..), withDBCF)
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldReturn)
 
@@ -150,6 +160,77 @@ spec =
                                     queryHistory indexer tenantA scopeX
                 onDisk `shouldBe` inMem
 
+        describe "tx-id lookup" $ do
+            it "returns a detailed summary scoped by tenant and txid" $
+                withInMemoryHistoryIndexer $ \indexer -> do
+                    let summary =
+                            mkSummary tenantA scopeX 7 0x44 roleOutput
+                        otherTenant =
+                            mkSummary tenantB scopeX 7 0x44 roleInput
+                    appendSummaries indexer [otherTenant, summary]
+                    getByTxId
+                        indexer
+                        tenantA
+                        (TxId (BS.replicate 32 0x44))
+                        `shouldReturn` Just summary
+                    getByTxId
+                        indexer
+                        tenantB
+                        (TxId (BS.replicate 32 0x55))
+                        `shouldReturn` Nothing
+
+            it "keeps scope scans compatible with detailed summaries" $
+                withInMemoryHistoryIndexer $ \indexer -> do
+                    let summary =
+                            mkSummary tenantA scopeX 8 0x45 roleOutput
+                    appendSummaries indexer [summary]
+                    queryHistory indexer tenantA scopeX
+                        `shouldReturn` [summaryToEntry summary]
+
+            it
+                "round-trips detailed summaries through the RocksDB \
+                \codec and getByTxId"
+                $ withSystemTempDirectory "tx-history-rocks-detail"
+                $ \dir ->
+                    withRocksDBHistoryIndexer dir $ \indexer -> do
+                        let summary =
+                                mkSummary tenantA scopeX 9 0x46 roleOutput
+                        appendSummaries indexer [summary]
+                        getByTxId
+                            indexer
+                            tenantA
+                            (TxId (BS.replicate 32 0x46))
+                            `shouldReturn` Just summary
+
+        describe "RocksDB compatibility" $ do
+            it "opens a store created with the previous two column families" $
+                withSystemTempDirectory "tx-history-rocks-legacy-schema" $
+                    \dir -> do
+                        withDBCF
+                            dir
+                            def{createIfMissing = True}
+                            [ ("tx-history.entries", def)
+                            , ("tx-history.blocks", def)
+                            ]
+                            $ \_ -> pure ()
+                        withRocksDBHistoryIndexer dir $ \indexer ->
+                            queryHistory indexer tenantA scopeX
+                                `shouldReturn` []
+
+            it "decodes pre-detail payload bytes as empty-detail values" $ do
+                let legacyPayload = "\SOHlegacy-payload"
+                summaryValueFromBytes legacyPayload
+                    `shouldBe` Just
+                        TxSummaryValue
+                            { tsvPayload = legacyPayload
+                            , tsvInputs = []
+                            , tsvOutputs = []
+                            , tsvRedeemer = Nothing
+                            , tsvFee = Nothing
+                            , tsvRequiredSigners = []
+                            , tsvBlockHash = Nothing
+                            }
+
 tenantA, tenantB :: TenantId
 tenantA = TenantId "tenant-a"
 tenantB = TenantId "tenant-b"
@@ -184,3 +265,41 @@ mkEntry tenant scope slot tx role =
 
 payload :: Word8 -> ByteString
 payload = BS.singleton
+
+mkSummary ::
+    TenantId ->
+    HistoryScope ->
+    Word8 ->
+    Word8 ->
+    TxRole ->
+    TxSummary
+mkSummary tenant scope slot tx role =
+    TxSummary
+        { txsKey =
+            TxSummaryKey
+                { tskTenant = tenant
+                , tskScope = scope
+                , tskSlot = SlotNo (fromIntegral slot)
+                , tskTxId = TxId (BS.replicate 32 tx)
+                , tskRole = role
+                }
+        , txsPayload = payload tx
+        , txsInputs =
+            [ TxSummaryInput
+                { tsiTxIn = "input#0"
+                , tsiScope = Just scope
+                , tsiValue = "42 lovelace"
+                }
+            ]
+        , txsOutputs =
+            [ TxSummaryOutput
+                { tsoAddress = "addr1..."
+                , tsoValue = "40 lovelace"
+                , tsoDatum = Just "datum-summary"
+                }
+            ]
+        , txsRedeemer = Just "redeemer-summary"
+        , txsFee = Just 2
+        , txsRequiredSigners = ["signer-a", "signer-b"]
+        , txsBlockHash = Just "block-hash"
+        }

--- a/test/Cardano/Node/Client/UTxOIndexer/SharedFollowerSpec.hs
+++ b/test/Cardano/Node/Client/UTxOIndexer/SharedFollowerSpec.hs
@@ -38,8 +38,10 @@ import Cardano.Node.Client.TxHistoryIndexer.Types (
     TenantId (..),
     TxId (..),
     TxRole (..),
+    TxSummary,
     TxSummaryEntry (..),
     TxSummaryKey (..),
+    entryToSummary,
  )
 import Cardano.Node.Client.UTxOIndexer.Follower (
     ChainSyncConfig (..),
@@ -154,7 +156,7 @@ slot-aware contract — a decoder that hardcoded a slot would file the
 entry under the wrong key.
 -}
 decodeAtSlot :: DecodeTx
-decodeAtSlot slot _ = Just [decodedEntryAt slot]
+decodeAtSlot slot _ = Just [decodedSummaryAt slot]
 
 {- | The single entry 'decodeAtSlot' emits for the integration block,
 keyed at the slot it received.
@@ -172,6 +174,9 @@ decodedEntryAt slot =
                 }
         , tsePayload = "history-payload"
         }
+
+decodedSummaryAt :: Slot.SlotNo -> TxSummary
+decodedSummaryAt = entryToSummary . decodedEntryAt
 
 -- | The block slot driven through the shared follower pass.
 processedSlot :: SlotNo


### PR DESCRIPTION
## Summary
- add TxSummary detail fields and a magic-prefixed RocksDB value codec with legacy payload fallback
- add appendSummaries/getByTxId and keep queryHistory/appendHistory compatibility
- carry detailed TxSummary values through DecodeTx and the shared follower
- stamp block-processed summaries with the block hash before storage so live tx-detail reads can show it
- store direct txid lookup rows in the existing entries column so prior two-column RocksDB stores still open

## Testing
- `nix develop --quiet -c cabal test cardano-node-clients:unit-tests -O0 --test-show-details=direct --test-options '--match TxHistoryIndexer'`
  - 14 examples, 0 failures
- `nix develop --quiet -c cabal test cardano-node-clients:unit-tests -O0 --test-show-details=direct --test-options '--match "shared-session history"'`
  - 5 examples, 0 failures
- `nix develop --quiet -c cabal test cardano-node-clients:unit-tests -O0 --test-show-details=direct --test-option=--match --test-option='tx-id lookup'`
  - 4 examples, 0 failures
- `nix develop --quiet -c cabal test cardano-node-clients:unit-tests -O0 --test-show-details=direct`
  - 136 examples, 0 failures, 1 pending

Refs lambdasistemi/amaru-treasury-tx#244
