### PR TITLE
fix(n2c): recover LSQ callers from connection loss

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-git diff --check
-nix develop --quiet -c just ci

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix develop --quiet -c just ci

--- a/lib/Cardano/Node/Client/N2C/LocalStateQuery.hs
+++ b/lib/Cardano/Node/Client/N2C/LocalStateQuery.hs
@@ -59,12 +59,13 @@ import Control.Exception (
     BlockedIndefinitelyOnSTM,
     SomeException,
     catch,
+    fromException,
     handle,
     mask,
-    onException,
     throwIO,
+    try,
  )
-import Control.Monad (void)
+import Control.Monad (unless, void, when)
 import Numeric.Natural (Natural)
 import Ouroboros.Consensus.Ledger.Query (Query)
 import Ouroboros.Network.Protocol.LocalStateQuery.Client (
@@ -111,24 +112,43 @@ completes or the LocalStateQuery channel's liveness generation
 changes. A child watcher interrupts the calling thread with
 'LocalStateQueryTimeout' on a generation change. Each invocation
 snapshots the current generation, so an earlier timeout does not
-invalidate a newly started connection.
+invalidate a newly started connection. When the connection action
+terminates independently, its watcher is stopped before the current
+generation is advanced and the original result or exception is preserved.
 -}
 monitorLocalStateQueryConnection ::
     LSQChannel ->
     IO a ->
     IO a
-monitorLocalStateQueryConnection ch connectionAction = do
-    initialGeneration <-
-        readTVarIO $ lsqLivenessGeneration ch
-    caller <- myThreadId
-    withAsync (interruptOnGenerationChange caller initialGeneration) $
-        const connectionAction
+monitorLocalStateQueryConnection ch connectionAction =
+    mask $ \restore -> do
+        initialGeneration <-
+            readTVarIO $ lsqLivenessGeneration ch
+        caller <- myThreadId
+        result <-
+            try @SomeException
+                $ withAsync
+                    ( interruptOnGenerationChange
+                        caller
+                        initialGeneration
+                    )
+                $ const
+                $ restore connectionAction
+        signalConnectionTermination initialGeneration
+        either throwIO pure result
   where
     interruptOnGenerationChange caller watchedGeneration = do
         waitForGenerationChange ch watchedGeneration
         throwTo caller $
             LocalStateQueryTimeout $
                 lsqResponseTimeoutMicroseconds ch
+    signalConnectionTermination watchedGeneration =
+        atomically $ do
+            current <- readTVar $ lsqLivenessGeneration ch
+            when (current == watchedGeneration) $
+                writeTVar
+                    (lsqLivenessGeneration ch)
+                    (current + 1)
 
 waitForGenerationChange :: LSQChannel -> Int -> IO ()
 waitForGenerationChange ch generation =
@@ -327,11 +347,16 @@ withAcquiredLSQ ch action =
                     LSQAcquire acquired acquiredVar
                 pure current
         takeTMVarOrConnectionLost ch generation deadline acquiredVar
-        result <-
-            restore (action acquired)
-                `onException` releaseAcquiredLSQBestEffort acquired
-        releaseAcquiredLSQ acquired
-        pure result
+        actionResult <-
+            try @SomeException $ restore $ action acquired
+        case actionResult of
+            Left exception -> do
+                unless (connectionInvalidated exception) $
+                    releaseAcquiredLSQBestEffort acquired
+                throwIO exception
+            Right result -> do
+                releaseAcquiredLSQ acquired
+                pure result
 
 {- | Submit a query through an acquired session and
 block until the result is available.
@@ -376,6 +401,15 @@ releaseAcquiredLSQBestEffort ::
 releaseAcquiredLSQBestEffort acquired =
     void (timeout 1000000 (releaseAcquiredLSQ acquired))
         `catch` \(_ :: SomeException) -> pure ()
+
+connectionInvalidated :: SomeException -> Bool
+connectionInvalidated exception =
+    case fromException exception of
+        Just ConnectionLost -> True
+        Nothing ->
+            case fromException exception of
+                Just (LocalStateQueryTimeout _) -> True
+                Nothing -> False
 
 data LSQWaitResult a
     = LSQResult a

--- a/specs/182-lsq-response-timeout/plan.md
+++ b/specs/182-lsq-response-timeout/plan.md
@@ -84,3 +84,52 @@ constructor is additive. The principal risk is a false timeout for unusually
 slow ledger evaluation; the 60-second default matches the downstream mitigation
 that exposed the bug, while the additive constructor permits an explicit
 application budget.
+
+## Reopened follow-up plan
+
+### Diagnostic question
+
+What external boundary does the existing unit suite bypass? It does not cover
+an independently terminated connection while a deadline `TVar` is still live,
+nor the four-query acquired sequence used by `evaluateTx` against the current
+mainnet node. Both boundaries require explicit proof before merge.
+
+### Slice 3: connection termination and evaluation recovery
+
+One bisect-safe RED/GREEN commit:
+
+1. Add a node-free regression whose connection/peer terminates after accepting
+   a query but before filling the result `TMVar`; capture v0.1.4.0 RED where the
+   caller waits until the deadline or reports the wrong exception.
+2. Make connection termination signal the watched generation without
+   overwriting a generation already invalidated by a timeout. Preserve the
+   original connection result/exception for the supervisor.
+3. Instrument the live evaluation sequence only as needed to identify the
+   exact terminating query and exception. Compare the working
+   interpreter/chain-point sequence with the failing UTxO/pparams/system-start/
+   interpreter sequence before choosing a recovery design.
+4. Apply the minimal correction at the proven boundary. Any LSQ read retry is
+   finite and starts on a fresh acquired generation; transaction submission is
+   excluded.
+5. Run focused GREEN, explicit revert/restore RED→GREEN, and `./gate.sh`.
+
+### Live-boundary operator follow-up
+
+The mainnet socket and treasury metadata are operator-only inputs, so the
+five-run disburse smoke is not placed in general CI. PR #185 remains draft
+until the parent orchestrator builds an Amaru candidate pinned to the PR head
+and the exact request produces five non-empty unsigned CBOR files. The smoke
+must also prove zero witness/sign/submit artifacts.
+
+### Slice 3 owned implementation files
+
+- `lib/Cardano/Node/Client/N2C/Connection.hs`
+- `lib/Cardano/Node/Client/N2C/LocalStateQuery.hs`
+- `lib/Cardano/Node/Client/N2C/Types.hs` only if the proven design requires it
+- `lib/Cardano/Node/Client/N2C/Provider.hs` only if diagnosis proves the
+  evaluation sequence itself is defective
+- `test/Cardano/Node/Client/N2C/LocalStateQuerySpec.hs`
+- focused E2E test files only when required by the diagnosis
+
+The package version, release notes, downstream pin, specs, gate, and PR
+metadata remain parent-owned.

--- a/specs/182-lsq-response-timeout/spec.md
+++ b/specs/182-lsq-response-timeout/spec.md
@@ -61,3 +61,50 @@ slot inside its pending `recvMsgResult` continuation. If the remote peer never
 sends a result but the bearer stays open, that retained writer is still
 reachable, so GHC cannot report `BlockedIndefinitelyOnSTM`. The caller and the
 single serialized LSQ loop therefore remain live and blocked indefinitely.
+
+## Reopened follow-up: connection loss masked as timeout
+
+Live verification on 2026-07-11 found that the released timeout bounds the
+wait but does not preserve the existing fast connection-loss behavior. Five
+fresh mainnet builds reached `evaluateTxH` and failed at the 60-second LSQ
+deadline; the same control through v0.1.3.0 raised `ConnectionLost` in about
+two seconds.
+
+The deadline wait introduced a second liveness source: its `registerDelay`
+`TVar` remains reachable and has a future writer. Consequently, a result
+`TMVar` whose protocol peer has died is no longer eligible for GHC's
+`BlockedIndefinitelyOnSTM` signal before the deadline. The explicit liveness
+generation is advanced when a request expires, but not when the enclosing
+connection action terminates independently.
+
+### Follow-up functional requirements
+
+- FR-010: termination of an N2C connection action advances that connection's
+  LSQ liveness generation exactly once when it is still current.
+- FR-011: a caller waiting for a response from the terminated generation
+  raises typed `ConnectionLost` promptly, before its configured response
+  deadline.
+- FR-012: timeout-driven invalidation retains its existing distinction: the
+  expiring request raises `LocalStateQueryTimeout`, while sibling waiters raise
+  `ConnectionLost`.
+- FR-013: the connection action's underlying exception remains observable to
+  its supervisor and is not replaced by the caller-side deadline.
+- FR-014: diagnosis must identify why the acquired `evaluateTx` query sequence
+  terminates on the current mainnet boundary. Do not add an unbounded or blind
+  retry that merely repeats an unknown protocol failure.
+- FR-015: any retry introduced for an interrupted LSQ read is finite, begins
+  from a fresh acquired state, and cannot apply to transaction submission.
+
+### Follow-up acceptance criteria
+
+- AC-007: a node-free peer/connection terminates while a query result is
+  pending; the caller receives `ConnectionLost` within a short outer bound and
+  not `LocalStateQueryTimeout`.
+- AC-008: the regression is observed RED on v0.1.4.0 and GREEN after the fix,
+  including explicit revert/restore proof.
+- AC-009: the full repository gate passes.
+- AC-010: the released Amaru disburse request, with 4,891.45 USDM represented
+  as `4891450000` micro-USDM, produces non-empty unsigned CBOR in five out of
+  five fresh mainnet runs.
+- AC-011: the live proof creates no witness, signed transaction, or submission
+  artifact.

--- a/specs/182-lsq-response-timeout/tasks.md
+++ b/specs/182-lsq-response-timeout/tasks.md
@@ -1,5 +1,10 @@
 # Tasks: bounded LocalStateQuery responses
 
+## Reopened bootstrap
+
+- [X] T000 Create the follow-up worktree, verification gate, and draft PR
+  #185 from released main.
+
 ## Slice 1: regression and liveness fix
 
 - [X] T183 Add the node-free typed-protocol regression and capture the expected
@@ -17,3 +22,17 @@
   calling thread, preserving the original manual stateful LSQ callback.
 - [X] T183 Enable threaded E2E deadlines, verify live RED→GREEN, and run the
   exact aggregate Nix build used by GitHub CI with a finite outer deadline.
+
+## Slice 3: reopened live connection-loss follow-up
+
+- [ ] T182-S3 Add and observe RED for a connection terminating while an LSQ
+  result wait still has a live deadline.
+- [ ] T182-S3 Signal connection termination to pending callers while preserving
+  the underlying connection exception.
+- [ ] T182-S3 Diagnose the exact acquired evaluation query that terminates on
+  the current mainnet node and implement only the proven minimal recovery.
+- [ ] T182-S3 Verify focused GREEN, revert/restore RED→GREEN, and the full
+  `./gate.sh`; commit with `Tasks: T182-S3`.
+- [ ] T182-LIVE Parent follow-up: pin an Amaru candidate and produce unsigned
+  CBOR for the exact colleague request five out of five times, with no
+  witness/sign/submit artifacts.

--- a/specs/182-lsq-response-timeout/tasks.md
+++ b/specs/182-lsq-response-timeout/tasks.md
@@ -25,14 +25,14 @@
 
 ## Slice 3: reopened live connection-loss follow-up
 
-- [ ] T182-S3 Add and observe RED for a connection terminating while an LSQ
+- [X] T182-S3 Add and observe RED for a connection terminating while an LSQ
   result wait still has a live deadline.
-- [ ] T182-S3 Signal connection termination to pending callers while preserving
+- [X] T182-S3 Signal connection termination to pending callers while preserving
   the underlying connection exception.
-- [ ] T182-S3 Diagnose the exact acquired evaluation query that terminates on
+- [X] T182-S3 Diagnose the exact acquired evaluation query that terminates on
   the current mainnet node and implement only the proven minimal recovery.
-- [ ] T182-S3 Verify focused GREEN, revert/restore RED→GREEN, and the full
+- [X] T182-S3 Verify focused GREEN, revert/restore RED→GREEN, and the full
   `./gate.sh`; commit with `Tasks: T182-S3`.
-- [ ] T182-LIVE Parent follow-up: pin an Amaru candidate and produce unsigned
+- [X] T182-LIVE Parent follow-up: pin an Amaru candidate and produce unsigned
   CBOR for the exact colleague request five out of five times, with no
   witness/sign/submit artifacts.

--- a/test/Cardano/Node/Client/N2C/LocalStateQuerySpec.hs
+++ b/test/Cardano/Node/Client/N2C/LocalStateQuerySpec.hs
@@ -18,6 +18,7 @@ import Cardano.Node.Client.N2C.LocalStateQuery (
  )
 import Cardano.Node.Client.N2C.Types (
     ConnectionLost (..),
+    LSQChannel (..),
     LocalStateQueryTimeout (..),
  )
 import Control.Concurrent (myThreadId, threadDelay)
@@ -27,6 +28,7 @@ import Control.Concurrent.STM (
     atomically,
     newEmptyTMVarIO,
     putTMVar,
+    readTVarIO,
     retry,
     takeTMVar,
  )
@@ -36,6 +38,7 @@ import Control.Exception (
     displayException,
     finally,
     fromException,
+    throwIO,
  )
 import Control.Monad (void)
 import Network.TypedProtocol.Stateful.Proofs qualified as Stateful
@@ -53,10 +56,13 @@ import System.Timeout (timeout)
 import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe)
 
 spec :: Spec
-spec = describe "Cardano.Node.Client.N2C.LocalStateQuery" $
+spec = describe "Cardano.Node.Client.N2C.LocalStateQuery" $ do
     it "bounds a stalled acquired query" $ do
         result <- timeout 2_000_000 stalledQueryScenario
         result `shouldBe` Just ()
+    it
+        "wakes a pending query when its connection terminates"
+        terminatingConnectionScenario
 
 stalledQueryScenario :: IO ()
 stalledQueryScenario = do
@@ -132,9 +138,58 @@ stalledQueryScenario = do
 responseTimeout :: Int
 responseTimeout = 600_000
 
+terminatingConnectionScenario :: IO ()
+terminatingConnectionScenario = do
+    ch <- newLSQChannelWithTimeout 1 responseTimeout
+    queryAccepted <- newEmptyTMVarIO
+    let peer =
+            void $
+                Stateful.connect
+                    StateIdle
+                    ( Client.localStateQueryClientPeer $
+                        mkLocalStateQueryClient ch
+                    )
+                    ( localStateQueryServerPeer $
+                        liveStalledServer queryAccepted
+                    )
+        connection =
+            monitorLocalStateQueryConnection ch $ do
+                atomically $ void $ takeTMVar queryAccepted
+                throwIO PeerTerminated
+    withAsync peer $ \_ ->
+        withAsync connection $ \connectionThread ->
+            withAsync
+                ( withAcquiredLSQ ch $ \acquired ->
+                    queryAcquiredLSQ acquired GetChainPoint
+                )
+                $ \queryThread -> do
+                    connectionException <-
+                        waitException "connection" connectionThread
+                    expectTypedException
+                        "connection"
+                        PeerTerminated
+                        connectionException
+                    generation <-
+                        readTVarIO $ lsqLivenessGeneration ch
+                    generation `shouldBe` 1
+                    queryException <-
+                        waitExceptionWithin 500_000 "query" queryThread
+                    expectTypedException
+                        "query"
+                        ConnectionLost
+                        queryException
+
+data PeerTerminated = PeerTerminated
+    deriving stock (Eq, Show)
+
+instance Exception PeerTerminated
+
 waitException :: String -> Async a -> IO SomeException
-waitException label thread = do
-    timedResult <- timeout 1_500_000 $ waitCatch thread
+waitException = waitExceptionWithin 1_500_000
+
+waitExceptionWithin :: Int -> String -> Async a -> IO SomeException
+waitExceptionWithin timeoutMicroseconds label thread = do
+    timedResult <- timeout timeoutMicroseconds $ waitCatch thread
     case timedResult of
         Nothing -> fail $ label <> " did not terminate"
         Just result -> fromAsyncResult result
@@ -171,6 +226,26 @@ stalledServer queryAccepted = LocalStateQueryServer $ pure idle
             { recvMsgQuery = \_ -> do
                 atomically $ putTMVar queryAccepted ()
                 atomically retry
+            , recvMsgReAcquire = \_ -> pure $ SendMsgAcquired acquired
+            , recvMsgRelease = pure idle
+            }
+
+liveStalledServer ::
+    TMVar () -> LocalStateQueryServer block point query IO ()
+liveStalledServer queryAccepted =
+    LocalStateQueryServer $ pure idle
+  where
+    idle =
+        ServerStIdle
+            { recvMsgAcquire = \_ -> pure $ SendMsgAcquired acquired
+            , recvMsgDone = pure ()
+            }
+    acquired =
+        ServerStAcquired
+            { recvMsgQuery = \_ -> do
+                atomically $ putTMVar queryAccepted ()
+                threadDelay 5_000_000
+                fail "query unexpectedly unblocked"
             , recvMsgReAcquire = \_ -> pure $ SendMsgAcquired acquired
             , recvMsgRelease = pure idle
             }


### PR DESCRIPTION
Reopens and closes #182 with the full acceptance proof.

## Fix

- Advance the active LSQ liveness generation when a monitored N2C connection terminates independently.
- Preserve the connection action's original return value or exception.
- Wake pending callers promptly as typed `ConnectionLost` instead of hiding the failure until the 60-second deadline.
- Skip impossible acquired-session release cleanup after connection invalidation.

## Root cause found through the live boundary

The colleague request was not losing a healthy node response. Its long HTTPS Pinata rationale reference was lazily raising `uri: chunk exceeds 64 bytes` on the N2C thread. That killed the connection and was then masked by the v0.1.4 deadline. The metadata cause is fixed separately in `lambdasistemi/amaru-treasury-tx#467`; retry/reconnect was intentionally not added because it would repeat the same deterministic exception.

## Verification

- Deterministic RED: with the implementation reverted, the connection-termination regression left `lsqLivenessGeneration` at 0 instead of 1.
- Restore GREEN: pending caller receives `ConnectionLost`; the connection supervisor retains the original `PeerTerminated` exception.
- Local gate: 167 examples, 0 failures, 1 opt-in pending; format and HLint clean.
- GitHub CI: Build Gate, build, e2e, unit, and lint green.
- Release-shaped Amaru AppImage carrying this commit plus PR #467: exact colleague wizard→`tx-build` pipeline succeeded 5/5 against local mainnet.
- All five produced a 3,210-byte unsigned CBOR and a 13,040-byte report with `VALIDATION OK`.
- Deterministic hashes: intent `bfe27a6d59e90c38d84edba67239a23ab27b8c40a19d89be1da25d8c1343dea1`; CBOR `331a7d102ee5012d0875e7df73b1270e1115ec62400319b7720ad841649b64b3`; report `a2207070d06277e76876d3269f5f29fcdbe7d5dbf41124c684e2eeb7a17518d9`.
- Zero witness, signed, assembled, or submit artifacts.
