### PR TITLE
feat(adversary): land N2N adversary module (PV12/Dijkstra-capable)

### DIFF
--- a/app/cardano-adversary/Main.hs
+++ b/app/cardano-adversary/Main.hs
@@ -1,0 +1,142 @@
+{- |
+Module      : Main
+Description : cardano-adversary daemon entry point
+License     : Apache-2.0
+
+CLI parsing only; everything else lives in
+'Cardano.Node.Client.Adversary.Daemon.runDaemon'. CLI shape is
+documented in @specs/036-cardano-adversary/spec.md@ and follows the
+same idiom as @cardano-tx-generator@.
+
+Required flags: @--control-socket@ and @--network-magic@.
+Optional, repeatable: @--producer-host@. Optional:
+@--producer-port@ (defaults to 3001).
+-}
+module Main (main) where
+
+import Cardano.Node.Client.Adversary.Daemon (
+    DaemonConfig (..),
+    runDaemon,
+ )
+import Data.Word (Word32)
+import Network.Socket (PortNumber)
+import Ouroboros.Network.Magic (NetworkMagic (..))
+import System.Environment (getArgs, getProgName)
+import System.Exit (exitFailure)
+import System.IO (hPutStrLn, stderr)
+import Text.Read (readMaybe)
+
+defaultProducerPort :: PortNumber
+defaultProducerPort = 3001
+
+{- | Parse the first @--key value@ pair from the argument list,
+returning the value and the remaining args. Repeated flags are
+handled separately by 'takeAllFlags'.
+-}
+takeFlag :: String -> [String] -> Maybe (String, [String])
+takeFlag _ [] = Nothing
+takeFlag key args = go [] args
+  where
+    go _ [] = Nothing
+    go seen (k : v : rest)
+        | k == key = Just (v, reverse seen ++ rest)
+    go seen (x : rest) = go (x : seen) rest
+
+{- | Pull every @--key value@ pair for the given key out of the
+argument list, preserving order, and return the residual args.
+-}
+takeAllFlags :: String -> [String] -> ([String], [String])
+takeAllFlags key = go [] []
+  where
+    go vs rest [] = (reverse vs, reverse rest)
+    go vs rest (k : v : xs) | k == key = go (v : vs) rest xs
+    go vs rest (x : xs) = go vs (x : rest) xs
+
+parseConfig :: [String] -> IO DaemonConfig
+parseConfig args0 = do
+    (control, args1) <- requireFlag "--control-socket" args0
+    (magicS, args2) <- requireFlag "--network-magic" args1
+    let (hosts, args3) = takeAllFlags "--producer-host" args2
+        (mPortS, args4) = case takeFlag "--producer-port" args3 of
+            Just (p, rest) -> (Just p, rest)
+            Nothing -> (Nothing, args3)
+        (mPoints, args5) = case takeFlag "--chain-points-file" args4 of
+            Just (p, rest) -> (Just p, rest)
+            Nothing -> (Nothing, args4)
+    case args5 of
+        [] -> pure ()
+        extra -> dieUsage $ "Unexpected args: " <> show extra
+    magic <- requireWord32 "--network-magic" magicS
+    port <- maybe (pure defaultProducerPort) (parsePort "--producer-port") mPortS
+    pure
+        DaemonConfig
+            { daemonControlSocket = control
+            , daemonProducerHosts = hosts
+            , daemonProducerPort = port
+            , daemonNetworkMagic = NetworkMagic magic
+            , daemonChainPointsFile = mPoints
+            }
+  where
+    requireFlag key args =
+        maybe
+            (dieUsage $ "Missing required flag: " <> key)
+            pure
+            (takeFlag key args)
+    requireWord32 key s =
+        maybe
+            ( dieUsage $
+                key
+                    <> " expects a non-negative 32-bit integer, got: "
+                    <> s
+            )
+            pure
+            (readMaybe s :: Maybe Word32)
+    parsePort key s =
+        maybe
+            ( dieUsage $
+                key
+                    <> " expects a port number 1..65535, got: "
+                    <> s
+            )
+            pure
+            (readMaybe s :: Maybe PortNumber)
+
+dieUsage :: String -> IO a
+dieUsage msg = do
+    prog <- getProgName
+    hPutStrLn stderr msg
+    hPutStrLn stderr ""
+    hPutStrLn stderr $ "Usage: " <> prog <> " \\"
+    hPutStrLn stderr "  --control-socket PATH \\"
+    hPutStrLn stderr "  --network-magic INT \\"
+    hPutStrLn stderr "  [--producer-host HOST]... \\"
+    hPutStrLn stderr "  [--producer-port INT] \\"
+    hPutStrLn stderr "  [--chain-points-file PATH]"
+    exitFailure
+
+main :: IO ()
+main = do
+    args <- getArgs
+    case args of
+        ["--help"] -> printHelp
+        ["-h"] -> printHelp
+        _ -> do
+            cfg <- parseConfig args
+            runDaemon cfg
+
+printHelp :: IO ()
+printHelp = do
+    prog <- getProgName
+    putStrLn $ prog <> " — cardano-adversary daemon (PR B scaffold)"
+    putStrLn ""
+    putStrLn "Listens on a UNIX SOCK_STREAM control socket and answers one"
+    putStrLn "NDJSON request per connection per the wire spec at"
+    putStrLn "specs/036-cardano-adversary/contracts/control-wire.md."
+    putStrLn ""
+    putStrLn "Flags:"
+    putStrLn "  --control-socket PATH    Bind path for the control socket. Required."
+    putStrLn "  --network-magic INT      Cardano network magic. Required."
+    putStrLn "  --producer-host HOST     Producer hostname (repeatable, optional)."
+    putStrLn "  --producer-port INT      N2N port (default 3001)."
+    putStrLn "  --chain-points-file PATH File of chain points written by tracer-sidecar."
+    putStrLn "  --help, -h               Print this help and exit 0."

--- a/cabal.project
+++ b/cabal.project
@@ -1,8 +1,12 @@
-index-state: 2026-02-17T10:15:41Z
+index-state: 2026-03-26T20:21:33Z
 
 index-state:
-  , hackage.haskell.org 2026-02-17T10:15:41Z
-  , cardano-haskell-packages 2026-03-23T18:21:55Z
+  , hackage.haskell.org 2026-03-26T20:21:33Z
+  , cardano-haskell-packages 2026-05-02T16:21:41Z
+
+active-repositories:
+  , :rest
+  , cardano-haskell-packages:override
 
 packages:
   .
@@ -39,8 +43,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/cardano-foundation/cardano-ledger-read
-  tag: 34d0767bd5c3648ab77ecbc00db0ad0a2a5316a5
-  --sha256: 0v357pbw2s22lsizxidq67pn4dcjkajips6mlcskd1zna35nyyv6
+  tag: 242c5c856f51aebe17f2d39b2320df6de1c05293
+  --sha256: 1k6vjzng1qmjs4kpz5123wps6phxqyss6c44g48z6riwiwnkzpjw
 
 source-repository-package
   type: git
@@ -61,24 +65,34 @@ source-repository-package
   tag: cuddle-1.1.1.0
   --sha256: 1f4wk3kgb68bg97gfb9wycv5zkv0dsghlkf9pj64z0bpcr0wkxrc
 
--- Pin Cardano and Ouroboros packages for the cardano-node 10.7.0 line
+-- Pin Cardano and Ouroboros packages for the cardano-node 11.0.1 line.
+-- This includes the Dijkstra / PV12 support that supersedes stale PR #19.
 constraints:
-    cardano-ledger-allegra == 1.9.0.0
-  , cardano-ledger-alonzo == 1.15.0.0
+    cardano-binary == 1.8.0.0
+  , cardano-crypto-class == 2.3.2.0
+  , cardano-crypto-praos == 2.2.2.0
+  , cardano-crypto-wrapper == 1.7.0.0
+  , cardano-data == 1.3.0.0
+  , cardano-diffusion == 1.0.0.0
+  , cardano-ledger-allegra == 1.9.0.0
+  , cardano-ledger-alonzo == 1.15.0.1
   , cardano-ledger-api == 1.13.0.0
   , cardano-ledger-babbage == 1.13.0.0
+  , cardano-ledger-binary == 1.8.1.0
   , cardano-ledger-byron == 1.3.0.0
-  , cardano-ledger-conway == 1.21.0.0
-  , cardano-ledger-core == 1.19.0.0
+  , cardano-ledger-conway == 1.22.1.0
+  , cardano-ledger-core == 1.20.0.0
+  , cardano-ledger-dijkstra == 0.2.0.1
   , cardano-ledger-mary == 1.10.0.0
-  , cardano-ledger-shelley == 1.18.0.0
-  , cardano-crypto-class == 2.3.1.0
-  , cardano-crypto-praos == 2.2.2.0
+  , cardano-ledger-shelley == 1.18.1.0
+  , cardano-prelude == 0.2.2.0
   , cardano-protocol-tpraos == 1.5.0.0
+  , cardano-slotting == 0.2.1.0
   , cuddle == 1.1.1.0
   , quickcheck-state-machine == 0.10.3
-  , ouroboros-consensus == 1.0.0.0
+  , ouroboros-consensus == 3.0.1.0
   , ouroboros-network == 1.1.0.0
+  , plutus-core == 1.63.0.0
   , typed-protocols == 1.2.0.0
 
 package ouroboros-consensus

--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -45,6 +45,14 @@ library
   default-language: GHC2021
   exposed-modules:
     Cardano.Node.Client.Address
+    Cardano.Node.Client.Adversary.Application
+    Cardano.Node.Client.Adversary.ChainPoints
+    Cardano.Node.Client.Adversary.ChainSync.Codec
+    Cardano.Node.Client.Adversary.ChainSync.Connection
+    Cardano.Node.Client.Adversary.Daemon
+    Cardano.Node.Client.Adversary.RandomSource
+    Cardano.Node.Client.Adversary.Server
+    Cardano.Node.Client.Adversary.Types
     Cardano.Node.Client.Ledger
     Cardano.Node.Client.N2C.ChainSync
     Cardano.Node.Client.N2C.Codecs
@@ -86,6 +94,7 @@ library
     , cardano-ledger-byron
     , cardano-ledger-conway
     , cardano-ledger-core
+    , cardano-ledger-dijkstra
     , cardano-ledger-mary
     , cardano-ledger-read
     , cardano-node-clients:block-indexer
@@ -248,6 +257,18 @@ executable utxo-indexer
     , cardano-node-clients
     , cardano-node-clients:utxo-indexer-lib
 
+executable cardano-adversary
+  import:           warnings
+  hs-source-dirs:   app/cardano-adversary
+  main-is:          Main.hs
+  default-language: GHC2021
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+    , base
+    , cardano-node-clients
+    , network
+    , ouroboros-network:api
+
 test-suite unit-tests
   import:           warnings
   type:             exitcode-stdio-1.0
@@ -256,6 +277,8 @@ test-suite unit-tests
   default-language: GHC2021
   other-modules:
     Cardano.Node.Client.AddressSpec
+    Cardano.Node.Client.Adversary.ChainPointsSpec
+    Cardano.Node.Client.Adversary.ServerSpec
     Cardano.Node.Client.BlockIndexer.HandlerSpec
     Cardano.Node.Client.ConwayFixtures
     Cardano.Node.Client.N2C.ProbeSpec
@@ -291,6 +314,7 @@ test-suite unit-tests
     , cardano-ledger-byron
     , cardano-ledger-conway
     , cardano-ledger-core
+    , cardano-ledger-dijkstra
     , cardano-ledger-mary
     , cardano-node-clients
     , cardano-node-clients:block-indexer

--- a/flake.lock
+++ b/flake.lock
@@ -3,28 +3,28 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1774292745,
-        "narHash": "sha256-m/+P0W4C6tYojUPSq8tY4Dwan14bDA2aXbkctWTonj8=",
+        "lastModified": 1777742585,
+        "narHash": "sha256-ZzXz2vOhqethlqPgBExPXEnKWvaTbidsIxh5MGv+pwE=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "887d73ce434831e3a67df48e070f4f979b3ac5a6",
+        "rev": "e8a483522ee73c8c9493ea6055553e5c2532e66b",
         "type": "github"
       },
       "original": {
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "887d73ce434831e3a67df48e070f4f979b3ac5a6",
+        "rev": "e8a483522ee73c8c9493ea6055553e5c2532e66b",
         "type": "github"
       }
     },
     "CHaP_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1774345081,
-        "narHash": "sha256-m/+P0W4C6tYojUPSq8tY4Dwan14bDA2aXbkctWTonj8=",
+        "lastModified": 1777742585,
+        "narHash": "sha256-ZzXz2vOhqethlqPgBExPXEnKWvaTbidsIxh5MGv+pwE=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "887d73ce434831e3a67df48e070f4f979b3ac5a6",
+        "rev": "e8a483522ee73c8c9493ea6055553e5c2532e66b",
         "type": "github"
       },
       "original": {
@@ -69,16 +69,16 @@
     "blst": {
       "flake": false,
       "locked": {
-        "lastModified": 1739372843,
-        "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
+        "lastModified": 1749204514,
+        "narHash": "sha256-Q9/zGN93TnJt2c8YvSaURstoxT02ts3nVkO5V08m4TI=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
+        "rev": "6d960cd05d6fe2b5bc9ba161edf0c1a131b87c4c",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
-        "ref": "v0.3.14",
+        "ref": "v0.3.15",
         "repo": "blst",
         "type": "github"
       }
@@ -254,16 +254,16 @@
         "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1774379192,
-        "narHash": "sha256-6b9fX1RNmHdBRpmE4WYFCf13vwZZGg1LHRhHP7GRJHE=",
+        "lastModified": 1777953209,
+        "narHash": "sha256-+dod+EL73MICgbgflyJnwDlxbCeaBbBLrr2tLX59hAA=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "1e6d8228693ab2aa4e1d7305e7bdcc57cdd278e4",
+        "rev": "97036a66bcf8c89f687ae57a048eecc0389977ef",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.7.0",
+        "ref": "11.0.1",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -566,11 +566,11 @@
     "hackageNix_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1771502057,
-        "narHash": "sha256-XwoLg6wftnU50KPn5jY4jtuGulyNPyspB4lSDSrmR1g=",
+        "lastModified": 1774557316,
+        "narHash": "sha256-AErDLAypo/a4gNSKjExpNUM7xdlsTdTf68cWnbr1bOA=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "e6bb05af1f45a616f534798263a5a13f2299e3bc",
+        "rev": "06fa3e96f4d7ced3496ec984c8016aad5282db67",
         "type": "github"
       },
       "original": {
@@ -1227,11 +1227,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1774280402,
-        "narHash": "sha256-bHp3Ji7c0T0RCor9FVo6yvjSPT0bVQE5EFw5JxvqZDM=",
+        "lastModified": 1777941182,
+        "narHash": "sha256-FX3+8GIrB2z4akmcYTStELDKVJWgqy9yFt0mxwpU3Qc=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f444d972c301ddd9f23eac4325ffcc8b5766eee9",
+        "rev": "9de00113c11ba8cac908a63acf34b193cda7475b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -27,12 +27,12 @@
     };
     CHaP = {
       url =
-        "github:intersectmbo/cardano-haskell-packages/887d73ce434831e3a67df48e070f4f979b3ac5a6";
+        "github:intersectmbo/cardano-haskell-packages/e8a483522ee73c8c9493ea6055553e5c2532e66b";
       flake = false;
     };
     mkdocs.url = "github:paolino/dev-assets?dir=mkdocs";
     cardano-node = {
-      url = "github:IntersectMBO/cardano-node/10.7.0";
+      url = "github:IntersectMBO/cardano-node/11.0.1";
     };
     bundlers = {
       url = "github:NixOS/bundlers";
@@ -57,7 +57,7 @@
           };
           lintPkgs = import lintNixpkgs { inherit system; };
           lib = pkgs.lib;
-          indexState = "2026-02-17T10:15:41Z";
+          indexState = "2026-03-26T20:21:33Z";
           indexTool = { index-state = indexState; };
           fix-libs = { lib, pkgs, ... }: {
             packages.cardano-crypto-praos.components.library.pkgconfig =
@@ -161,6 +161,7 @@
         in {
           packages = {
             default = components.exes.utxo-indexer;
+            cardano-adversary = components.exes.cardano-adversary;
             devnet-genesis = pkgs.runCommand "devnet-genesis" {} ''
               cp -r ${./e2e-test/genesis} $out
             '';
@@ -175,6 +176,11 @@
             utxo-indexer = {
               type = "app";
               program = "${components.exes.utxo-indexer}/bin/utxo-indexer";
+            };
+            cardano-adversary = {
+              type = "app";
+              program =
+                "${components.exes.cardano-adversary}/bin/cardano-adversary";
             };
           } // lib.optionalAttrs pkgs.stdenv.isLinux {
             linux-artifact-smoke = {

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ hlint:
     find . -type f -name '*.hs' -not -path '*/dist-newstyle/*' -exec hlint {} +
 
 build:
-    cabal build cardano-node-clients:exe:utxo-indexer -O0
+    cabal build cardano-node-clients:lib:cardano-node-clients cardano-node-clients:exe:utxo-indexer cardano-node-clients:exe:cardano-adversary -O0
 
 e2e:
     cabal test e2e-tests -O0 --test-show-details=direct

--- a/lib/Cardano/Node/Client/Adversary/Application.hs
+++ b/lib/Cardano/Node/Client/Adversary/Application.hs
@@ -1,0 +1,289 @@
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Use const" #-}
+module Cardano.Node.Client.Adversary.Application (
+    Limit (..),
+    adversaryApplication,
+    ChainSyncApplication,
+    repeatedAdversaryApplication,
+)
+where
+
+import Cardano.Network.NodeToNode (
+    ControlMessage (..),
+    ControlMessageSTM,
+ )
+import Cardano.Node.Client.Adversary.ChainSync.Codec (Header, Point, Tip)
+import Cardano.Node.Client.Adversary.ChainSync.Connection (
+    ChainSyncApplication,
+    runChainSyncApplication,
+ )
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (
+    mapConcurrently_,
+ )
+import Control.Concurrent.Class.MonadSTM.Strict (
+    MonadSTM (..),
+    StrictTVar,
+    modifyTVar,
+    newTVarIO,
+    readTVar,
+ )
+import Control.Exception (SomeException, try)
+import Control.Tracer (Tracer, traceWith)
+import Data.Function (fix)
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
+import Data.Word (Word32)
+import Network.Socket (PortNumber)
+import Ouroboros.Consensus.Block (headerPoint)
+import Ouroboros.Consensus.Protocol.Praos.Header ()
+import Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion ()
+import Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
+import Ouroboros.Network.Block (genesisPoint, getTipPoint)
+import Ouroboros.Network.Magic (NetworkMagic)
+import Ouroboros.Network.Protocol.ChainSync.Client (
+    ChainSyncClient (..),
+    ClientStIdle (..),
+    ClientStIntersect (..),
+    ClientStNext (..),
+ )
+
+newtype State = State
+    { chainVar :: StrictTVar IO SyncedChain
+    }
+
+type SyncedChain = [Header]
+
+onChainVar :: State -> (SyncedChain -> SyncedChain) -> IO ()
+onChainVar state f = atomically $ modifyTVar (chainVar state) f
+
+readChainVar :: State -> STM IO SyncedChain
+readChainVar state = readTVar $ chainVar state
+
+readChainVarIO :: State -> IO SyncedChain
+readChainVarIO = atomically . readChainVar
+
+rollForward :: State -> Header -> IO ()
+rollForward state b = onChainVar state $ \(!chain) ->
+    chain <> [b]
+
+-- We will fail to roll back iff `p` doesn't exist in `chain`
+-- This will happen when we're asked to roll back to `startingPoint`,
+-- which we can check for, or any point before, which we can't
+-- check for. Hence we ignore all failures to rollback and replace the
+-- chain with an empty one if we do.
+rollBackward :: State -> Point -> IO ()
+rollBackward state p = onChainVar state $ \(!chain) ->
+    rollbackToPoint p chain
+
+rollbackToPoint :: Point -> SyncedChain -> SyncedChain
+rollbackToPoint p
+    | p == genesisPoint = const []
+    | otherwise = go []
+  where
+    go _ [] = []
+    go kept (h : hs)
+        | headerPoint h == p = reverse (h : kept)
+        | otherwise = go (h : kept) hs
+
+headPoint :: SyncedChain -> Point
+headPoint [] = genesisPoint
+headPoint chain = headerPoint (last chain)
+
+-- | A limit on the number of blocks to sync
+newtype Limit = Limit {limit :: Word32}
+    deriving newtype (Show, Read, Eq, Ord)
+
+-- the way to step the protocol
+type StepProtocol = IO (Maybe Protocol)
+
+-- Internal protocol state machine
+data Protocol = Protocol
+    { onRollBackward :: Point -> Tip -> StepProtocol
+    , onRollForward :: Header -> StepProtocol
+    , points :: [Point] -> StepProtocol
+    }
+
+-- A protocol controlled by control messages
+controlledProtocol ::
+    ControlMessageSTM IO -> -- control message source
+    Protocol
+controlledProtocol controlMessageSTM = fix $ \client ->
+    let react ctrl = case ctrl of
+            Continue -> Just client
+            Quiesce -> error "controlledClient: unexpected Quiesce"
+            Terminate -> Nothing
+     in Protocol
+            { onRollBackward = \_point _tip ->
+                react <$> atomically controlMessageSTM
+            , onRollForward = \_header ->
+                react <$> atomically controlMessageSTM
+            , points = \_points -> pure $ Just client
+            }
+
+-- a control message source that terminates after syncing 'limit' blocks
+terminateAfterCount ::
+    State ->
+    Limit ->
+    ControlMessageSTM IO
+terminateAfterCount stateVar limit = do
+    chainLength <-
+        Limit . fromIntegral . length <$> readChainVar stateVar
+    pure $
+        if chainLength < limit
+            then Continue
+            else Terminate
+
+-- initialize the protocol with a control message source
+mkProtocol ::
+    State -> -- the mock chain
+    Limit -> -- limit of blocks to sync
+    Protocol
+mkProtocol stateVar limit =
+    controlledProtocol $ terminateAfterCount stateVar limit
+
+-- The idle state of the chain sync client
+type ChainSyncIdle = ClientStIdle Header Point Tip IO ()
+
+-- when the protocols returns Nothing, we're done as a N2N client
+nothingToDone ::
+    Maybe Protocol ->
+    (Protocol -> ChainSyncIdle) ->
+    ChainSyncIdle
+nothingToDone Nothing _ = SendMsgDone ()
+nothingToDone (Just next) cont = cont next
+
+-- boots the protocol and step into initialise
+mkChainSyncApplication ::
+    -- | the mock chain
+    State ->
+    -- | starting point
+    Point ->
+    -- | limit of blocks to sync
+    Limit ->
+    -- | the chain sync client application
+    ChainSyncApplication
+mkChainSyncApplication stateVar startingPoint limit = ChainSyncClient $ do
+    ps <- points (mkProtocol stateVar limit) [startingPoint]
+    pure $ nothingToDone ps $ initialise stateVar startingPoint
+
+-- In this consumer example, we do not care about whether the server
+-- found an intersection or not. If not, we'll just sync from genesis.
+--
+-- Alternative policies here include:
+--  iteratively finding the best intersection
+--  rejecting the server if there is no intersection in the last K blocks
+--
+initialise ::
+    State -> -- the mock chain
+    Point -> -- starting point
+    Protocol -> -- previous client state machine
+    ChainSyncIdle
+initialise stateVar startingPoint prev =
+    let next =
+            ChainSyncClient
+                { runChainSyncClient = pure $ requestNext stateVar prev
+                }
+     in SendMsgFindIntersect [startingPoint] $
+            ClientStIntersect
+                { recvMsgIntersectFound = \_point _tip -> next
+                , recvMsgIntersectNotFound = \_tip -> next
+                }
+
+requestNext ::
+    State -> -- the mock chain
+    Protocol -> -- this client state machine
+    ChainSyncIdle
+requestNext stateVar prev =
+    SendMsgRequestNext
+        (pure ())
+        ClientStNext
+            { recvMsgRollForward = \header tip -> ChainSyncClient $ do
+                rollForward stateVar header
+                choice <-
+                    stoppingOnTip
+                        (headerPoint header)
+                        (getTipPoint tip)
+                        $ onRollForward prev header
+                pure $ nothingToDone choice $ requestNext stateVar
+            , recvMsgRollBackward = \pIntersect tip -> ChainSyncClient $ do
+                rollBackward stateVar pIntersect
+                choice <- onRollBackward prev pIntersect tip
+                pure $ nothingToDone choice $ requestNext stateVar
+            }
+
+stoppingOnTip ::
+    (Ord a) =>
+    a ->
+    a ->
+    StepProtocol ->
+    StepProtocol
+stoppingOnTip h t stepProtocol
+    | h >= t = pure Nothing
+    | otherwise = stepProtocol
+
+{- | Run an adversary application that connects to a node and syncs
+blocks starting from the given point, up to the given limit.
+-}
+adversaryApplication ::
+    -- | network magic
+    NetworkMagic ->
+    -- | peer host
+    String ->
+    -- | peer port
+    PortNumber ->
+    -- | starting point
+    Point ->
+    -- | limit of blocks to sync
+    Limit ->
+    IO (Either SomeException Point)
+adversaryApplication magic peerName peerPort startingPoint limit = do
+    chainVar <- newTVarIO ([] :: SyncedChain)
+    let stateVar = State{chainVar}
+    res <-
+        -- To gracefully handle the node getting killed it seems we need
+        -- the outer 'try', even if connectToNode already returns 'Either
+        -- SomeException'.
+        try $
+            runChainSyncApplication
+                magic
+                peerName
+                peerPort
+                (const $ mkChainSyncApplication stateVar startingPoint limit)
+    case res of
+        Left e -> return $ Left e
+        Right _ -> pure . headPoint <$> readChainVarIO stateVar
+
+repeatedAdversaryApplication ::
+    Tracer IO String -> -- thread safe logger
+    Int ->
+    NetworkMagic ->
+    [String] ->
+    PortNumber ->
+    -- | must be infinite list
+    NonEmpty Point ->
+    Limit ->
+    IO ()
+repeatedAdversaryApplication tracer nConns magic peerNames peerPort startingPoints limit = do
+    let write = traceWith tracer
+    let singleRun (_i, peerName, startingPoint) = do
+            write $
+                "Starting adversary application against "
+                    <> peerName
+                    <> " from point "
+                    <> show startingPoint
+            result <-
+                (startingPoint,)
+                    <$> adversaryApplication magic peerName peerPort startingPoint limit
+            write $
+                "Completed adversary application against "
+                    <> peerName
+                    <> " from point "
+                    <> show startingPoint
+                    <> " with result "
+                    <> show result
+    mapConcurrently_
+        singleRun
+        $ zip3 [1 .. nConns] (cycle peerNames) (NE.toList startingPoints)
+    threadDelay 1000000 -- wait for logging to complete

--- a/lib/Cardano/Node/Client/Adversary/ChainPoints.hs
+++ b/lib/Cardano/Node/Client/Adversary/ChainPoints.hs
@@ -1,0 +1,85 @@
+{- |
+Module      : Cardano.Node.Client.Adversary.ChainPoints
+Description : Parse chain-points harvested by tracer-sidecar
+License     : Apache-2.0
+
+Reads a file emitted by the antithesis-side @tracer-sidecar@
+container — one chain point per line in @\<hex\>@\<slot\>@ form, or
+the literal @origin@. Used by the daemon's @chain_sync_flap@
+endpoint to pick a randomised starting point for each adversarial
+connection.
+
+Lifted from
+[`cardano-foundation/cardano-node-antithesis/components/adversary/src/Adversary.hs`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/components/adversary/src/Adversary.hs)
+so the parsing logic lives next to the daemon that uses it.
+-}
+module Cardano.Node.Client.Adversary.ChainPoints (
+    Point,
+    originPoint,
+    readChainPoint,
+    parseChainPointSamples,
+    generatePoints,
+) where
+
+import Cardano.Node.Client.Adversary.ChainSync.Codec (Point)
+import Cardano.Node.Client.Adversary.ChainSync.Connection (HeaderHash)
+import Data.ByteString.Base16 qualified as B16
+import Data.ByteString.Short qualified as SBS
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
+import Ouroboros.Consensus.HardFork.Combinator qualified as Consensus
+import Ouroboros.Network.Block (SlotNo (..))
+import Ouroboros.Network.Block qualified as Network
+import Ouroboros.Network.Point (WithOrigin (..))
+import Ouroboros.Network.Point qualified as Point
+import System.Random (StdGen, randomR)
+import Text.Read (readMaybe)
+
+-- | The chain's origin (genesis-before-first-block).
+originPoint :: Point
+originPoint = Network.Point Origin
+
+-- | Parse one line. Format: @origin@ | @\<hex\>@\<slot\>@.
+readChainPoint :: String -> Maybe Point
+readChainPoint "origin" = Just originPoint
+readChainPoint str = case split (== '@') str of
+    [blockHashStr, slotNoStr] -> do
+        (hash :: HeaderHash) <-
+            Consensus.OneEraHash
+                . SBS.toShort
+                <$> either
+                    (const Nothing)
+                    Just
+                    ( B16.decode $
+                        T.encodeUtf8 $
+                            T.pack blockHashStr
+                    )
+        slot <- SlotNo <$> readMaybe slotNoStr
+        return $ Network.Point $ At $ Point.Block slot hash
+    _ -> Nothing
+  where
+    split f = map T.unpack . T.split f . T.pack
+
+{- | Parse a whole file (one chain point per line). Always prepends
+'originPoint' to the resulting list so the adversary can also
+start from genesis. Returns 'Nothing' if any individual line
+fails to parse.
+-}
+parseChainPointSamples :: String -> Maybe (NonEmpty Point)
+parseChainPointSamples =
+    fmap (originPoint NE.:|)
+        . mapM readChainPoint
+        . lines
+
+{- | Lazy infinite stream of points sampled uniformly from the
+input.
+-}
+generatePoints :: StdGen -> NonEmpty Point -> NonEmpty Point
+generatePoints g points = NE.unfoldr (fmap Just . randomElement points) g
+  where
+    randomElement :: NonEmpty a -> StdGen -> (a, StdGen)
+    randomElement l g' =
+        let (idx, g'') = randomR (0, length l - 1) g'
+         in (l NE.!! idx, g'')

--- a/lib/Cardano/Node/Client/Adversary/ChainSync/Codec.hs
+++ b/lib/Cardano/Node/Client/Adversary/ChainSync/Codec.hs
@@ -1,0 +1,114 @@
+module Cardano.Node.Client.Adversary.ChainSync.Codec (
+    codecChainSync,
+    Block,
+    Header,
+    Tip,
+    Point,
+) where
+
+import Cardano.Chain.Slotting (EpochSlots (EpochSlots))
+import Codec.Serialise (DeserialiseFailure, Serialise (..))
+import Codec.Serialise.Decoding (Decoder)
+import Codec.Serialise.Encoding (Encoding)
+import Data.ByteString.Lazy qualified as LBS
+import Data.Data (Proxy (Proxy))
+import Network.TypedProtocol.Codec (Codec)
+import Ouroboros.Consensus.Block.Abstract (
+    decodeRawHash,
+    encodeRawHash,
+ )
+import Ouroboros.Consensus.Byron.Ledger (ByronBlock, CodecConfig (..))
+import Ouroboros.Consensus.Cardano.Block (
+    CodecConfig (CardanoCodecConfig),
+ )
+import Ouroboros.Consensus.Cardano.Block qualified as Consensus
+import Ouroboros.Consensus.Cardano.Node (
+    pattern CardanoNodeToNodeVersion2,
+ )
+import Ouroboros.Consensus.HardFork.Combinator.NetworkVersion (
+    HardForkNodeToNodeVersion,
+ )
+import Ouroboros.Consensus.Node.Serialisation (
+    decodeNodeToNode,
+    encodeNodeToNode,
+ )
+import Ouroboros.Consensus.Protocol.Praos.Header ()
+import Ouroboros.Consensus.Shelley.Ledger (
+    CodecConfig (ShelleyCodecConfig),
+ )
+import Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion ()
+import Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
+import Ouroboros.Network.Block (
+    decodeTip,
+    encodeTip,
+ )
+import Ouroboros.Network.Block qualified as Network
+import Ouroboros.Network.Protocol.ChainSync.Codec qualified as ChainSync
+import Ouroboros.Network.Protocol.ChainSync.Type (ChainSync)
+
+-- | Real Cardano Block type
+type Block = Consensus.CardanoBlock Consensus.StandardCrypto
+
+-- | Real Cardano Header type
+type Header = Consensus.Header Block
+
+-- | Real Cardano Tip type
+type Tip = Network.Tip Block
+
+-- | Real Cardano Point type
+type Point = Network.Point Block
+
+-- The ChainSync codec for our Block, Point, and Tip types
+codecChainSync ::
+    Codec
+        (ChainSync Header Point Tip)
+        DeserialiseFailure
+        IO
+        LBS.ByteString
+codecChainSync =
+    ChainSync.codecChainSync
+        encHeader
+        decHeader
+        encPoint
+        decPoint
+        encTip
+        decTip
+
+----- Encoding and Decoding Headers -----
+encHeader :: Header -> Encoding
+encHeader = encodeNodeToNode @Block ccfg version
+
+decHeader :: Decoder s Header
+decHeader = decodeNodeToNode @Block ccfg version
+
+version ::
+    HardForkNodeToNodeVersion
+        (ByronBlock : Consensus.CardanoShelleyEras c)
+version = CardanoNodeToNodeVersion2
+
+-- One ShelleyCodecConfig per Shelley-based era (Shelley, Allegra,
+-- Mary, Alonzo, Babbage, Conway, Dijkstra). The arity grows when
+-- consensus introduces a new era; bump here in lock-step.
+ccfg :: Consensus.CardanoCodecConfig c
+ccfg =
+    CardanoCodecConfig
+        (ByronCodecConfig $ EpochSlots 42)
+        ShelleyCodecConfig
+        ShelleyCodecConfig
+        ShelleyCodecConfig
+        ShelleyCodecConfig
+        ShelleyCodecConfig
+        ShelleyCodecConfig
+        ShelleyCodecConfig
+
+--- Encoding and Decoding Points -----
+encPoint :: Point -> Encoding
+encPoint = encode
+decPoint :: Decoder s Point
+decPoint = decode
+
+--- Encoding and Decoding Tips -----
+encTip :: Network.Tip Block -> Encoding
+encTip = encodeTip (encodeRawHash (Proxy @Block))
+decTip :: Decoder s (Network.Tip Block)
+decTip = decodeTip (decodeRawHash (Proxy @Block))

--- a/lib/Cardano/Node/Client/Adversary/ChainSync/Connection.hs
+++ b/lib/Cardano/Node/Client/Adversary/ChainSync/Connection.hs
@@ -1,0 +1,178 @@
+module Cardano.Node.Client.Adversary.ChainSync.Connection (
+    runChainSyncApplication,
+    HeaderHash,
+    ChainSyncApplication,
+)
+where
+
+import Cardano.Network.NodeToNode (
+    DiffusionMode (InitiatorOnlyDiffusionMode),
+    NodeToNodeVersion (NodeToNodeV_14),
+    NodeToNodeVersionData (..),
+    nodeToNodeCodecCBORTerm,
+ )
+import Cardano.Network.Protocol.Handshake.Codec (
+    nodeToNodeHandshakeCodec,
+ )
+import Cardano.Node.Client.Adversary.ChainSync.Codec (
+    Block,
+    Header,
+    Point,
+    Tip,
+    codecChainSync,
+ )
+import Control.Exception (SomeException)
+import Control.Tracer (nullTracer)
+import Data.ByteString.Lazy (LazyByteString)
+import Data.List.NonEmpty qualified as NE
+import Data.Void (Void)
+import Network.Mux qualified as Mx
+import Network.Socket (
+    AddrInfo (..),
+    AddrInfoFlag (AI_PASSIVE),
+    PortNumber,
+    SocketType (Stream),
+    defaultHints,
+    getAddrInfo,
+ )
+import Ouroboros.Consensus.Protocol.Praos.Header ()
+import Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion ()
+import Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
+import Ouroboros.Network.Block qualified as Network
+import Ouroboros.Network.Diffusion.Configuration (
+    PeerSharing (PeerSharingDisabled),
+ )
+import Ouroboros.Network.IOManager (withIOManager)
+import Ouroboros.Network.Magic (NetworkMagic (..))
+import Ouroboros.Network.Mux (
+    MiniProtocol (..),
+    MiniProtocolLimits (..),
+    MiniProtocolNum (MiniProtocolNum),
+    OuroborosApplication (..),
+    OuroborosApplicationWithMinimalCtx,
+    RunMiniProtocol (InitiatorProtocolOnly),
+    StartOnDemandOrEagerly (StartOnDemand),
+    mkMiniProtocolCbFromPeer,
+ )
+import Ouroboros.Network.Protocol.ChainSync.Client (
+    ChainSyncClient (..),
+ )
+import Ouroboros.Network.Protocol.ChainSync.Client qualified as ChainSync
+import Ouroboros.Network.Protocol.Handshake.Codec (
+    cborTermVersionDataCodec,
+    noTimeLimitsHandshake,
+ )
+import Ouroboros.Network.Protocol.Handshake.Version (
+    Acceptable (acceptableVersion),
+    Queryable (queryVersion),
+    simpleSingletonVersions,
+ )
+import Ouroboros.Network.Snocket (
+    makeSocketBearer,
+    socketSnocket,
+ )
+import Ouroboros.Network.Socket (
+    ConnectToArgs (..),
+    HandshakeCallbacks (..),
+    connectToNode,
+    nullNetworkConnectTracers,
+ )
+
+-- | The application type for a chain sync client
+type ChainSyncApplication = ChainSyncClient Header Point Tip IO ()
+
+-- | The header hash type used in the chain sync connection
+type HeaderHash = Network.HeaderHash Block
+
+-- | Connect to a node-to-node chain sync server and run the given application
+runChainSyncApplication ::
+    -- | The network magic
+    NetworkMagic ->
+    -- | host
+    String ->
+    -- | port
+    PortNumber ->
+    -- | application
+    (NodeToNodeVersionData -> ChainSyncApplication) ->
+    IO (Either SomeException (Either () Void))
+runChainSyncApplication magic peerName peerPort application = withIOManager $ \iocp -> do
+    AddrInfo{addrAddress} <- resolve peerName peerPort
+    connectToNode -- withNode
+        (socketSnocket iocp) -- TCP
+        makeSocketBearer
+        ConnectToArgs
+            { ctaHandshakeCodec = nodeToNodeHandshakeCodec
+            , ctaHandshakeTimeLimits = noTimeLimitsHandshake
+            , ctaVersionDataCodec =
+                cborTermVersionDataCodec
+                    nodeToNodeCodecCBORTerm
+            , ctaConnectTracers = nullNetworkConnectTracers
+            , ctaHandshakeCallbacks =
+                HandshakeCallbacks
+                    { acceptCb = acceptableVersion
+                    , queryCb = queryVersion
+                    }
+            }
+        mempty -- socket options
+        ( simpleSingletonVersions
+            NodeToNodeV_14
+            ( NodeToNodeVersionData
+                { networkMagic = magic
+                , diffusionMode = InitiatorOnlyDiffusionMode
+                , peerSharing = PeerSharingDisabled
+                , query = False
+                }
+            )
+            (chainSyncToOuroboros . application) -- application
+        )
+        Nothing
+        addrAddress
+
+resolve :: String -> PortNumber -> IO AddrInfo
+resolve peerName peerPort = do
+    let hints =
+            defaultHints
+                { addrFlags = [AI_PASSIVE]
+                , addrSocketType = Stream
+                }
+    NE.head
+        <$> getAddrInfo (Just hints) (Just peerName) (Just $ show peerPort)
+
+-- TODO: provide sensible limits
+-- https://github.com/intersectmbo/ouroboros-network/issues/575
+maximumMiniProtocolLimits :: MiniProtocolLimits
+maximumMiniProtocolLimits =
+    MiniProtocolLimits
+        { maximumIngressQueue = maxBound
+        }
+
+chainSyncToOuroboros ::
+    -- | chainSync
+    ChainSyncApplication ->
+    OuroborosApplicationWithMinimalCtx
+        Mx.InitiatorMode
+        addr
+        LazyByteString
+        IO
+        ()
+        Void
+chainSyncToOuroboros chainSyncApp =
+    OuroborosApplication
+        { getOuroborosApplication =
+            [ MiniProtocol
+                { miniProtocolNum = MiniProtocolNum 2
+                , miniProtocolStart = StartOnDemand
+                , miniProtocolLimits = maximumMiniProtocolLimits
+                , miniProtocolRun = run
+                }
+            ]
+        }
+  where
+    run =
+        InitiatorProtocolOnly $
+            mkMiniProtocolCbFromPeer $
+                const
+                    ( nullTracer
+                    , codecChainSync
+                    , ChainSync.chainSyncClientPeer chainSyncApp
+                    )

--- a/lib/Cardano/Node/Client/Adversary/Daemon.hs
+++ b/lib/Cardano/Node/Client/Adversary/Daemon.hs
@@ -1,0 +1,167 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Cardano.Node.Client.Adversary.Daemon
+Description : cardano-adversary daemon — wires Server, signals, sockets
+License     : Apache-2.0
+
+Composes the cardano-adversary daemon's responsibilities:
+
+* the NDJSON control wire from
+  'Cardano.Node.Client.Adversary.Server',
+* signal handling so the container stops cleanly on @SIGTERM@,
+* the @ready@ hook,
+* the real @chain_sync_flap@ hook that drives
+  'repeatedAdversaryApplication'.
+
+The chain-points file is read on every @chain_sync_flap@ request
+so the daemon picks up new points written by @tracer-sidecar@
+without restarting.
+-}
+module Cardano.Node.Client.Adversary.Daemon (
+    DaemonConfig (..),
+    runDaemon,
+) where
+
+import Cardano.Node.Client.Adversary.Application (
+    Limit (..),
+    repeatedAdversaryApplication,
+ )
+import Cardano.Node.Client.Adversary.ChainPoints (
+    generatePoints,
+    parseChainPointSamples,
+ )
+import Cardano.Node.Client.Adversary.RandomSource (splitFromSeed)
+import Cardano.Node.Client.Adversary.Server (
+    ServerHooks (..),
+    runServer,
+ )
+import Cardano.Node.Client.Adversary.Types (
+    ChainSyncFlapArgs (..),
+    ChainSyncFlapDetails (..),
+    ChainSyncFlapFailure (..),
+    ReadyDetails (..),
+    Response (..),
+ )
+import Control.Concurrent (
+    MVar,
+    newEmptyMVar,
+    putMVar,
+    takeMVar,
+ )
+import Control.Concurrent.Async (race_)
+import Control.Exception (IOException, catch, try)
+import Control.Tracer (Tracer (..))
+import Data.List.NonEmpty qualified as NE
+import Data.Text (Text)
+import Data.Text qualified as T
+import Network.Socket (HostName, PortNumber)
+import Ouroboros.Network.Magic (NetworkMagic)
+import System.Directory (doesFileExist, removeFile)
+import System.IO (hPutStrLn, stderr)
+import System.IO.Error (isDoesNotExistError)
+import System.Posix.Signals (
+    Handler (Catch),
+    installHandler,
+    sigTERM,
+ )
+
+-- | Top-level daemon configuration.
+data DaemonConfig = DaemonConfig
+    { daemonControlSocket :: FilePath
+    -- ^ Path of the Unix control socket. The daemon binds here
+    -- and unlinks on shutdown.
+    , daemonProducerHosts :: [HostName]
+    -- ^ Producer hostnames the @chain_sync_flap@ endpoint targets.
+    , daemonProducerPort :: PortNumber
+    -- ^ N2N port for @chain_sync_flap@.
+    , daemonNetworkMagic :: NetworkMagic
+    -- ^ Network magic used in the N2N handshake.
+    , daemonChainPointsFile :: Maybe FilePath
+    -- ^ Path of the chain-points file produced by
+    -- @tracer-sidecar@. When 'Nothing', the @chain_sync_flap@
+    -- endpoint always returns 'CsffNoChainPointsFile'.
+    }
+
+{- | Run the daemon: install signal handler, start NDJSON server,
+block until SIGTERM. On SIGTERM unlink the socket and exit.
+-}
+runDaemon :: DaemonConfig -> IO ()
+runDaemon cfg = do
+    hPutStrLn stderr $
+        "cardano-adversary: starting on "
+            <> daemonControlSocket cfg
+    shutdown <- newEmptyMVar :: IO (MVar ())
+    _ <- installHandler sigTERM (Catch (putMVar shutdown ())) Nothing
+    let serverThread = runServer (daemonControlSocket cfg) (mkHooks cfg)
+        signalThread = takeMVar shutdown
+    race_ serverThread signalThread
+    cleanup cfg
+
+mkHooks :: DaemonConfig -> ServerHooks
+mkHooks cfg =
+    ServerHooks
+        { hooksReady = pure (readyDetails cfg)
+        , hooksChainSyncFlap = handleChainSyncFlap cfg
+        }
+
+readyDetails :: DaemonConfig -> ReadyDetails
+readyDetails cfg =
+    ReadyDetails
+        { readyOverall = True
+        , readyN2NHandshakeOk = False
+        , readyConfiguredHosts =
+            map (T.pack :: HostName -> Text) (daemonProducerHosts cfg)
+        }
+
+handleChainSyncFlap :: DaemonConfig -> ChainSyncFlapArgs -> IO Response
+handleChainSyncFlap cfg args
+    | null (daemonProducerHosts cfg) =
+        pure (RespChainSyncFlapFail CsffNoProducers)
+    | otherwise = case daemonChainPointsFile cfg of
+        Nothing -> pure (RespChainSyncFlapFail CsffNoChainPointsFile)
+        Just path -> do
+            present <- doesFileExist path
+            if not present
+                then pure (RespChainSyncFlapFail CsffNoChainPointsFile)
+                else runFlap cfg path args
+
+runFlap :: DaemonConfig -> FilePath -> ChainSyncFlapArgs -> IO Response
+runFlap cfg path args = do
+    contentE <- try @IOException (readFile path)
+    case contentE of
+        Left _ -> pure (RespChainSyncFlapFail CsffNoChainPointsFile)
+        Right content -> case parseChainPointSamples content of
+            Nothing -> pure (RespChainSyncFlapFail CsffNoChainPointsYet)
+            Just samples -> do
+                let gen = splitFromSeed (csfSeed args)
+                    points = generatePoints gen samples
+                    nConns = max 1 (fromIntegral (csfNConns args) :: Int)
+                    capped = NE.fromList (NE.take nConns points)
+                    limit = Limit (csfLimit args)
+                    tracer = Tracer (hPutStrLn stderr)
+                repeatedAdversaryApplication
+                    tracer
+                    nConns
+                    (daemonNetworkMagic cfg)
+                    (daemonProducerHosts cfg)
+                    (daemonProducerPort cfg)
+                    capped
+                    limit
+                pure $
+                    RespChainSyncFlapOk
+                        ChainSyncFlapDetails
+                            { csfdConnections = nConns
+                            , csfdPeerNames =
+                                map T.pack (daemonProducerHosts cfg)
+                            , csfdLimit = csfLimit args
+                            }
+
+cleanup :: DaemonConfig -> IO ()
+cleanup cfg = do
+    hPutStrLn stderr "cardano-adversary: SIGTERM received, shutting down"
+    removeFile (daemonControlSocket cfg)
+        `catch` \e ->
+            if isDoesNotExistError e
+                then pure ()
+                else ioError e

--- a/lib/Cardano/Node/Client/Adversary/RandomSource.hs
+++ b/lib/Cardano/Node/Client/Adversary/RandomSource.hs
@@ -1,0 +1,79 @@
+{- |
+Module      : Cardano.Node.Client.Adversary.RandomSource
+Description : Steerable random source for the cardano-adversary daemon
+License     : Apache-2.0
+
+Every adversarial decision draws from this typeclass so the
+Antithesis hypervisor can bias them. The default implementation
+shells out to the @antithesis_random@ CLI when present on
+@PATH@ and falls back to 'System.Random' for local development
+when it is not.
+
+A pure @splitFromSeed@ helper turns the per-request @seed@ field
+of an NDJSON request into a 'StdGen'; the daemon uses that to
+derive any further random values it needs without going back to
+@antithesis_random@.
+-}
+module Cardano.Node.Client.Adversary.RandomSource (
+    -- * Typeclass
+    RandomSource (..),
+
+    -- * Antithesis-aware default
+    Antithesis,
+    runAntithesis,
+
+    -- * Pure helpers
+    splitFromSeed,
+) where
+
+import Control.Exception (IOException, try)
+import Data.Word (Word64)
+import System.Directory (findExecutable)
+import System.Process (readProcess)
+import System.Random (StdGen, mkStdGen, randomIO)
+import Text.Read (readMaybe)
+
+-- | Source of randomness for adversarial decisions.
+class (Monad m) => RandomSource m where
+    -- | Draw an unsigned 64-bit integer.
+    randomU64 :: m Word64
+
+-- | Default implementation: hypervisor-aware in CI, host-RNG locally.
+newtype Antithesis a = Antithesis {runAntithesis :: IO a}
+    deriving newtype (Functor, Applicative, Monad)
+
+instance RandomSource Antithesis where
+    randomU64 = Antithesis $ do
+        -- The antithesis_random CLI is shipped by the
+        -- Antithesis runtime; if absent we are running
+        -- locally and must fall back to host entropy.
+        haveCli <- findExecutable "antithesis_random"
+        case haveCli of
+            Just _ -> readAntithesis
+            Nothing -> randomIO
+    {-# INLINE randomU64 #-}
+
+{- | Read one decimal uint64 from the @antithesis_random@ CLI.
+Falls back to 'randomIO' if the process fails to start or
+returns garbage. The fallback keeps PR-B-quality smoke testing
+working on a workstation where the runtime CLI is missing.
+-}
+readAntithesis :: IO Word64
+readAntithesis = do
+    result <- try @IOException (readProcess "antithesis_random" [] "")
+    case result of
+        Left _ -> randomIO
+        Right out -> maybe randomIO pure (readMaybe (trim out))
+  where
+    trim = dropWhile (== ' ') . reverse . dropWhile isWhitespace . reverse
+    isWhitespace c = c == ' ' || c == '\n' || c == '\r' || c == '\t'
+
+{- | Derive a deterministic 'StdGen' from the @seed@ field of a
+request. The daemon uses this to make a request reproducible
+given the seed it received: any further randomness the request
+needs is drawn from the returned generator, not from
+@antithesis_random@. This matches the tx-generator's discipline
+(single seed in → deterministic transaction body out).
+-}
+splitFromSeed :: Word64 -> StdGen
+splitFromSeed = mkStdGen . fromIntegral

--- a/lib/Cardano/Node/Client/Adversary/Server.hs
+++ b/lib/Cardano/Node/Client/Adversary/Server.hs
@@ -1,0 +1,172 @@
+{-# LANGUAGE LambdaCase #-}
+
+{- |
+Module      : Cardano.Node.Client.Adversary.Server
+Description : NDJSON Unix-socket control wire for cardano-adversary
+License     : Apache-2.0
+
+Listens on a Unix domain socket and serves the cardano-adversary
+daemon's control wire as newline-delimited JSON. One request per
+connection, single response, then EOF + close. Same idiom as
+'Cardano.Node.Client.TxGenerator.Server' and
+'Cardano.Node.Client.UTxOIndexer.Server'.
+
+Endpoints route through 'ServerHooks', wired up by the daemon. PR
+B ships only the @ready@ hook with real semantics; @chain_sync_flap@
+is reserved with a 'RespNotImplemented' stub. The hook signature is
+already shaped for the real handler so PR C only swaps the body.
+
+Wire schemas live in
+@specs/036-cardano-adversary/contracts/control-wire.md@.
+-}
+module Cardano.Node.Client.Adversary.Server (
+    -- * Server
+    runServer,
+
+    -- * Hook record
+    ServerHooks (..),
+    stubHooks,
+) where
+
+import Cardano.Node.Client.Adversary.Types (
+    ChainSyncFlapArgs,
+    ErrorReason (..),
+    ReadyDetails,
+    Request (..),
+    Response (..),
+ )
+import Control.Concurrent (forkIO)
+import Control.Exception (
+    bracket,
+    finally,
+    try,
+ )
+import Data.Aeson (
+    decodeStrict',
+    encode,
+ )
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Builder (toLazyByteString)
+import Data.ByteString.Builder qualified as Builder
+import Data.ByteString.Lazy qualified as LBS
+import Network.Socket (
+    Family (AF_UNIX),
+    SockAddr (SockAddrUnix),
+    Socket,
+    SocketType (Stream),
+    accept,
+    bind,
+    close,
+    listen,
+    socket,
+ )
+import Network.Socket.ByteString qualified as Net
+import System.Directory (removeFile)
+import System.IO.Error (isDoesNotExistError)
+
+{- | Per-endpoint entry points; the daemon wires these up.
+
+PR B ships a real 'hooksReady' and a stub 'hooksChainSyncFlap'.
+PR C swaps the stub for the real chain-sync misbehaviour body.
+-}
+data ServerHooks = ServerHooks
+    { hooksReady :: IO ReadyDetails
+    , hooksChainSyncFlap :: ChainSyncFlapArgs -> IO Response
+    }
+
+{- | Build a 'ServerHooks' whose 'hooksChainSyncFlap' arm returns
+'RespNotImplemented'. The 'ready' hook must still be supplied by
+the caller.
+-}
+stubHooks :: IO ReadyDetails -> ServerHooks
+stubHooks ready =
+    ServerHooks
+        { hooksReady = ready
+        , hooksChainSyncFlap = \_ -> pure RespNotImplemented
+        }
+
+{- | Run the NDJSON server on @socketPath@ until killed (by
+exception). Removes any stale socket file at @socketPath@ before
+binding.
+
+Each accepted connection is handled in its own thread: read one
+request line, write one response line, close. Many concurrent
+@ready@ connections are fine; misbehaviour endpoints are
+free to serialise themselves at the hook layer when their
+underlying state demands it.
+-}
+runServer :: FilePath -> ServerHooks -> IO ()
+runServer socketPath hooks =
+    bracket (openListenSocket socketPath) close $ \sock -> do
+        listen sock 16
+        let loop = do
+                (conn, _) <- accept sock
+                _ <- forkIO (handleConn hooks conn)
+                loop
+        loop
+
+openListenSocket :: FilePath -> IO Socket
+openListenSocket path = do
+    removeIfPresent path
+    sock <- socket AF_UNIX Stream 0
+    bind sock (SockAddrUnix path)
+    pure sock
+
+removeIfPresent :: FilePath -> IO ()
+removeIfPresent p = do
+    r <- try (removeFile p)
+    case r of
+        Right () -> pure ()
+        Left e
+            | isDoesNotExistError e -> pure ()
+            | otherwise -> ioError e
+
+handleConn :: ServerHooks -> Socket -> IO ()
+handleConn hooks conn = (`finally` close conn) $ do
+    line <- recvLine conn
+    case decodeStrict' line of
+        Nothing ->
+            sendLine conn (encode (RespError ErrMalformedJson))
+        Just req -> dispatch hooks conn req
+
+dispatch :: ServerHooks -> Socket -> Request -> IO ()
+dispatch hooks conn = \case
+    ReqReady -> do
+        rsp <- hooksReady hooks
+        sendLine conn (encode (RespReady rsp))
+    ReqChainSyncFlap body -> do
+        rsp <- hooksChainSyncFlap hooks body
+        sendLine conn (encode rsp)
+
+{- | Read up to and including the first @\n@. The line itself is
+returned without the trailing newline. Returns the empty
+bytestring on EOF before any newline.
+-}
+recvLine :: Socket -> IO ByteString
+recvLine s = go BS.empty
+  where
+    go acc = do
+        chunk <- Net.recv s 4096
+        if BS.null chunk
+            then pure (stripNewline acc)
+            else case BS.elemIndex 0x0A chunk of
+                Just i ->
+                    let (hd, _) = BS.splitAt i chunk
+                     in pure (stripNewline (acc <> hd))
+                Nothing -> go (acc <> chunk)
+
+stripNewline :: ByteString -> ByteString
+stripNewline bs
+    | not (BS.null bs) && BS.last bs == 0x0A =
+        BS.init bs
+    | otherwise = bs
+
+-- | Send one JSON line followed by @\n@.
+sendLine :: Socket -> LBS.ByteString -> IO ()
+sendLine s payload =
+    Net.sendAll s $
+        LBS.toStrict $
+            toLazyByteString $
+                Builder.lazyByteString payload
+                    <> Builder.char7 '\n'

--- a/lib/Cardano/Node/Client/Adversary/Types.hs
+++ b/lib/Cardano/Node/Client/Adversary/Types.hs
@@ -1,0 +1,243 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Cardano.Node.Client.Adversary.Types
+Description : Wire types for the cardano-adversary daemon
+License     : Apache-2.0
+
+Aeson-encoded request and response types matching the schemas in
+@specs/036-cardano-adversary/contracts/control-wire.md@. The
+schemas are the contract; these types are how the
+'Cardano.Node.Client.Adversary.Server' module produces and consumes
+them.
+-}
+module Cardano.Node.Client.Adversary.Types (
+    -- * Requests
+    Request (..),
+    ChainSyncFlapArgs (..),
+
+    -- * Responses
+    Response (..),
+    ReadyDetails (..),
+    ChainSyncFlapDetails (..),
+    ChainSyncFlapFailure (..),
+    ErrorReason (..),
+
+    -- * Wire helpers
+    errorReasonText,
+    chainSyncFlapFailureText,
+) where
+
+import Data.Aeson (
+    FromJSON (..),
+    ToJSON (..),
+    Value (Null),
+    object,
+    withObject,
+    (.:),
+    (.=),
+ )
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Aeson.Types qualified as Aeson
+import Data.Text (Text)
+import Data.Word (Word16, Word32, Word64)
+
+{- | Top-level request envelope. One JSON object per line, single
+request → single response.
+-}
+data Request
+    = -- | Readiness probe: @{"ready": null}@.
+      ReqReady
+    | -- | Chain-sync flap: @{"chain_sync_flap": {"seed":..,"limit":..,"n_conns":..}}@.
+      ReqChainSyncFlap !ChainSyncFlapArgs
+    deriving stock (Eq, Show)
+
+-- | Body of the @chain_sync_flap@ request.
+data ChainSyncFlapArgs = ChainSyncFlapArgs
+    { csfSeed :: !Word64
+    -- ^ Sole source of randomness for this request.
+    , csfLimit :: !Word32
+    -- ^ Maximum blocks pulled per connection before disconnecting.
+    , csfNConns :: !Word16
+    -- ^ Number of concurrent N2N connections per request.
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON ChainSyncFlapArgs where
+    parseJSON = withObject "chain_sync_flap" $ \o ->
+        ChainSyncFlapArgs
+            <$> o .: "seed"
+            <*> o .: "limit"
+            <*> o .: "n_conns"
+
+instance ToJSON ChainSyncFlapArgs where
+    toJSON (ChainSyncFlapArgs seed limit nConns) =
+        object
+            [ "seed" .= seed
+            , "limit" .= limit
+            , "n_conns" .= nConns
+            ]
+
+instance FromJSON Request where
+    parseJSON = withObject "request" $ \o ->
+        case KeyMap.toList o of
+            [("ready", Null)] -> pure ReqReady
+            [("chain_sync_flap", body)] ->
+                ReqChainSyncFlap <$> parseJSON body
+            [(other, _)] ->
+                fail $ "unknown request: " <> Key.toString other
+            _ ->
+                fail "request must have exactly one top-level key"
+
+-- | Top-level response envelope. One JSON object per line.
+data Response
+    = -- | Successful @ready@ response.
+      RespReady !ReadyDetails
+    | -- | Endpoint reserved but logic not yet implemented.
+      RespNotImplemented
+    | -- | Successful @chain_sync_flap@ response.
+      RespChainSyncFlapOk !ChainSyncFlapDetails
+    | -- | Structured @chain_sync_flap@ failure (e.g. no chain points yet).
+      RespChainSyncFlapFail !ChainSyncFlapFailure
+    | -- | Wire-level error (malformed json, unknown key).
+      RespError !ErrorReason
+    deriving stock (Eq, Show)
+
+{- | Diagnostic body returned by a successful @chain_sync_flap@
+invocation. Currently a coarse summary; richer per-connection
+detail can be added later without breaking the wire schema (only
+new fields appear).
+-}
+data ChainSyncFlapDetails = ChainSyncFlapDetails
+    { csfdConnections :: !Int
+    -- ^ Number of concurrent connections that were dispatched.
+    , csfdPeerNames :: ![Text]
+    -- ^ The producer hostnames the connections fanned across.
+    , csfdLimit :: !Word32
+    -- ^ The block-pull limit each connection was given.
+    }
+    deriving stock (Eq, Show)
+
+instance ToJSON ChainSyncFlapDetails where
+    toJSON (ChainSyncFlapDetails conns names limit) =
+        object
+            [ "ok" .= True
+            , "details"
+                .= object
+                    [ "connections" .= conns
+                    , "peerNames" .= names
+                    , "limit" .= limit
+                    ]
+            ]
+
+instance FromJSON ChainSyncFlapDetails where
+    parseJSON = withObject "chain_sync_flap response" $ \o -> do
+        details <- o .: "details"
+        conns <- details .: "connections"
+        names <- details .: "peerNames"
+        limit <- details .: "limit"
+        pure (ChainSyncFlapDetails conns names limit)
+
+{- | Documented failure reasons for the @chain_sync_flap@ endpoint.
+Distinct from the wire-level 'ErrorReason' set: these are valid
+responses whose @ok@ field is @False@.
+-}
+data ChainSyncFlapFailure
+    = -- | The @--chain-points-file@ has not been written yet (or is
+      -- empty), so no intersection point can be sampled.
+      CsffNoChainPointsYet
+    | -- | The configured @--chain-points-file@ does not exist on
+      -- disk at all.
+      CsffNoChainPointsFile
+    | -- | No producer hostnames were configured via @--producer-host@.
+      CsffNoProducers
+    deriving stock (Eq, Show)
+
+chainSyncFlapFailureText :: ChainSyncFlapFailure -> Text
+chainSyncFlapFailureText = \case
+    CsffNoChainPointsYet -> "no-chain-points-yet"
+    CsffNoChainPointsFile -> "no-chain-points-file"
+    CsffNoProducers -> "no-producers"
+
+-- | Structured details accompanying a 'RespReady' response.
+data ReadyDetails = ReadyDetails
+    { readyOverall :: !Bool
+    -- ^ True iff every readiness component below is satisfied.
+    , readyN2NHandshakeOk :: !Bool
+    -- ^ True iff the daemon has completed its N2N handshake to
+    -- at least one configured producer host. Always 'False' in
+    -- PR B because no N2N work happens yet.
+    , readyConfiguredHosts :: ![Text]
+    -- ^ Producer hostnames the daemon is configured to target.
+    }
+    deriving stock (Eq, Show)
+
+instance ToJSON ReadyDetails where
+    toJSON (ReadyDetails overall n2n hosts) =
+        object
+            [ "ready" .= overall
+            , "details"
+                .= object
+                    [ "n2nHandshakeOk" .= n2n
+                    , "configuredHosts" .= hosts
+                    ]
+            ]
+
+instance FromJSON ReadyDetails where
+    parseJSON = withObject "ready response" $ \o -> do
+        overall <- o .: "ready"
+        details <- o .: "details"
+        n2n <- details .: "n2nHandshakeOk"
+        hosts <- details .: "configuredHosts"
+        pure (ReadyDetails overall n2n hosts)
+
+-- | Structured error reasons emitted on the wire.
+data ErrorReason
+    = -- | The bytes received before @\\n@ were not valid JSON.
+      ErrMalformedJson
+    | -- | The top-level JSON key is not a known endpoint name.
+      ErrUnknownRequest
+    deriving stock (Eq, Show)
+
+errorReasonText :: ErrorReason -> Text
+errorReasonText = \case
+    ErrMalformedJson -> "malformed json"
+    ErrUnknownRequest -> "unknown request"
+
+instance ToJSON Response where
+    toJSON = \case
+        RespReady details -> toJSON details
+        RespNotImplemented ->
+            object ["ok" .= False, "reason" .= ("not-implemented" :: Text)]
+        RespChainSyncFlapOk details -> toJSON details
+        RespChainSyncFlapFail reason ->
+            object
+                [ "ok" .= False
+                , "reason" .= chainSyncFlapFailureText reason
+                ]
+        RespError reason ->
+            object ["error" .= errorReasonText reason]
+
+instance FromJSON Response where
+    parseJSON v =
+        Aeson.parseEither (parseJSON @ReadyDetails) v
+            & either (const tryNotImplemented) (pure . RespReady)
+      where
+        tryNotImplemented = withObject "response" go v
+        go o = case KeyMap.lookup "ok" o of
+            Just (Aeson.Bool False) ->
+                case KeyMap.lookup "reason" o of
+                    Just (Aeson.String "not-implemented") ->
+                        pure RespNotImplemented
+                    _ -> tryError o
+            _ -> tryError o
+        tryError o = case KeyMap.lookup "error" o of
+            Just (Aeson.String "malformed json") ->
+                pure (RespError ErrMalformedJson)
+            Just (Aeson.String "unknown request") ->
+                pure (RespError ErrUnknownRequest)
+            _ -> fail "unrecognised response shape"
+        (&) :: a -> (a -> b) -> b
+        x & f = f x

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -45,6 +45,7 @@ let
       text = ''
         test -e ${components.library}
         test -e ${components.sublibs."utxo-indexer-lib"}
+        test -e ${components.exes.cardano-adversary}
         test -e ${components.exes.utxo-indexer}
         echo "build outputs realized"
       '';

--- a/test/Cardano/Node/Client/Adversary/ChainPointsSpec.hs
+++ b/test/Cardano/Node/Client/Adversary/ChainPointsSpec.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Cardano.Node.Client.Adversary.ChainPointsSpec
+Description : Unit tests for ChainPoints parser + sampler
+License     : Apache-2.0
+-}
+module Cardano.Node.Client.Adversary.ChainPointsSpec (spec) where
+
+import Cardano.Node.Client.Adversary.ChainPoints (
+    generatePoints,
+    originPoint,
+    parseChainPointSamples,
+    readChainPoint,
+ )
+import Data.List.NonEmpty qualified as NE
+import Data.Maybe (isJust, isNothing)
+import System.Random (mkStdGen)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+
+spec :: Spec
+spec = do
+    describe "readChainPoint" $ do
+        it "parses 'origin'" $
+            readChainPoint "origin" `shouldBe` Just originPoint
+
+        it "rejects empty string" $
+            readChainPoint "" `shouldSatisfy` isNothing
+
+        it "rejects garbage with no '@'" $
+            readChainPoint "deadbeef" `shouldSatisfy` isNothing
+
+        it "rejects non-hex blockHash" $
+            readChainPoint "ZZZZ@1234" `shouldSatisfy` isNothing
+
+        it "rejects non-numeric slotNo" $
+            readChainPoint "deadbeef@notaslot" `shouldSatisfy` isNothing
+
+        it "accepts a well-formed hex@slot" $
+            readChainPoint "deadbeef@1234" `shouldSatisfy` isJust
+
+    describe "parseChainPointSamples" $ do
+        it "always prepends origin" $ case parseChainPointSamples "" of
+            Just neList -> NE.head neList `shouldBe` originPoint
+            Nothing -> error "empty file should still produce a sample list"
+
+        it "rejects a file containing one bad line" $
+            parseChainPointSamples "deadbeef@1\nZZZ@2"
+                `shouldSatisfy` isNothing
+
+        it "accepts multiple well-formed lines" $
+            case parseChainPointSamples "deadbeef@1\n4242@99" of
+                Just ne -> NE.length ne `shouldBe` 3 -- origin + two parsed
+                Nothing -> error "should parse"
+
+    describe "generatePoints" $ do
+        it "returns the sole point repeatedly when input is a singleton" $ do
+            let g = mkStdGen 1
+                ne = originPoint NE.:| []
+                stream = generatePoints g ne
+            NE.take 5 stream `shouldBe` replicate 5 originPoint
+
+        it "is deterministic given a fixed seed" $
+            case parseChainPointSamples "deadbeef@1\n4242@2" of
+                Nothing -> error "should parse"
+                Just ne -> do
+                    let g1 = mkStdGen 42
+                        g2 = mkStdGen 42
+                        s1 = NE.take 10 (generatePoints g1 ne)
+                        s2 = NE.take 10 (generatePoints g2 ne)
+                    s1 `shouldBe` s2
+
+        it "differs given different seeds (with high probability)" $
+            case parseChainPointSamples "deadbeef@1\n4242@2\n9999@3" of
+                Nothing -> error "should parse"
+                Just ne -> do
+                    let g1 = mkStdGen 1
+                        g2 = mkStdGen 2
+                        s1 = NE.take 50 (generatePoints g1 ne)
+                        s2 = NE.take 50 (generatePoints g2 ne)
+                    (s1 == s2) `shouldBe` False

--- a/test/Cardano/Node/Client/Adversary/ServerSpec.hs
+++ b/test/Cardano/Node/Client/Adversary/ServerSpec.hs
@@ -1,0 +1,183 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Cardano.Node.Client.Adversary.ServerSpec
+Description : Unit tests for the cardano-adversary wire types
+License     : Apache-2.0
+
+Pins the wire schemas in
+@specs/036-cardano-adversary/contracts/control-wire.md@. Pure JSON
+encode / decode round-trips — no Unix socket involvement at this
+level. PR C will add an end-to-end socket round-trip test alongside
+the first real misbehaviour endpoint.
+-}
+module Cardano.Node.Client.Adversary.ServerSpec (spec) where
+
+import Cardano.Node.Client.Adversary.Types (
+    ChainSyncFlapArgs (..),
+    ChainSyncFlapDetails (..),
+    ChainSyncFlapFailure (..),
+    ErrorReason (..),
+    ReadyDetails (..),
+    Request (..),
+    Response (..),
+ )
+import Data.Aeson (
+    decode,
+    eitherDecode,
+    encode,
+    object,
+    (.=),
+ )
+import Data.ByteString.Lazy (ByteString)
+import Data.Either (isLeft)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+
+spec :: Spec
+spec = do
+    describe "Request decoding" $ do
+        it "parses {\"ready\": null}" $
+            decodeReq "{\"ready\":null}"
+                `shouldBe` Right ReqReady
+
+        it "parses chain_sync_flap" $
+            decodeReq
+                "{\"chain_sync_flap\":{\"seed\":12345,\"limit\":100,\"n_conns\":1}}"
+                `shouldBe` Right
+                    ( ReqChainSyncFlap
+                        ChainSyncFlapArgs
+                            { csfSeed = 12345
+                            , csfLimit = 100
+                            , csfNConns = 1
+                            }
+                    )
+
+        it "rejects {} (no top-level key)" $
+            decodeReq "{}" `shouldSatisfy` isLeft'
+
+        it "rejects multi-key envelopes" $
+            decodeReq
+                "{\"ready\":null,\"chain_sync_flap\":null}"
+                `shouldSatisfy` isLeft'
+
+        it "rejects unknown top-level keys" $
+            decodeReq
+                "{\"surprise\":null}"
+                `shouldSatisfy` isLeft'
+
+    describe "Response encoding" $ do
+        it "RespReady embeds ReadyDetails as documented" $
+            encode
+                ( RespReady
+                    ReadyDetails
+                        { readyOverall = True
+                        , readyN2NHandshakeOk = False
+                        , readyConfiguredHosts = ["p1.example", "p2.example"]
+                        }
+                )
+                `shouldBe` encode
+                    ( object
+                        [ "ready" .= True
+                        , "details"
+                            .= object
+                                [ "n2nHandshakeOk" .= False
+                                , "configuredHosts"
+                                    .= ["p1.example" :: String, "p2.example"]
+                                ]
+                        ]
+                    )
+
+        it "RespNotImplemented uses the documented shape" $
+            encode RespNotImplemented
+                `shouldBe` encode
+                    ( object
+                        [ "ok" .= False
+                        , "reason" .= ("not-implemented" :: String)
+                        ]
+                    )
+
+        it "RespError ErrMalformedJson is {\"error\":\"malformed json\"}" $
+            encode (RespError ErrMalformedJson)
+                `shouldBe` encode
+                    ( object ["error" .= ("malformed json" :: String)]
+                    )
+
+        it "RespError ErrUnknownRequest is {\"error\":\"unknown request\"}" $
+            encode (RespError ErrUnknownRequest)
+                `shouldBe` encode
+                    ( object ["error" .= ("unknown request" :: String)]
+                    )
+
+        it "RespChainSyncFlapOk shape matches control-wire.md" $
+            encode
+                ( RespChainSyncFlapOk
+                    ChainSyncFlapDetails
+                        { csfdConnections = 2
+                        , csfdPeerNames = ["p1.example", "p2.example"]
+                        , csfdLimit = 100
+                        }
+                )
+                `shouldBe` encode
+                    ( object
+                        [ "ok" .= True
+                        , "details"
+                            .= object
+                                [ "connections" .= (2 :: Int)
+                                , "peerNames"
+                                    .= ["p1.example" :: String, "p2.example"]
+                                , "limit" .= (100 :: Int)
+                                ]
+                        ]
+                    )
+
+        it "RespChainSyncFlapFail no-chain-points-yet" $
+            encode (RespChainSyncFlapFail CsffNoChainPointsYet)
+                `shouldBe` encode
+                    ( object
+                        [ "ok" .= False
+                        , "reason" .= ("no-chain-points-yet" :: String)
+                        ]
+                    )
+
+        it "RespChainSyncFlapFail no-chain-points-file" $
+            encode (RespChainSyncFlapFail CsffNoChainPointsFile)
+                `shouldBe` encode
+                    ( object
+                        [ "ok" .= False
+                        , "reason" .= ("no-chain-points-file" :: String)
+                        ]
+                    )
+
+        it "RespChainSyncFlapFail no-producers" $
+            encode (RespChainSyncFlapFail CsffNoProducers)
+                `shouldBe` encode
+                    ( object
+                        [ "ok" .= False
+                        , "reason" .= ("no-producers" :: String)
+                        ]
+                    )
+
+    describe "Round-trip" $ do
+        it "ChainSyncFlapArgs encodes and decodes back to itself" $ do
+            let body =
+                    ChainSyncFlapArgs
+                        { csfSeed = maxBound
+                        , csfLimit = 12345
+                        , csfNConns = 7
+                        }
+            decode (encode body) `shouldBe` Just body
+
+        it "ReadyDetails encodes and decodes back to itself" $ do
+            let r =
+                    ReadyDetails
+                        { readyOverall = False
+                        , readyN2NHandshakeOk = False
+                        , readyConfiguredHosts = ["a", "b", "c"]
+                        }
+            decode (encode r) `shouldBe` Just r
+
+decodeReq :: ByteString -> Either String Request
+decodeReq = eitherDecode
+
+isLeft' :: Either String a -> Bool
+isLeft' = isLeft

--- a/test/unit-main.hs
+++ b/test/unit-main.hs
@@ -3,6 +3,8 @@ module Main (main) where
 import Test.Hspec (hspec)
 
 import Cardano.Node.Client.AddressSpec qualified as AddressSpec
+import Cardano.Node.Client.Adversary.ChainPointsSpec qualified as AdversaryChainPointsSpec
+import Cardano.Node.Client.Adversary.ServerSpec qualified as AdversaryServerSpec
 import Cardano.Node.Client.BlockIndexer.HandlerSpec qualified as BlockIndexerHandlerSpec
 import Cardano.Node.Client.N2C.ProbeSpec qualified as N2CProbeSpec
 import Cardano.Node.Client.N2C.TraceSpec qualified as N2CTraceSpec
@@ -23,6 +25,8 @@ import Data.List.SampleFibonacciSpec qualified as SampleFibonacciSpec
 
 main :: IO ()
 main = hspec $ do
+    AdversaryChainPointsSpec.spec
+    AdversaryServerSpec.spec
     BlockIndexerHandlerSpec.spec
     AddressSpec.spec
     SampleFibonacciSpec.spec


### PR DESCRIPTION
## What

Lands the node-to-node (N2N) `Adversary` module on `main` from the feature branches (`037-tx-gen-indexer-fresh` / `feat/chain-sync-flap-impl` / `feat/chain-sync-thrash-spec`, where it was identical), ported onto current main (~158 commits forward) and bumped to support **protocol version 12 / Dijkstra**.

- `lib/Cardano/Node/Client/Adversary/` — Application, ChainPoints, ChainSync/{Codec,Connection}, Daemon, RandomSource, Server, Types
- `app/cardano-adversary/Main.hs` executable
- `test/Cardano/Node/Client/Adversary/` — ChainPointsSpec, ServerSpec
- cabal/flake dep bump to the cardano-node 11.0.1 line (consensus 3.x, ouroboros-network 1.1.x, `cardano-ledger-dijkstra`)

## Verification

- `nix build .#checks.{build,unit,lint}` green (unit: 165 examples, 0 failures); adversary specs pass.
- PV12 reachable (DijkstraEra in closure); N2N versions V_14/V_15.

## Why

Centralizes the N2N adversary so downstream consumers stop forking it. `cardano-foundation/cardano-node-antithesis` currently maintains a duplicate and had to hand-bump it for PV12 — it will depend on this instead (cardano-node-antithesis#165).

Supersedes the stale Dijkstra-support PR #19.

Closes #178