### PR TITLE
docs: align README and docs site with current code; add agent layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,49 +1,52 @@
-# cardano-node-clients Development Guidelines
+# Repository Agent Guide
 
-Auto-generated from feature plans. Last updated: 2026-05-10
+## What this repo is
 
-## Active Technologies
+`cardano-node-clients` is a Haskell package (Cabal multi-component,
+built with Nix/haskell.nix) of channel-driven clients for the Cardano
+node Ouroboros mini-protocols. It provides N2C LocalStateQuery,
+LocalTxSubmission, and ChainSync clients over the node's Unix socket,
+high-level `Provider`/`Submitter` record-of-functions interfaces, a
+reconnect supervisor with an LSQ tip probe, a layered indexer stack
+(generic `block-indexer`, address-keyed UTxO indexer, multi-tenant
+tx-history indexer), and an N2N adversary for fault-injection testing.
+It ships two executables: the `utxo-indexer` daemon and the
+`cardano-adversary` daemon. Transaction building/balancing/diffing
+lives in a separate repo,
+[cardano-tx-tools](https://github.com/lambdasistemi/cardano-tx-tools).
 
-- Haskell, GHC2021
-- Cabal multi-component package
-- Nix development environment
-- Cardano ledger and Plutus libraries
+## How to work here
 
-## Project Structure
+All commands run inside the Nix dev shell; `just` recipes pin `-O0`.
 
-```text
-lib/              # main cardano-node-clients library
-lib-utxo-indexer/ # UTxO indexer sublibrary
-e2e-test/         # devnet helper library
-app/              # executables
-test/             # unit and e2e test modules
-specs/            # Spec Kit feature artifacts
-```
+- Build: `nix develop -c just build` (library + both executables)
+- Unit tests: `nix develop -c just unit`
+- E2E tests (spawns a real devnet `cardano-node`): `nix develop -c just e2e`
+- Format: `nix develop -c just format` (fourmolu + cabal-fmt)
+- Lint: `nix develop -c just hlint`
+- Full gate: `nix develop -c just ci` (build + unit + format check + lint)
+- Docs preview: `nix develop -c just serve-docs`
+- Run an executable: `nix run .#utxo-indexer` / `nix run .#cardano-adversary`
 
-## Commands
+GHC is pinned to `ghc9123` by the flake; the package is `GHC2021`.
+Public modules must keep Haddock on exports and Apache-2.0 module
+headers. Do not break existing public module compatibility without a
+spec.
 
-```bash
-just build
-just unit
-just e2e
-just format
-just hlint
-just ci
-```
+## Skills
 
-Use focused Cabal commands with `-O0` while iterating.
+Activatable procedures live under `skills/`. Load the one whose
+description matches your task:
 
-## Code Style
+- `skills/cardano-node-clients-guide/` — repository map, exact
+  build/test/run commands, where each feature lives in the source,
+  verified CLI/library usage, and where answers to common questions
+  live.
 
-- Follow the repo's Fourmolu formatting.
-- Keep component dependencies minimal and explicit.
-- Preserve existing public module compatibility unless a spec says
-  otherwise.
+## Documentation
 
-## Recent Changes
-
-- `041-extract-txbuild`: planned extraction of TxBuild and Balance into
-  a non-network transaction-building component.
-
-<!-- MANUAL ADDITIONS START -->
-<!-- MANUAL ADDITIONS END -->
+- Human docs: <https://lambdasistemi.github.io/cardano-node-clients/>
+  (sources under `docs/`, built with mkdocs).
+- README.md — overview, install, quickstart, usage.
+- `app/utxo-indexer/README.md` — the indexer daemon's CLI and wire.
+- `specs/` — Spec Kit feature artifacts (one dir per feature).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,39 +1,9 @@
-# cardano-node-clients-tx-builder Development Guidelines
+# CLAUDE.md
 
-Auto-generated from all feature plans. Last updated: 2026-05-12
+This project's agent guidance lives in [AGENTS.md](AGENTS.md) — what the
+repo is, how to build/test/run it, and the skills under `skills/`.
+Start there.
 
-## Active Technologies
-- Haskell, GHC 9.6+ (matches repo). (034-cardano-tx-generator)
-- two files in `--state-dir` (`master.seed` 32 bytes, (034-cardano-tx-generator)
-- Haskell, GHC 9.6+ (matches repo) + `cardano-ledger-conway`, `ouroboros-network`, internal `chain-follower` `Follower` abstraction, internal `N2C.Reconnect.runReconnectLoop` (PR #105) (037-tx-gen-indexer-fresh)
-- in-memory `TVar ReadyState` (no persistence change) (037-tx-gen-indexer-fresh)
-- Haskell, GHC 9.12.2 (matches existing flake-pinned toolchain). + `cardano-ledger-conway` (1.21), `cardano-ledger-babbage` (1.13, supplies `totalCollateralTxBodyL` / `collateralReturnTxBodyL`), `cardano-ledger-alonzo` (supplies `ppCollateralPercentageL`), `cardano-ledger-api` (`estimateMinFeeTx`). All are already in the closure. (040-txbuild-conway-collateral)
-- N/A — pure tx assembly; no persistence change. (040-txbuild-conway-collateral)
-- Haskell, GHC pinned by `cabal.project` (current + `cardano-ledger-conway`, `cardano-ledger-api`, (042-conway-stake-treasury)
-- N/A. DSL is pure; produces a `ConwayTx` for submission. (042-conway-stake-treasury)
-
-- Haskell (GHC 9.6+, same as cardano-node-clients) + cardano-ledger-api, cardano-ledger-conway, plutus-ledger-api, plutus-tx (ToData/FromData) (003-tx-builder-dsl)
-
-## Project Structure
-
-```text
-src/
-tests/
-```
-
-## Commands
-
-# Add commands for Haskell (GHC 9.6+, same as cardano-node-clients)
-
-## Code Style
-
-Haskell (GHC 9.6+, same as cardano-node-clients): Follow standard conventions
-
-## Recent Changes
-- 042-conway-stake-treasury: Added Haskell, GHC pinned by `cabal.project` (current + `cardano-ledger-conway`, `cardano-ledger-api`,
-- 040-txbuild-conway-collateral: Added Haskell, GHC 9.12.2 (matches existing flake-pinned toolchain). + `cardano-ledger-conway` (1.21), `cardano-ledger-babbage` (1.13, supplies `totalCollateralTxBodyL` / `collateralReturnTxBodyL`), `cardano-ledger-alonzo` (supplies `ppCollateralPercentageL`), `cardano-ledger-api` (`estimateMinFeeTx`). All are already in the closure.
-- 037-tx-gen-indexer-fresh: Added Haskell, GHC 9.6+ (matches repo) + `cardano-ledger-conway`, `ouroboros-network`, internal `chain-follower` `Follower` abstraction, internal `N2C.Reconnect.runReconnectLoop` (PR #105)
-
-
-<!-- MANUAL ADDITIONS START -->
-<!-- MANUAL ADDITIONS END -->
+For activatable procedures, load
+`skills/cardano-node-clients-guide/SKILL.md` (repository map, exact
+commands, code navigation, verified usage, and where answers live).

--- a/README.md
+++ b/README.md
@@ -1,59 +1,187 @@
 # cardano-node-clients
 
-Channel-driven Haskell clients for Cardano node Ouroboros mini-protocols (N2C + N2N).
+Haskell clients for Cardano node mini-protocols (N2C + N2N).
 
-**[Documentation](https://paolino.github.io/cardano-node-clients/)**
+## What is this
 
-## Features
+`cardano-node-clients` is a Haskell library plus two daemons for talking
+to a Cardano node over the Ouroboros mini-protocols. The library is
+channel-driven: callers enqueue requests into STM channels and the
+protocol clients drain them against the node, decoupling application
+code from the protocol state machines.
 
-- **Provider** -- query UTxOs and protocol parameters
-- **Submitter** -- submit signed transactions
-- **N2C** -- LocalStateQuery + LocalTxSubmission over Unix socket
-- **block-indexer** -- generic chain-follower rollback/readiness
-  helpers for building indexers without depending on UTxO internals
-- **UTxOIndexer** -- address-keyed UTxO indexer fed by a chain-follower,
-  exposing NDJSON snapshot/await over a Unix socket
+On the Node-to-Client (N2C) side it provides LocalStateQuery,
+LocalTxSubmission, and ChainSync clients over the node's Unix socket,
+wrapped in high-level `Provider` (ledger queries: UTxOs, protocol
+parameters, stake rewards, governance state, treasury, slot/time
+conversion) and `Submitter` (signed Conway transaction submission)
+record-of-functions interfaces. A reconnect supervisor with an LSQ
+tip probe keeps long-running chain followers alive across node
+restarts.
+
+On top of the ChainSync client sit three indexer components: a generic
+`block-indexer` engine (rollback log, handler composition, readiness),
+an address-keyed UTxO indexer (in-memory or RocksDB-backed, shipped
+as the `utxo-indexer` daemon with an NDJSON Unix-socket read API), and
+a multi-tenant `tx-history-indexer` that records transaction summaries
+with direction. On the Node-to-Node (N2N) side, the `cardano-adversary`
+daemon opens adversarial ChainSync connections against block producers
+for fault-injection testing (e.g. under Antithesis).
 
 Transaction building, balancing, blueprint-aware diffing, and the
 `tx-diff` / `cardano-tx-generator` executables live in
 [lambdasistemi/cardano-tx-tools](https://github.com/lambdasistemi/cardano-tx-tools).
 
-## Executables
+## Architecture
 
-- [`utxo-indexer`](app/utxo-indexer/) -- address->UTxO indexer daemon
-  (in-memory or RocksDB-backed) exposing NDJSON snapshot/await over a
-  Unix socket. In-process auto-reconnect on upstream-relay disconnect
-  with full-jitter exponential backoff via `Control.Retry`, gated by
-  an LSQ tip probe (issue
-  [#97](https://github.com/lambdasistemi/cardano-node-clients/issues/97)).
+```mermaid
+flowchart LR
+    subgraph exes["Executables"]
+        UI["utxo-indexer<br/>NDJSON daemon"]
+        CA["cardano-adversary<br/>NDJSON daemon"]
+    end
 
-## Library Components
+    subgraph mainlib["Library cardano-node-clients"]
+        PROV["Provider / Submitter"]
+        CONN["N2C Connection<br/>LSQ + LTxS + ChainSync"]
+        REC["Reconnect supervisor<br/>+ LSQ tip probe"]
+        ADV["Adversary<br/>N2N ChainSync"]
+    end
 
-- `cardano-node-clients` contains the node-client APIs and bundled
-  UTxO indexer follower/daemon surface.
-- `cardano-node-clients:block-indexer` contains only generic
-  rollback-log, handler-composition, and readiness helpers. It does
-  not depend on UTxO columns, `InterestSet`, or `UtxoOp`.
-- `cardano-node-clients:utxo-indexer-lib` contains the concrete UTxO
-  storage columns, `liveUtxoHandler`, and the source-compatible
-  `InterestSet` / `filterBlockOps` exports re-exported by the follower.
+    subgraph sublibs["Sublibraries"]
+        BI["block-indexer<br/>engine, handlers, readiness"]
+        UIL["utxo-indexer-lib<br/>RocksDB columns"]
+        THI["tx-history-indexer-lib<br/>multi-tenant history"]
+    end
 
-## Testing
+    NODE["cardano-node"]
 
-- Unit tests cover the N2C probe and trace surface, the UTxO indexer
-  (daemon, indexer, persistence, server, types), address parsing, and
-  validity helpers.
-- E2E tests run against a real devnet for provider, chainsync,
-  chain-population, governance smoke, `balanceFeeLoop`, multi-asset
-  change, a submitted `TxBuild` transaction, and the UTxO indexer
-  (including a relay-restart reconnect scenario).
+    UI --> REC
+    UI --> UIL
+    CA --> ADV
+    PROV --> CONN
+    REC --> CONN
+    CONN -- "Unix socket (N2C)" --> NODE
+    ADV -- "TCP (N2N)" --> NODE
+    UIL --> BI
+    THI --> BI
+```
 
-## Build
+## Install
+
+Released `utxo-indexer` builds for x86_64 Linux (AppImage, deb, rpm)
+are attached to the
+[GitHub releases](https://github.com/lambdasistemi/cardano-node-clients/releases).
+
+With Nix, run the executables straight from the flake:
 
 ```bash
-nix develop -c just build
-nix develop -c just ci       # format + lint + build
+nix run github:lambdasistemi/cardano-node-clients              # utxo-indexer
+nix run github:lambdasistemi/cardano-node-clients#cardano-adversary
 ```
+
+## Quickstart
+
+Index a node's UTxO set and query it over NDJSON:
+
+```bash
+utxo-indexer \
+  --relay-socket /run/cardano-node/node.socket \
+  --listen /tmp/utxo-indexer.sock \
+  --network-magic 764824073 \
+  --byron-epoch-slots 21600 &
+
+printf '{"ready": null}\n' | nc -U /tmp/utxo-indexer.sock
+```
+
+`--network-magic` / `--byron-epoch-slots` are `764824073` / `21600` on
+mainnet, `1` / `21600` on preprod, `2` / `21600` on preview.
+
+## Usage
+
+### Executables
+
+- [`utxo-indexer`](app/utxo-indexer/) — address→UTxO indexer daemon
+  (in-memory or RocksDB-backed via `--db-path`) exposing `ready`,
+  `utxos_at`, and `await` over a Unix-socket NDJSON wire. Survives
+  upstream-relay restarts via an in-process reconnect supervisor with
+  full-jitter exponential backoff, gated by an LSQ tip probe (issue
+  [#97](https://github.com/lambdasistemi/cardano-node-clients/issues/97)).
+- `cardano-adversary` — N2N adversary daemon for fault-injection
+  testing. Serves `ready` and `chain_sync_flap` (open N concurrent
+  adversarial ChainSync connections against the configured producers,
+  pull a bounded number of blocks from randomised chain points, then
+  disconnect) over a Unix-socket NDJSON control wire.
+
+### Library
+
+```haskell
+import Cardano.Node.Client.N2C.Connection
+import Cardano.Node.Client.N2C.Provider
+import Cardano.Node.Client.N2C.Submitter
+import Control.Concurrent.Async (async)
+import Ouroboros.Network.Magic (NetworkMagic (..))
+
+main :: IO ()
+main = do
+    lsqCh  <- newLSQChannel 16
+    ltxsCh <- newLTxSChannel 16
+    -- connect in background
+    _ <- async $
+        runNodeClient
+            (NetworkMagic 764824073)  -- mainnet
+            "/run/cardano-node/node.socket"
+            lsqCh
+            ltxsCh
+    let provider  = mkN2CProvider lsqCh
+        submitter = mkN2CSubmitter ltxsCh
+    -- use provider / submitter ...
+    pure ()
+```
+
+### Library components
+
+- `cardano-node-clients` — N2C clients, `Provider` / `Submitter`,
+  reconnect supervisor, the N2N adversary modules, and the bundled
+  UTxO indexer follower/daemon/server surface.
+- `cardano-node-clients:block-indexer` — generic rollback-log,
+  handler-composition, and readiness helpers. No dependency on UTxO
+  columns or the node transport.
+- `cardano-node-clients:utxo-indexer-lib` — concrete UTxO storage
+  columns over `kv-transactions` (RocksDB or in-memory) and the
+  indexer state machine.
+- `cardano-node-clients:tx-history-indexer-lib` — multi-tenant
+  transaction-history storage with direction-aware summaries.
+- `cardano-node-clients:devnet` — `withCardanoNode` /
+  `withRestartableCardanoNode` helpers that run a real `cardano-node`
+  subprocess for E2E tests.
+
+## Documentation
+
+Full documentation:
+**<https://lambdasistemi.github.io/cardano-node-clients/>**
+
+For AI agents, start at [AGENTS.md](AGENTS.md).
+
+## Development
+
+```bash
+nix develop -c just build   # compile library + executables (-O0)
+nix develop -c just unit    # unit tests
+nix develop -c just e2e     # E2E tests against a real devnet node
+nix develop -c just ci      # build + unit + format/lint checks
+nix develop -c just serve-docs  # local mkdocs preview
+```
+
+Unit tests cover the N2C probe and trace surface, the UTxO indexer
+(block extraction, daemon, follower, indexer, persistence, provider,
+server, shared follower, types, mainnet smoke), the tx-history
+indexer (indexing and history rollback), the block-indexer handler,
+the adversary chain-points parser and server, address parsing, and
+validity helpers. E2E tests run a real devnet node for ChainSync,
+horizon-aware validity, provider queries, the full N2C session, the
+UTxO indexer relay-restart reconnect scenario, and the issue #97
+reproduction.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,36 +2,82 @@
 
 ## Design
 
-The library separates **protocol-agnostic interfaces** from
-**protocol-specific implementations**.
+The package separates **protocol-agnostic interfaces** from
+**protocol-specific implementations**, and layers indexers on top of a
+single ChainSync subscription.
 
-```
-cardano-node-clients:tx-build
-├── Ledger         -- ConwayTx alias
-├── Balance        -- transaction balancing
-└── TxBuild        -- transaction builder DSL
+```mermaid
+flowchart TB
+    subgraph main["cardano-node-clients (main library)"]
+        TYPES["Types — Block, BlockPoint"]
+        LEDGER["Ledger — ConwayTx alias"]
+        PROVIDER["Provider — query record-of-functions"]
+        SUBMITTER["Submitter — submit record-of-functions"]
+        VALIDITY["Validity — horizon-aware bounds"]
+        ADDRESS["Address — credential helpers"]
+        subgraph n2c["N2C"]
+            N2CTYPES["Types — LSQChannel, LTxSChannel"]
+            CODECS["Codecs — codec config + ChainSync codec"]
+            CONNECTION["Connection — runNodeClient(Full)"]
+            LSQ["LocalStateQuery client"]
+            LTXS["LocalTxSubmission client"]
+            CHAINSYNC["ChainSync client"]
+            PROBE["Probe — LSQ tip readiness"]
+            RECONNECT["Reconnect — retry supervisor"]
+            TRACE["Trace — N2CEvent"]
+            N2CPROVIDER["N2C.Provider — mkN2CProvider"]
+            N2CSUBMITTER["N2C.Submitter — mkN2CSubmitter"]
+        end
+        subgraph adv["Adversary (N2N)"]
+            ADVDAEMON["Daemon + Server"]
+            ADVAPP["Application — chain_sync_flap"]
+            ADVCONN["ChainSync.Connection (N2N)"]
+        end
+        UTXODAEMON["UTxOIndexer.Daemon / Follower / Server"]
+    end
 
-cardano-node-clients
-├── Types          -- Block, BlockPoint aliases
-├── Provider       -- query interface (record-of-functions)
-├── Submitter      -- submit interface (record-of-functions)
-├── Balance        -- re-export from tx-build
-├── TxBuild        -- re-export from tx-build
-└── N2C
-    ├── Types              -- LSQChannel, LTxSChannel
-    ├── Codecs             -- N2C codec config
-    ├── Connection         -- multiplexed Unix socket
-    ├── LocalStateQuery    -- LSQ protocol client
-    ├── LocalTxSubmission  -- LTxS protocol client
-    ├── Provider           -- N2C-backed Provider
-    └── Submitter          -- N2C-backed Submitter
+    subgraph bi["block-indexer"]
+        ENGINE["Engine — rollback-log engine"]
+        HANDLER["Handler — composable handlers"]
+        READINESS["Readiness — lag + ready decisions"]
+    end
+
+    subgraph uil["utxo-indexer-lib"]
+        UCOLUMNS["Columns — TxIn/AddressIndex/Rollback"]
+        UINDEXER["Indexer — apply/rollback/await"]
+    end
+
+    subgraph thi["tx-history-indexer-lib"]
+        TCOLUMNS["Columns — composite key codec"]
+        TINDEXER["Indexer — multi-tenant history"]
+    end
+
+    PROVIDER --> N2CPROVIDER
+    SUBMITTER --> N2CSUBMITTER
+    N2CPROVIDER --> LSQ
+    N2CSUBMITTER --> LTXS
+    PROVIDER --> VALIDITY
+    LSQ --> CONNECTION
+    LTXS --> CONNECTION
+    CHAINSYNC --> CODECS
+    RECONNECT --> PROBE
+    RECONNECT --> CHAINSYNC
+    UTXODAEMON --> RECONNECT
+    UTXODAEMON --> UINDEXER
+    UINDEXER --> UCOLUMNS
+    UINDEXER --> ENGINE
+    TINDEXER --> ENGINE
+    ENGINE --> HANDLER
+    ADVDAEMON --> ADVAPP
+    ADVAPP --> ADVCONN
 ```
 
 ## Channel-driven protocol clients
 
-Each mini-protocol client is driven by an STM channel (`TBQueue`).
-Callers enqueue a request and block on a `TMVar` for the result.
-This decouples request submission from the Ouroboros protocol loop.
+Each N2C mini-protocol client is driven by an STM channel
+(`TBQueue`). Callers enqueue a request and block on a `TMVar` for the
+result. This decouples request submission from the Ouroboros protocol
+loop.
 
 ```
                   ┌───────────────┐
@@ -41,51 +87,68 @@ This decouples request submission from the Ouroboros protocol loop.
 ```
 
 The **LocalStateQuery** client batches queries: it waits for the
-first query, acquires the volatile tip, drains the queue in a
-single session, then releases and loops.
+first query, acquires the volatile tip, drains the queue in a single
+acquired session, then releases and loops. Explicit acquired sessions
+(`withAcquired`) begin from their own acquire so a group of related
+reads share one ledger snapshot.
 
 ## N2C connection
 
 `runNodeClient` opens a Unix socket to the Cardano node and
 multiplexes two mini-protocols:
 
-- **MiniProtocol 6** -- LocalTxSubmission
-- **MiniProtocol 7** -- LocalStateQuery
+- **MiniProtocol 6** — LocalTxSubmission
+- **MiniProtocol 7** — LocalStateQuery
 
-The connection blocks until closed. Run it in a background thread
-with `async`.
+`runNodeClientFull` adds **MiniProtocol 5** — ChainSync — on the same
+mux session, for processes (like the bundled indexer or the
+`cardano-tx-generator` daemon) that need more than one of
+{ChainSync, LSQ, LTxS} over a single physical connection.
 
-## Transaction balancing
+Both helpers negotiate `NodeToClientV_23` and block until the
+connection is closed — run them in a background thread with `async`.
 
-`Cardano.Node.Client.Balance` is implemented by the public
-`cardano-node-clients:tx-build` sublibrary and re-exported by the main
-library for compatibility. It has no node-communication, indexer,
-daemon, socket, or RocksDB dependency.
+## Reconnect supervisor
 
-`balanceTx` iteratively computes the exact ledger fee with
-`getMinFeeTx`, then adds VKey witness padding for the unsigned
-transaction before adding fee-paying inputs and a change output.
-It converges in at most 10 rounds. Only ADA-only inputs are
-supported; multi-asset coin selection is out of scope.
+Long-running chain followers must survive upstream-relay restarts.
+`Cardano.Node.Client.N2C.Reconnect` wraps a single ChainSync run in an
+indefinitely-retrying supervisor over `Control.Retry` with full-jitter
+exponential backoff (defaults 1 s → 30 s, healthy-run reset at 30 s).
 
-## Transaction builder DSL
+Before the first attempt — and because `cardano-node` binds its socket
+*before* its ChainDB finishes loading — the supervisor calls
+`Cardano.Node.Client.N2C.Probe.waitForNodeReady`, which opens an
+LSQ-only connection and polls the tip until it is non-Origin. Only then
+is ChainSync attached, avoiding the `intersectNotFound` trap against a
+node still replaying its chain.
 
-`Cardano.Node.Client.TxBuild` sits one layer above raw transaction
-assembly. It lives in `cardano-node-clients:tx-build`, and the main
-library re-exports the same module for existing import paths. The
-builder accepts a caller-supplied script evaluator, so the extracted
-component does not need Provider, N2C, ChainSync, indexer, devnet, or
-RocksDB dependencies.
+## Indexers
 
-Current implemented pieces:
+The indexer stack is split so consumers depend only on what they need:
 
-- fixed transaction instructions for spends, outputs, collateral,
-  minting, required signers, and attached scripts
-- `Peek` for fixpoint values derived from the assembled transaction
-- `Ctx` for pluggable domain queries resolved by `Interpret` or
-  `InterpretIO`
-- `Valid` for opt-in post-convergence transaction checks
-- reference inputs and explicit validity intervals in the assembled
-  `TxBody`
-- `draft` and `draftWith` for pure assembly
-- `build` for script evaluation, `ExUnits` patching, and balancing
+- `block-indexer` owns domain-neutral concerns: the rollback-log
+  watermark, restoration/following phase threading, rollback pruning,
+  replay/conflict classification, and readiness/lag math. It has no
+  dependency on UTxO columns or the node transport.
+- `utxo-indexer-lib` defines the concrete `kv-transactions` columns
+  (a `TxIn → Address` primary table, an `AddressIndex` secondary index
+  for prefix snapshot queries, and a slot-keyed `RollbackCol` inverse
+  log) and the apply/rollback/await state machine.
+- `tx-history-indexer-lib` records direction-aware transaction
+  summaries under a composite `(tenant, scope, slot, txid, role)` key
+  whose on-disk byte form preserves that ordering.
+
+The bundled `utxo-indexer` daemon glues the chain-sync follower (over
+the reconnect supervisor) to an `IndexerHandle` and the NDJSON server.
+The follower is exposed as a standalone `withChainSyncFollower`
+resource so downstream consumers can run it against a caller-owned
+handle without the socket server.
+
+## Transaction building
+
+Transaction building, balancing, blueprint-aware diffing, and the
+`tx-diff` / `cardano-tx-generator` executables were moved out of this
+repository to
+[lambdasistemi/cardano-tx-tools](https://github.com/lambdasistemi/cardano-tx-tools).
+The E2E tests here depend on `cardano-tx-tools` for the balancing and
+tx-build helpers they exercise.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,64 +1,55 @@
 # cardano-node-clients
 
-Channel-driven Haskell clients for Cardano node Ouroboros mini-protocols.
+Channel-driven Haskell clients for Cardano node Ouroboros
+mini-protocols (N2C + N2N).
 
 ## Overview
 
-This library provides high-level interfaces for communicating with a
-Cardano node:
+This package provides high-level interfaces for communicating with a
+Cardano node, plus indexers built on top of them:
 
-- **Provider** -- query UTxOs and protocol parameters
-- **Submitter** -- submit signed transactions
-- **Balance** -- exact-fee balancing and fee-dependent output convergence
-- **TxBuild** -- Conway-era transaction builder DSL with `Peek` fixpoints and pluggable `Ctx` queries
-- **TxDiff** -- structural transaction diffing with blueprint-aware datum/redeemer decoding ([architecture](modules/tx-diff.md))
-- **Validity** -- pick an `invalid-hereafter` slot inside the chain's plutus-translation horizon ([details](modules/validity.md))
+- **Provider** — ledger queries: UTxOs (by address or `TxIn`),
+  protocol parameters, ledger snapshot (era/tip/epoch), stake
+  rewards, reward accounts, vote delegatees, treasury, governance
+  state, POSIX-to-slot conversion, and horizon-aware validity bounds
+  ([details](modules/provider.md))
+- **Submitter** — submit signed Conway transactions
+  ([details](modules/submitter.md))
+- **N2C** — LocalStateQuery, LocalTxSubmission, and ChainSync over
+  the node's Unix socket, with a reconnect supervisor and an LSQ tip
+  probe ([details](modules/n2c.md))
+- **Validity** — pick an `invalid-hereafter` slot inside the chain's
+  plutus-translation horizon ([details](modules/validity.md))
+- **Indexers** — a generic block-indexer engine plus concrete
+  UTxO and transaction-history indexers
+  ([details](modules/indexers.md))
+- **Adversary** — N2N ChainSync misbehaviour for fault-injection
+  testing, shipped as the `cardano-adversary` daemon
+  ([manual](usage/cardano-adversary.md))
 
-`Balance` and `TxBuild` are implemented by the public
-`cardano-node-clients:tx-build` sublibrary. The main library re-exports
-those modules for compatibility, while transaction-only consumers can
-depend on the smaller component without node communication, indexer,
-daemon, socket, or RocksDB dependencies.
+Transaction building, balancing, and blueprint-aware diffing (the
+`tx-diff` and `cardano-tx-generator` executables) live in
+[lambdasistemi/cardano-tx-tools](https://github.com/lambdasistemi/cardano-tx-tools).
 
-The interfaces are protocol-agnostic records-of-functions. Each transport
-protocol supplies its own constructor:
+The query/submit interfaces are protocol-agnostic
+records-of-functions. Each transport protocol supplies its own
+constructor:
 
 | Protocol | Provider | Submitter |
 |----------|----------|-----------|
 | N2C (Unix socket) | `mkN2CProvider` | `mkN2CSubmitter` |
-| N2N (TCP) | planned | planned |
 
 ## Executables
 
-- **tx-diff** -- compare two Conway transactions, optionally decode Plutus
-  datum/redeemer data with blueprints, and group repeated list diffs with YAML
-  collapse rules ([manual](executables/tx-diff.md)). Install released builds
-  from the GitHub Release assets on Linux or with
-  `brew tap lambdasistemi/tap && brew install tx-diff` on macOS.
+- **utxo-indexer** — address→UTxO indexer daemon (in-memory or
+  RocksDB-backed) exposing `ready`, `utxos_at`, and `await` over a
+  Unix-socket NDJSON wire ([manual](usage/utxo-indexer.md))
+- **cardano-adversary** — N2N adversary daemon serving `ready` and
+  `chain_sync_flap` over a Unix-socket NDJSON control wire
+  ([manual](usage/cardano-adversary.md))
 
-## Current TxBuild status
-
-The transaction builder DSL is under active development and currently
-implements the first complete branch scope:
-
-- spending, script spending, outputs, collateral, minting, required
-  signers, attached scripts, reference inputs, and validity intervals
-- `Peek`-driven fixpoint values for indices and fee-dependent assembly
-- pure drafting with `draft` and `draftWith`
-- effectful building with `build` and `InterpretIO`
-- pluggable context queries through `Ctx`
-- opt-in final-transaction validation via `Valid`
-- balancing with eval retry, fee oscillation handling, bisection, and
-  final `maxFee` re-iteration
-
-## Testing
-
-- Unit tests cover exact `getMinFeeTx` balancing, eval retry,
-  oscillation handling, `bumpFee`, and the `TxBuild` instruction set.
-- E2E tests run against a real devnet for provider, `balanceFeeLoop`,
-  chainsync, chain population, and a submitted `TxBuild` transaction
-  that exercises `spend`, `payTo`, `payTo'`, `ctx`, `peek`, `valid`,
-  `requireSignature`, and `validFrom`/`validTo`.
+See [Installation](installation.md) for release artifacts and Nix
+invocations.
 
 ## Quick start
 
@@ -86,9 +77,23 @@ main = do
     pure ()
 ```
 
+## Testing
+
+- Unit tests cover the N2C probe and trace surface, the UTxO indexer
+  (block extraction, daemon, follower, indexer, persistence,
+  provider, server, shared follower, types, and a mainnet smoke
+  test), the tx-history indexer, the block-indexer handler, the
+  adversary chain-points parser and server, address parsing, and
+  validity helpers.
+- E2E tests run a real devnet `cardano-node` for ChainSync,
+  horizon-aware validity, provider queries, the full N2C session,
+  the UTxO indexer relay-restart reconnect scenario, and the issue
+  [#97](https://github.com/lambdasistemi/cardano-node-clients/issues/97)
+  reproduction.
+
 ## Build
 
 ```bash
 nix develop -c just build   # compile
-nix develop -c just ci      # format + lint + build
+nix develop -c just ci      # build + unit + format/lint checks
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,50 @@
+# Installation
+
+## Release artifacts
+
+Released `utxo-indexer` builds for **x86_64 Linux** are attached to
+each [GitHub release](https://github.com/lambdasistemi/cardano-node-clients/releases):
+
+- `utxo-indexer-<version>-x86_64-linux.AppImage`
+- `utxo-indexer-<version>-x86_64-linux.deb`
+- `utxo-indexer-<version>-x86_64-linux.rpm`
+- `SHA256SUMS`
+
+The AppImage is self-contained; the `.deb` / `.rpm` install through
+the system package manager.
+
+## Nix
+
+The flake exposes both executables as packages and apps. Run them
+directly:
+
+```bash
+nix run github:lambdasistemi/cardano-node-clients              # utxo-indexer (default)
+nix run github:lambdasistemi/cardano-node-clients#utxo-indexer
+nix run github:lambdasistemi/cardano-node-clients#cardano-adversary
+```
+
+Or build them into `./result`:
+
+```bash
+nix build github:lambdasistemi/cardano-node-clients#utxo-indexer
+nix build github:lambdasistemi/cardano-node-clients#cardano-adversary
+```
+
+The flake targets `x86_64-linux` and `aarch64-darwin`. The Linux
+release artifacts (AppImage/deb/rpm) are produced by the
+`linux-release-artifacts` package on Linux only.
+
+## From source
+
+Enter the development shell and build with `just` (which pins `-O0`
+for fast iteration):
+
+```bash
+nix develop
+just build   # library + utxo-indexer + cardano-adversary
+```
+
+See [Development](architecture.md) and the project `justfile` for the
+full recipe list (`unit`, `e2e`, `format`, `hlint`, `ci`,
+`serve-docs`).

--- a/docs/modules/indexers.md
+++ b/docs/modules/indexers.md
@@ -1,0 +1,103 @@
+# Indexers
+
+The indexer stack is split across three components so consumers depend
+only on what they need. All three persist through the
+`kv-transactions` abstraction (RocksDB or in-memory backend) and apply
+every block's mutations in the same transaction that records its
+rollback point.
+
+## block-indexer
+
+::: {.module}
+`Cardano.Node.Client.BlockIndexer.*` (sublibrary
+`cardano-node-clients:block-indexer`)
+:::
+
+The domain-neutral engine. It owns concerns independent of any
+indexed domain:
+
+- `Engine` — rollback-log watermarks, restoration/following phase
+  threading, rollback-log pruning counters, and replay/conflict
+  classification.
+- `Handler` — a transaction-level `IndexerHandler` interface over a
+  typed column GADT and inverse type, plus composition helpers that
+  adapt one or more handlers to the chain-follower
+  `Restoring`/`Following` interface. Multiple domain handlers can
+  share one chain-sync subscription while preserving atomic block
+  application.
+- `Readiness` — generic readiness state and lag math, parameterised
+  over slot and upstream-status types so it does not depend on any
+  concrete reconnect module.
+
+This sublibrary has **no** dependency on UTxO columns, `InterestSet`,
+`UtxoOp`, or the Cardano node transport.
+
+## utxo-indexer-lib
+
+::: {.module}
+`Cardano.Node.Client.UTxOIndexer.{Columns,Indexer,IndexerOp,Types}`
+(sublibrary `cardano-node-clients:utxo-indexer-lib`)
+:::
+
+The concrete address→UTxO store. Three typed columns:
+
+- `TxInCol :: KV TxIn Address` — primary table keyed by `TxIn`, so a
+  block consuming an input can resolve its address without scanning.
+- `AddressIndex :: KV AddrKey TxOut` — secondary index with composite
+  key `lenByte || address || txId || ix`, so a cursor seek to
+  `lenByte || address` yields every UTxO at that address with its full
+  `TxOut` inline.
+- `RollbackCol :: KV SlotNo (RollbackPoint [UtxoOp] BlockHash)` —
+  slot-keyed inverse-op log (8-byte big-endian key, so cursor order
+  matches slot order) used to undo apply-block writes on a chain-sync
+  rollback.
+
+`Indexer` exposes `applyAtSlot` (commit a batch of create/spend ops
+plus the inverse log in one transaction, waking `await` waiters),
+`rollbackTo` (replay the inverse log for every slot past the target),
+`pruneRollbacks` (cap the log at the security parameter `k`), and the
+follower-block wrappers used during cold sync.
+
+## tx-history-indexer-lib
+
+::: {.module}
+`Cardano.Node.Client.TxHistoryIndexer.*` (sublibrary
+`cardano-node-clients:tx-history-indexer-lib`)
+:::
+
+A multi-tenant transaction-history store. Each entry is filed under a
+composite `TxSummaryKey` whose on-disk byte form orders entries by
+`(tenant, scope, slot, txid, role)`:
+
+```
+key = lenTenant || tenant || lenScope || scope
+        || slotBE(8) || txidLen(2 BE) || txid || roleLen(2 BE) || role
+```
+
+Variable-length tenant and scope ids are length-prefixed so prefix
+scans stay correct across mixed lengths (tenant `"a"` never bleeds
+into tenant `"ab"`). `appendSummaries` files a batch of detailed
+`TxSummary` rows and maintains a tenant-local tx-id lookup;
+`queryHistory` returns every entry of a single `(tenant, scope)`
+ordered by `(slot, txid, role)`. A slot-aware resumable surface
+(`processHistoryBlock`) lets the shared chain-sync follower drive this
+store and the UTxO store through separate persisted cursors, resuming
+from the oldest safe point across both.
+
+## Bundled daemon and follower
+
+::: {.module}
+`Cardano.Node.Client.UTxOIndexer.{Daemon,Follower,Server,Provider,BlockExtract}`
+(main library)
+:::
+
+`Daemon.runDaemon` wires an `IndexerHandle` (opened locally, RocksDB
+or in-memory) to the chain-sync follower over the reconnect supervisor
+and the NDJSON `Server`. `Follower.withChainSyncFollower` exposes the
+follower as a standalone bracketed resource against a **caller-owned**
+handle, so an embedder (for example an HTTP container that owns the
+RocksDB store) can run the follower without the socket server.
+`BlockExtract` decodes each consensus block into `(SlotNo, [UtxoOp])`
+era-polymorphically via `cardano-ledger-read`. See the
+[utxo-indexer manual](../usage/utxo-indexer.md) for the daemon's CLI
+and wire protocol.

--- a/docs/modules/n2c.md
+++ b/docs/modules/n2c.md
@@ -17,10 +17,26 @@ runNodeClient
 
 Opens a multiplexed connection with two mini-protocols:
 
-- **MiniProtocol 6** -- LocalTxSubmission
-- **MiniProtocol 7** -- LocalStateQuery
+- **MiniProtocol 6** — LocalTxSubmission
+- **MiniProtocol 7** — LocalStateQuery
 
-Uses `NodeToClientV_20` and `CardanoNodeToClientVersion16`.
+For processes that also need ChainSync on the same physical
+connection, use `runNodeClientFull`, which adds **MiniProtocol 5**
+(ChainSync) and takes an `EpochSlots` and a ChainSync application:
+
+```haskell
+runNodeClientFull
+    :: NetworkMagic -> EpochSlots -> FilePath
+    -> N2CChainSyncApplication
+    -> LSQChannel -> LTxSChannel
+    -> IO (Either SomeException ())
+```
+
+Both helpers negotiate `NodeToClientV_23`. The shared codec
+configuration (`Cardano.Node.Client.N2C.Codecs`) uses
+`CardanoNodeToClientVersion19` with a configurable `EpochSlots`
+(default 42 for devnet). Run either helper in a background thread —
+it blocks until the connection closes.
 
 ## Channels
 
@@ -33,8 +49,9 @@ ltxsCh <- newLTxSChannel 16  -- 16-slot submit queue
 
 ## LocalStateQuery
 
-The LSQ client batches queries in a single acquired session.
-Use `queryLSQ` for direct access:
+The LSQ client batches queries in a single acquired session. Use
+`queryLSQ` for a one-shot query, or `withAcquiredLSQ` /
+`queryAcquiredLSQ` to run several queries against one acquired tip:
 
 ```haskell
 queryLSQ :: LSQChannel -> Query Block result -> IO result
@@ -42,10 +59,21 @@ queryLSQ :: LSQChannel -> Query Block result -> IO result
 
 ## LocalTxSubmission
 
-Use `submitTxN2C` for low-level submission (takes `GenTx Block`),
-or prefer the high-level `mkN2CSubmitter` which wraps
-`Tx ConwayEra` automatically.
+Use `submitTxN2C` for low-level submission (it takes a consensus
+`GenTx Block`), or prefer the high-level `mkN2CSubmitter`, which wraps
+a Conway `ConwayTx` automatically.
 
 ```haskell
-submitTxN2C :: LTxSChannel -> GenTx Block -> IO (Either (ApplyTxErr Block) ())
+submitTxN2C
+    :: LTxSChannel -> GenTx Block
+    -> IO (Either (ApplyTxErr Block) ())
 ```
+
+## Reconnect and readiness
+
+For long-running followers, the `Reconnect` supervisor retries
+ChainSync with full-jitter exponential backoff and gates the first
+attempt on the `Probe` LSQ tip check, so chain-sync is never attached
+against a node still loading its ChainDB. See
+[Architecture](../architecture.md#reconnect-supervisor) and the
+[utxo-indexer manual](../usage/utxo-indexer.md).

--- a/docs/modules/provider.md
+++ b/docs/modules/provider.md
@@ -4,17 +4,29 @@
 `Cardano.Node.Client.Provider`
 :::
 
-Protocol-agnostic interface for querying the Cardano blockchain.
+Protocol-agnostic interface for querying the Cardano blockchain. All
+era-specific types are fixed to `ConwayEra`.
 
 ```haskell
 data Provider m = Provider
-    { withAcquired       :: forall a. (QueryHandle m -> m a) -> m a
-    , queryUTxOs         :: Addr -> m [(TxIn, TxOut ConwayEra)]
-    , queryUTxOByTxIn    :: Set TxIn -> m (Map TxIn (TxOut ConwayEra))
+    { withAcquired        :: forall a. (QueryHandle m -> m a) -> m a
+    , queryUTxOs          :: Addr -> m [(TxIn, TxOut ConwayEra)]
+    , queryUTxOByTxIn     :: Set TxIn -> m (Map TxIn (TxOut ConwayEra))
     , queryProtocolParams :: m (PParams ConwayEra)
-    , evaluateTx         :: ConwayTx -> m (EvaluateTxResult ConwayEra)
-    , posixMsToSlot      :: Integer -> m SlotNo
-    , posixMsCeilSlot    :: Integer -> m SlotNo
+    , queryLedgerSnapshot :: m LedgerSnapshot
+    , queryStakeRewards   :: Set (Credential Staking)
+                          -> m (Map (Credential Staking) Coin)
+    , queryRewardAccounts :: Set AccountAddress
+                          -> m (Map AccountAddress Coin)
+    , queryVoteDelegatees :: Set (Credential Staking)
+                          -> m (Map (Credential Staking) DRep)
+    , queryTreasury       :: m Coin
+    , queryGovernanceState :: m (GovState ConwayEra)
+    , evaluateTx          :: ConwayTx -> m (EvaluateTxResult ConwayEra)
+    , posixMsToSlot       :: Integer -> m SlotNo
+    , posixMsCeilSlot     :: Integer -> m SlotNo
+    , queryUpperBoundSlot :: ValidityChoice
+                          -> m (Either HorizonError SlotNo)
     }
 ```
 
@@ -24,54 +36,66 @@ data Provider m = Provider
 |-------|-------------|
 | `withAcquired` | Run several queries against one acquired ledger snapshot |
 | `queryUTxOs` | Look up UTxOs at an address |
-| `queryUTxOByTxIn` | Look up UTxOs by their transaction inputs |
+| `queryUTxOByTxIn` | Look up unspent UTxOs by their `TxIn` at the tip |
 | `queryProtocolParams` | Fetch current protocol parameters |
+| `queryLedgerSnapshot` | Fetch current era, chain point, tip slot, and epoch |
+| `queryStakeRewards` | Reward balances for stake credentials |
+| `queryRewardAccounts` | Reward balances by reward account |
+| `queryVoteDelegatees` | Conway vote delegatees for stake credentials |
+| `queryTreasury` | Current treasury value |
+| `queryGovernanceState` | Conway governance state |
 | `evaluateTx` | Evaluate script execution units for a transaction |
 | `posixMsToSlot` | Convert POSIX milliseconds to a floor `SlotNo` |
 | `posixMsCeilSlot` | Convert POSIX milliseconds to a ceiling `SlotNo` |
+| `queryUpperBoundSlot` | Horizon-aware `invalid-hereafter` slot ([Validity](validity.md)) |
 
-## Acquired Sessions
+## Acquired sessions
 
 `withAcquired` gives the callback a `QueryHandle` whose query functions
 share one LocalStateQuery `Acquire`. N2C-backed handles keep the node
-protocol client in the acquired state until the callback returns, so all
-handle queries read the same ledger snapshot.
+protocol client in the acquired state until the callback returns, so
+all handle queries read the same ledger snapshot.
 
 ```haskell
 withAcquired provider $ \handle -> do
-    pp <- queryProtocolParamsH handle
+    pp        <- queryProtocolParamsH handle
     byAddress <- queryUTxOsAtH handle requestedAddresses
-    byInput <- queryUTxOByTxInH handle requestedInputs
+    byInput   <- queryUTxOByTxInH handle requestedInputs
     pure (pp, byAddress, byInput)
 ```
 
-Handle functions mirror the LSQ-backed provider methods:
+Handle functions mirror the standalone provider methods with an `H`
+suffix:
 
 | Handle function | Description |
 |-----------------|-------------|
-| `queryUTxOsH` | Look up UTxOs at one address in the acquired snapshot |
-| `queryUTxOsAtH` | Look up UTxOs at several addresses, grouped by address |
-| `queryUTxOByTxInH` | Look up UTxOs by their transaction inputs |
-| `queryProtocolParamsH` | Fetch protocol parameters |
+| `queryUTxOsH` | UTxOs at one address in the acquired snapshot |
+| `queryUTxOsAtH` | UTxOs at several addresses, grouped by address |
+| `queryUTxOByTxInH` | UTxOs by their `TxIn` |
+| `queryProtocolParamsH` | Protocol parameters |
+| `queryLedgerSnapshotH` | Era, chain point, tip slot, epoch |
+| `queryStakeRewardsH` | Reward balances for stake credentials |
+| `queryRewardAccountsH` | Reward balances by reward account |
+| `queryVoteDelegateesH` | Vote delegatees for stake credentials |
+| `queryTreasuryH` | Treasury value |
+| `queryGovernanceStateH` | Conway governance state |
 | `evaluateTxH` | Evaluate script execution units |
-| `posixMsToSlotH` | Convert POSIX milliseconds to a floor `SlotNo` |
-| `posixMsCeilSlotH` | Convert POSIX milliseconds to a ceiling `SlotNo` |
+| `posixMsToSlotH` | POSIX milliseconds to a floor `SlotNo` |
+| `posixMsCeilSlotH` | POSIX milliseconds to a ceiling `SlotNo` |
 
-The standalone provider methods are unchanged for callers. For N2C they
-wrap `withAcquired` internally with one query, so existing call sites can
-keep using `queryUTxOs`, `queryUTxOByTxIn`, `queryProtocolParams`,
-`evaluateTx`, `posixMsToSlot`, and `posixMsCeilSlot`. When several
-related reads must share one snapshot, prefer one explicit `withAcquired`
-callback instead of several standalone calls; each standalone N2C call
-opens and releases its own acquired session.
+The standalone provider methods are unchanged for callers. For N2C
+they wrap `withAcquired` internally with a single query, so each
+standalone call opens and releases its own acquired session. When
+several related reads must share one snapshot, prefer one explicit
+`withAcquired` callback.
 
 ### `evaluateTx`
 
 Evaluates Plutus script execution units for a fully-built transaction.
-The implementation resolves all transaction inputs (spending, collateral,
-and reference) from the node, fetches protocol parameters, system start,
-and the hard-fork interpreter, then calls the ledger's `evalTxExUnits`
-locally.
+The implementation resolves all transaction inputs (spending,
+collateral, and reference) from the node, fetches protocol parameters,
+system start, and the hard-fork interpreter, then calls the ledger's
+`evalTxExUnits` locally.
 
 Returns a `Map` from each script purpose to either a
 `TransactionScriptFailure` or the computed `ExUnits`.
@@ -89,14 +113,14 @@ import Cardano.Node.Client.N2C.Provider (mkN2CProvider)
 
 let provider = mkN2CProvider lsqChannel
 
-utxos  <- queryUTxOs provider myAddress
-pp     <- queryProtocolParams provider
+utxos   <- queryUTxOs provider myAddress
+pp      <- queryProtocolParams provider
 exUnits <- evaluateTx provider mySignedTx
 
 (pp2, utxosByAddress, utxosByInput) <-
     withAcquired provider $ \handle -> do
-        pp2 <- queryProtocolParamsH handle
+        pp2            <- queryProtocolParamsH handle
         utxosByAddress <- queryUTxOsAtH handle myAddresses
-        utxosByInput <- queryUTxOByTxInH handle myInputs
+        utxosByInput   <- queryUTxOByTxInH handle myInputs
         pure (pp2, utxosByAddress, utxosByInput)
 ```

--- a/docs/modules/submitter.md
+++ b/docs/modules/submitter.md
@@ -5,14 +5,16 @@
 :::
 
 Protocol-agnostic interface for submitting signed transactions.
+`ConwayTx` is the package's alias for `Tx TopTx ConwayEra`
+(`Cardano.Node.Client.Ledger`).
 
 ```haskell
 data SubmitResult
-    = Submitted TxId
-    | Rejected ByteString
+    = Submitted !TxId       -- accepted into the mempool
+    | Rejected !ByteString  -- rejection reason (UTF-8)
 
 newtype Submitter m = Submitter
-    { submitTx :: Tx ConwayEra -> m SubmitResult
+    { submitTx :: ConwayTx -> m SubmitResult
     }
 ```
 
@@ -21,6 +23,10 @@ newtype Submitter m = Submitter
 | Function | Module | Transport |
 |----------|--------|-----------|
 | `mkN2CSubmitter` | `Cardano.Node.Client.N2C.Submitter` | Unix socket (N2C) |
+
+The N2C submitter wraps the ledger `ConwayTx` into a consensus
+`GenTx Block` before submission and serialises any rejection reason to
+a `ByteString`.
 
 ## Usage
 
@@ -31,6 +37,6 @@ let submitter = mkN2CSubmitter ltxsChannel
 
 result <- submitTx submitter signedTx
 case result of
-    Submitted txId -> putStrLn $ "OK: " <> show txId
+    Submitted txId  -> putStrLn $ "OK: " <> show txId
     Rejected reason -> putStrLn $ "FAIL: " <> show reason
 ```

--- a/docs/usage/cardano-adversary.md
+++ b/docs/usage/cardano-adversary.md
@@ -1,0 +1,81 @@
+# cardano-adversary
+
+N2N adversary daemon for fault-injection testing (for example under
+Antithesis). It listens on a Unix-domain control socket and answers one
+NDJSON request per connection, driving adversarial Node-to-Node
+ChainSync connections against configured block producers.
+
+## CLI
+
+```bash
+cardano-adversary \
+  --control-socket PATH \
+  --network-magic  INT \
+  [--producer-host HOST]... \
+  [--producer-port INT] \
+  [--chain-points-file PATH]
+```
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--control-socket` | — | Bind path for the NDJSON control socket. Required. |
+| `--network-magic` | — | Cardano network magic for the N2N handshake. Required. |
+| `--producer-host` | (none) | Producer hostname the `chain_sync_flap` endpoint targets. Repeatable. |
+| `--producer-port` | `3001` | N2N port for `chain_sync_flap`. |
+| `--chain-points-file` | (unset) | File of chain points written by `tracer-sidecar`; re-read on every `chain_sync_flap` request. |
+
+`cardano-adversary --help` prints the same summary. The daemon installs
+a `SIGTERM` handler, unlinks the socket on shutdown, and exits cleanly.
+
+## Control wire (NDJSON)
+
+One request line per connection, one response line, then EOF. The full
+schema is the contract at
+`specs/036-cardano-adversary/contracts/control-wire.md`.
+
+### `ready`
+
+```
+REQ:  {"ready": null}
+RESP: {"ready": <bool>,
+       "details": {"n2nHandshakeOk": <bool>,
+                   "configuredHosts": [<host>, ...]}}
+```
+
+`configuredHosts` echoes the `--producer-host` values.
+
+### `chain_sync_flap`
+
+Opens `n_conns` concurrent adversarial ChainSync connections against
+the configured producers, each starting from a randomised chain point
+sampled (seeded by `seed`) from the chain-points file and pulling at
+most `limit` blocks before disconnecting.
+
+```
+REQ:  {"chain_sync_flap": {"seed": <u64>, "limit": <u32>, "n_conns": <u16>}}
+RESP: {"ok": true,
+       "details": {"connections": <int>,
+                   "peerNames": [<host>, ...],
+                   "limit": <u32>}}
+```
+
+Structured failures keep `ok: false` with a `reason`:
+
+| `reason` | Cause |
+|----------|-------|
+| `no-producers` | No `--producer-host` was configured. |
+| `no-chain-points-file` | The `--chain-points-file` is unset or missing on disk. |
+| `no-chain-points-yet` | The file exists but holds no usable chain points yet. |
+
+Wire-level problems return `{"error": "<reason>"}` (for example
+malformed JSON or an unknown top-level key).
+
+## Random source
+
+Every adversarial decision draws from
+`Cardano.Node.Client.Adversary.RandomSource`. The default
+implementation shells out to the `antithesis_random` CLI when it is on
+`PATH` (so the Antithesis hypervisor can bias choices) and falls back
+to `System.Random` for local development when it is not. The per-request
+`seed` field is turned into a `StdGen` so a request is reproducible
+from its seed.

--- a/docs/usage/utxo-indexer.md
+++ b/docs/usage/utxo-indexer.md
@@ -1,0 +1,113 @@
+# utxo-indexer
+
+In-process address→UTxO indexer daemon. Follows the chain via
+Node-to-Client (N2C) ChainSync from a single Cardano relay, maintains
+an indexed view (in-memory or RocksDB-backed), and exposes three read
+primitives over a Unix-domain NDJSON socket: `ready`,
+`utxos_at <addr>`, and `await <txin> [timeout_seconds]`.
+
+## CLI
+
+```bash
+utxo-indexer \
+  --relay-socket   /path/to/cardano-node/node.sock \
+  --listen         /tmp/idx.sock \
+  --network-magic  42 \
+  --byron-epoch-slots 86400 \
+  [--ready-threshold-slots 60] \
+  [--security-param-k 2160] \
+  [--db-path        /tmp/idx-db] \
+  [--reconnect-initial-ms          1000] \
+  [--reconnect-max-ms              30000] \
+  [--reconnect-reset-threshold-ms  30000] \
+  [--node-ready-timeout-ms         <ms>]
+```
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--relay-socket` | — | Unix socket of the upstream cardano-node relay. |
+| `--listen` | — | Path the indexer will bind for NDJSON consumers. |
+| `--network-magic` | — | Cardano network magic (mainnet=764824073, preprod=1, preview=2, antithesis testnet=42). |
+| `--byron-epoch-slots` | — | Byron-era epoch length (mainnet=21600, antithesis testnet=86400). |
+| `--ready-threshold-slots` | `60` | `slotsBehind ≤ this ⇒ ready=true`. |
+| `--security-param-k` | `2160` | Cardano security parameter k; caps the rollback log. |
+| `--db-path` | (in-memory) | If set, RocksDB at this path. State survives process restart. |
+| `--reconnect-initial-ms` | `1000` | Base of the supervisor's full-jitter exponential backoff. |
+| `--reconnect-max-ms` | `30000` | Cap of the supervisor's backoff window. |
+| `--reconnect-reset-threshold-ms` | `30000` | Healthy-run duration that resets the supervisor's failure counter. |
+| `--node-ready-timeout-ms` | unset | Total cap on the LSQ tip probe. **Unset = wait forever** for the upstream node's ChainDB to load. Set explicitly for CI scenarios that want to fail fast. |
+
+All flags are parsed in `app/utxo-indexer/Main.hs`; required flags are
+`--relay-socket`, `--listen`, `--network-magic`, and
+`--byron-epoch-slots`.
+
+## Read wire (NDJSON)
+
+One request line per connection, one response line, then EOF:
+
+```
+REQ:  {"ready": null}
+RESP: {"ready":<bool>, "tipSlot":<int|null>,
+       "processedSlot":<int|null>, "slotsBehind":<int|null>, ...}
+
+REQ:  {"utxos_at": "<hex-of-address-bytes>"}
+RESP: {"utxos": [{"txin":"<txid>#<ix>", "txout":"<base16-cbor>"}, ...]}
+
+REQ:  {"await": "<txid_hex>#<ix>"}            # optional trailing timeout
+```
+
+Address bytes go on the wire as hex; bech32 parsing lives in the
+consumer. On upstream disconnect the `ready` response carries an
+`upstream` object naming the reason, attempt counter, and
+elapsed-since-disconnect time, while `utxos_at` and `await` continue
+to be served from cached state.
+
+## Reconnect behaviour (issue #97)
+
+The daemon survives upstream relay disconnects (e.g. relay container
+restart) without exiting:
+
+- the listen socket keeps accepting consumer connections;
+- `ready` returns `ready=false` with the `upstream` reason while
+  disconnected;
+- `utxos_at` and `await` keep serving cached state — consumer
+  connections are never EOFed because of an upstream disconnect;
+- before each reconnect attempt the supervisor probes the relay via
+  LocalStateQuery (acquire volatile tip + read tip); ChainSync is
+  attached only once the probe sees a non-Origin tip;
+- reconnect retries use full-jitter exponential backoff (defaults
+  1 s → 30 s) via `Control.Retry`.
+
+Operators no longer need orchestrator-level `restart: always` on the
+indexer container to recover from peer flapping.
+
+## Stderr trace stream
+
+Every lifecycle transition emits one line on stderr:
+
+```
+2026-04-30T12:34:56.789Z INFO indexer event=started        socketPath=... dbPath=...
+2026-04-30T12:35:42.103Z INFO indexer event=disconnected   reason=bearer-closed
+2026-04-30T12:35:42.380Z INFO indexer event=node-replaying attempt=1 elapsedMs=275
+2026-04-30T12:35:43.500Z INFO indexer event=reconnecting   attempt=1 waitMs=312
+2026-04-30T12:35:44.815Z INFO indexer event=reconnected    resumeSlot=12345 elapsedMs=2712
+2026-04-30T12:40:00.001Z INFO indexer event=stopped        reason=normal
+```
+
+`grep '^.*indexer '` is the operator-friendly filter. Counting
+`event=disconnected` vs `event=reconnected` per peer-restart cycle is
+the recommended fault-injection assertion; `event=node-replaying`
+lines reveal that the upstream relay is alive but its ChainDB hasn't
+finished loading.
+
+## Embedded use
+
+Embedders that want to route `N2CEvent`s into their own tracer can
+pass a custom `Tracer IO N2CEvent` to
+`Cardano.Node.Client.UTxOIndexer.Daemon.runDaemon`'s first argument
+instead of `defaultStderrTracer`. To own the `IndexerHandle` (RocksDB
+is single-writer) and run the follower without the NDJSON server, use
+`Cardano.Node.Client.UTxOIndexer.Follower.withChainSyncFollower`. The
+`cardano-tx-generator` daemon in
+[lambdasistemi/cardano-tx-tools](https://github.com/lambdasistemi/cardano-tx-tools)
+embeds the indexer this way.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,11 +1,22 @@
 site_name: cardano-node-clients
-site_url: https://paolino.github.io/cardano-node-clients/
+site_url: https://lambdasistemi.github.io/cardano-node-clients/
 repo_url: https://github.com/lambdasistemi/cardano-node-clients
 
 theme:
   name: material
   palette:
-    scheme: slate
+    # Light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
   features:
     - navigation.indexes
     - toc.integrate
@@ -23,7 +34,11 @@ markdown_extensions:
       line_spans: __span
       pygments_lang_class: true
   - pymdownx.inlinehilite
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - admonition
@@ -33,9 +48,14 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Installation: installation.md
+  - Usage:
+      - utxo-indexer: usage/utxo-indexer.md
+      - cardano-adversary: usage/cardano-adversary.md
   - Architecture: architecture.md
   - Modules:
       - Provider: modules/provider.md
       - Submitter: modules/submitter.md
       - N2C: modules/n2c.md
       - Validity: modules/validity.md
+      - Indexers: modules/indexers.md

--- a/skills/cardano-node-clients-guide/SKILL.md
+++ b/skills/cardano-node-clients-guide/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: cardano-node-clients-guide
+description: >-
+  Guide for working in the lambdasistemi/cardano-node-clients Haskell
+  repository — channel-driven Cardano node Ouroboros mini-protocol
+  clients (N2C + N2N). Load when a task touches this repo: the
+  utxo-indexer or cardano-adversary daemons; the Provider/Submitter
+  record-of-functions interfaces (mkN2CProvider, mkN2CSubmitter); N2C
+  LocalStateQuery / LocalTxSubmission / ChainSync over a Unix socket
+  (runNodeClient, runNodeClientFull, LSQChannel, LTxSChannel,
+  NodeToClientV_23, CardanoNodeToClientVersion19); the reconnect
+  supervisor and LSQ tip probe (issue #97, waitForNodeReady,
+  IndexerNodeReplaying, intersectNotFound, TimeTranslationPastHorizon);
+  horizon-aware validity (ValidityChoice, AutoLongest, MaxHours,
+  ExactlyHours, queryUpperBoundSlot); the block-indexer engine and the
+  utxo-indexer-lib / tx-history-indexer-lib sublibraries (kv-transactions,
+  RocksDB columns, rollback log, await/utxos_at NDJSON wire); the N2N
+  adversary (chain_sync_flap, tracer-sidecar chain points,
+  antithesis_random). Modules live under Cardano.Node.Client.*. Build
+  with `nix develop -c just build`. Note: transaction building/balancing
+  /tx-diff moved to the separate cardano-tx-tools repo.
+---
+
+# cardano-node-clients guide
+
+Channel-driven Haskell clients for the Cardano node Ouroboros
+mini-protocols, plus an indexer stack and an N2N adversary. Two
+executables ship: `utxo-indexer` and `cardano-adversary`.
+
+## Repository map
+
+| Path | Purpose |
+|------|---------|
+| `lib/Cardano/Node/Client/` | Main library. `Provider.hs`, `Submitter.hs`, `Validity.hs`, `Address.hs`, `Ledger.hs` (`ConwayTx` alias), `Types.hs` (`Block`). |
+| `lib/Cardano/Node/Client/N2C/` | N2C transport: `Connection` (`runNodeClient(Full)`), `LocalStateQuery`, `LocalTxSubmission`, `ChainSync`, `Codecs`, `Provider` (`mkN2CProvider`), `Submitter` (`mkN2CSubmitter`), `Probe` (LSQ tip readiness), `Reconnect` (retry supervisor), `Trace` (`N2CEvent`), `Types` (channels). |
+| `lib/Cardano/Node/Client/Adversary/` | N2N adversary: `Daemon`, `Server` (NDJSON wire), `Application` (`chain_sync_flap`), `ChainPoints`, `RandomSource`, `Types`, `ChainSync/` (N2N codec + connection). |
+| `lib/Cardano/Node/Client/UTxOIndexer/` | Bundled daemon: `Daemon`, `Follower` (`withChainSyncFollower`), `Server` (NDJSON), `Provider`, `BlockExtract`. |
+| `lib-block-indexer/` | Sublibrary `block-indexer`: `Engine`, `Handler`, `Readiness`, `Types`. Domain-neutral rollback-log engine. |
+| `lib-utxo-indexer/` | Sublibrary `utxo-indexer-lib`: `Columns`, `Indexer`, `IndexerOp`, `Types`. Concrete UTxO store over `kv-transactions`. |
+| `lib-tx-history-indexer/` | Sublibrary `tx-history-indexer-lib`: `Columns`, `Indexer`, `BlockExtract`, `Types`. Multi-tenant history. |
+| `app/utxo-indexer/` | `Main.hs` (CLI parsing) + `README.md`. |
+| `app/cardano-adversary/` | `Main.hs` (CLI parsing). |
+| `e2e-test/` | Sublibrary `devnet`: `withCardanoNode`, `Devnet`, `Setup`, `ChainPopulator`, `CrashRecovery`. |
+| `test/` | `unit-tests` and `e2e-tests` suites. |
+| `docs/`, `mkdocs.yml` | mkdocs site. `specs/` holds Spec Kit feature artifacts. |
+| `flake.nix`, `justfile`, `cabal.project`, `nix/` | Build tooling. |
+
+## Build, test, run
+
+All inside the Nix dev shell; `just` pins `-O0`.
+
+```bash
+nix develop -c just build   # library + utxo-indexer + cardano-adversary
+nix develop -c just unit    # unit-tests
+nix develop -c just e2e     # e2e-tests (spawns a real cardano-node devnet)
+nix develop -c just ci      # build + unit + cabal-fmt -c + fourmolu check + hlint
+nix develop -c just format  # fourmolu -i + cabal-fmt -i
+nix run .#utxo-indexer
+nix run .#cardano-adversary
+```
+
+A single component: `cabal build cardano-node-clients:lib:cardano-node-clients -O0`.
+GHC is `ghc9123`; the package is `GHC2021`. To see all GHC errors add
+`--ghc-options="-fmax-errors=0"`.
+
+## Navigating the code
+
+- **Entry points** are CLI-parsing-only: `app/utxo-indexer/Main.hs`
+  delegates to `UTxOIndexer.Daemon.runDaemon`;
+  `app/cardano-adversary/Main.hs` delegates to
+  `Adversary.Daemon.runDaemon`.
+- **Querying the node**: the `Provider` record is defined in
+  `lib/.../Provider.hs`; the live N2C implementation (each field) is in
+  `lib/.../N2C/Provider.hs`. Submission mirrors this in `Submitter.hs`
+  / `N2C/Submitter.hs`.
+- **The protocol loop**: `N2C/Connection.hs` multiplexes mini-protocols
+  5/6/7 (`runNodeClientFull` adds ChainSync). Channel plumbing
+  (`LSQChannel`, `LTxSChannel`, `TBQueue`/`TMVar`) is in `N2C/Types.hs`.
+- **Reconnect/readiness**: `N2C/Reconnect.hs` (retry supervisor) calls
+  `N2C/Probe.hs` (`waitForNodeReady`) before attaching ChainSync. Trace
+  events for grepping are in `N2C/Trace.hs`.
+- **Indexer feature logic**: apply/rollback/await live in
+  `lib-utxo-indexer/.../Indexer.hs`; storage layout in `Columns.hs`;
+  generic engine in `lib-block-indexer/.../Engine.hs`. The daemon glues
+  follower + server in `lib/.../UTxOIndexer/Daemon.hs`.
+- **Adversary wire**: schemas in
+  `specs/036-cardano-adversary/contracts/control-wire.md`; types in
+  `Adversary/Types.hs`; dispatch in `Adversary/Server.hs`; the
+  misbehaviour body in `Adversary/Application.hs`.
+
+## Using the artifacts
+
+`utxo-indexer` (required flags `--relay-socket`, `--listen`,
+`--network-magic`, `--byron-epoch-slots`):
+
+```bash
+utxo-indexer --relay-socket /run/cardano-node/node.socket \
+  --listen /tmp/idx.sock --network-magic 764824073 --byron-epoch-slots 21600
+printf '{"ready": null}\n'                 | nc -U /tmp/idx.sock
+printf '{"utxos_at": "<hex-addr>"}\n'      | nc -U /tmp/idx.sock
+```
+
+`cardano-adversary` (required `--control-socket`, `--network-magic`):
+
+```bash
+cardano-adversary --control-socket /tmp/adv.sock --network-magic 42 \
+  --producer-host relay.example --chain-points-file /tmp/points
+printf '{"chain_sync_flap":{"seed":1,"limit":50,"n_conns":4}}\n' | nc -U /tmp/adv.sock
+```
+
+Library:
+
+```haskell
+lsqCh <- newLSQChannel 16; ltxsCh <- newLTxSChannel 16
+_ <- async $ runNodeClient (NetworkMagic 764824073) sock lsqCh ltxsCh
+let provider = mkN2CProvider lsqCh; submitter = mkN2CSubmitter ltxsCh
+```
+
+## Answering questions
+
+- "What does this repo do / how do I install it?" → `README.md`
+  (What-is-this, Install, Quickstart) and the docs site landing page
+  `docs/index.md`.
+- "How do I run / configure the indexer? what flags / what wire?" →
+  `app/utxo-indexer/README.md` and `docs/usage/utxo-indexer.md` (verified
+  against `app/utxo-indexer/Main.hs`).
+- "How does the adversary work?" → `docs/usage/cardano-adversary.md`
+  and the control-wire spec under `specs/036-cardano-adversary/`.
+- "What queries can I run against a node?" → `docs/modules/provider.md`
+  and the `Provider` record in `lib/.../Provider.hs`.
+- "How does it survive node restarts?" → reconnect/probe sections in
+  `docs/architecture.md` and `app/utxo-indexer/README.md` (issue #97);
+  source in `N2C/Reconnect.hs` and `N2C/Probe.hs`.
+- "Where did tx-diff / TxBuild / balancing go?" → moved to
+  [cardano-tx-tools](https://github.com/lambdasistemi/cardano-tx-tools);
+  see the CHANGELOG "Unreleased" breaking-changes note.
+- "How is the architecture laid out?" → `docs/architecture.md` (mermaid)
+  and `docs/modules/indexers.md`.


### PR DESCRIPTION
## Summary

Documentation review of the repo against the actual state of the code.
The docs had drifted: they still described the transaction-building
tooling that was extracted to `cardano-tx-tools`, pointed at the wrong
GitHub Pages URL, and predated both the N2N adversary daemon and the
indexer sublibraries. Docs-only change — no source, tests, workflows,
`flake.nix`, or `justfile` touched.

## What was inaccurate

- **README**: described only the old `Provider`/`Submitter`/`N2C`
  surface; missing the `cardano-adversary` executable, the
  `block-indexer` / `tx-history-indexer` sublibraries, and `devnet`.
  No architecture diagram. Documentation link pointed at
  `paolino.github.io` (actual Pages site is
  `lambdasistemi.github.io`).
- **docs/index.md & docs/architecture.md**: documented a
  `cardano-node-clients:tx-build` sublibrary and `Balance` / `TxBuild`
  / `TxDiff` / `tx-diff` content that no longer ships from this repo
  (moved to `cardano-tx-tools`, per the CHANGELOG breaking-changes
  note).
- **docs/modules/n2c.md**: stated `NodeToClientV_20` and
  `CardanoNodeToClientVersion16`. Source negotiates
  `NodeToClientV_23` (`N2C/Connection.hs`) with
  `CardanoNodeToClientVersion19` (`N2C/Codecs.hs`).
  `runNodeClientFull` (ChainSync on the same mux) was undocumented.
- **docs/modules/provider.md**: documented 7 of the `Provider`
  record's 14 fields. Missing `queryLedgerSnapshot`,
  `queryStakeRewards`, `queryRewardAccounts`, `queryVoteDelegatees`,
  `queryTreasury`, `queryGovernanceState`, and `queryUpperBoundSlot`.
- **docs/modules/submitter.md**: gave `submitTx :: Tx ConwayEra -> …`;
  the field is `ConwayTx -> m SubmitResult`
  (`ConwayTx = Tx TopTx ConwayEra`).
- **mkdocs.yml**: wrong `site_url`; no light/dark palette toggle; no
  mermaid superfence.
- **AGENTS.md / CLAUDE.md**: auto-generated Spec-Kit boilerplate
  describing a `src/ tests/` layout and tx-builder content that do not
  exist in this repo.

## What changed

- Rewrote **README.md** into the standard section order with a mermaid
  architecture diagram, both executables, accurate sublibrary list,
  and corrected Pages URL.
- Rewrote **docs/index.md** and **docs/architecture.md** for the
  current N2C-clients + indexer + adversary layout (new mermaid
  module graph); fixed the N2C protocol versions; completed the
  Provider record; corrected the Submitter field type.
- Added **docs/installation.md**, **docs/usage/utxo-indexer.md**,
  **docs/usage/cardano-adversary.md**, and **docs/modules/indexers.md**;
  wired them into the mkdocs nav. Added the light/dark palette toggle
  and the mermaid superfence to **mkdocs.yml**.
- Added the agent layer: a real **AGENTS.md**, a repo skill at
  **skills/cardano-node-clients-guide/SKILL.md** (agentskills.io
  layout), and converted **CLAUDE.md** to a thin pointer to AGENTS.md.

## How it was verified

- CLI flags/defaults checked against `app/utxo-indexer/Main.hs` and
  `app/cardano-adversary/Main.hs`.
- API signatures checked against `lib/Cardano/Node/Client/**`
  (`Provider`, `Submitter`, `Ledger`, `Validity`, `N2C/Connection`,
  `N2C/Codecs`, `N2C/Reconnect`, `N2C/Probe`).
- Protocol versions / mini-protocol numbers grepped from
  `N2C/Connection.hs` and `N2C/Codecs.hs`.
- Adversary wire checked against `Adversary/{Types,Server,Daemon}.hs`
  and `specs/036-cardano-adversary/contracts/control-wire.md`.
- Release artifacts confirmed via `gh release view` (AppImage/deb/rpm,
  x86_64 Linux); Pages URL via `gh api .../pages`.
- Both mermaid diagrams checked for balanced quotes/brackets and
  matched `subgraph`/`end`.
- `mkdocs build --strict` runs clean (no warnings). The full
  `nix develop` dev shell exceeded a ~14 min cap to evaluate, so the
  strict build was run with the project's `from-nixpkgs` mkdocs
  (the same package the dev shell provides) outside the haskell.nix
  shell.
