### PR TITLE
fix(devnet): stock committee arrangement blocks all governance enactment

### DIFF
--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -361,6 +361,7 @@ test-suite e2e-tests
   other-modules:
     Cardano.Node.Client.ConwayFixtures
     Cardano.Node.Client.E2E.ChainSyncSpec
+    Cardano.Node.Client.E2E.GovernanceEnactmentSpec
     Cardano.Node.Client.E2E.HorizonSpec
     Cardano.Node.Client.E2E.Issue97ReproSpec
     Cardano.Node.Client.E2E.N2CFullSpec
@@ -373,6 +374,8 @@ test-suite e2e-tests
     , base
     , bytestring
     , cardano-crypto-class
+    , cardano-data
+    , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-byron
     , cardano-ledger-conway
@@ -380,6 +383,7 @@ test-suite e2e-tests
     , cardano-node-clients
     , cardano-node-clients:devnet
     , cardano-slotting
+    , cardano-strict-containers
     , chain-follower
     , containers
     , contra-tracer

--- a/e2e-test/Cardano/Node/Client/E2E/Setup.hs
+++ b/e2e-test/Cardano/Node/Client/E2E/Setup.hs
@@ -16,6 +16,12 @@ module Cardano.Node.Client.E2E.Setup (
     genesisSignKey,
     genesisAddr,
 
+    -- * Constitutional committee keys
+    ccColdSignKey,
+    ccHotSignKey,
+    ccColdKeyHash,
+    ccHotCredential,
+
     -- * Key generation
     mkSignKey,
     keyHashFromSignKey,
@@ -96,6 +102,7 @@ import Cardano.Ledger.Keys (
     VKey (..),
     WitVKey (..),
     asWitness,
+    coerceKeyRole,
     hashKey,
     signedDSIGN,
  )
@@ -147,6 +154,43 @@ genesisAddr :: Addr
 genesisAddr =
     enterpriseAddr
         (keyHashFromSignKey genesisSignKey)
+
+{- | Stock constitutional-committee cold signing key.
+Its key hash is the sole member of
+@committee.members@ in @conway-genesis.json@.
+Seed must be exactly 32 bytes.
+-}
+ccColdSignKey :: SignKeyDSIGN Ed25519DSIGN
+ccColdSignKey =
+    mkSignKey
+        "e2e-cc-cold-key-seed-00000000001"
+
+{- | Stock constitutional-committee hot signing key.
+Authorized at runtime via a
+@ConwayAuthCommitteeHotKey@ certificate witnessed
+by 'ccColdSignKey'. Seed must be exactly 32 bytes.
+-}
+ccHotSignKey :: SignKeyDSIGN Ed25519DSIGN
+ccHotSignKey =
+    mkSignKey
+        "e2e-cc-hot-key-seed-000000000001"
+
+{- | Cold key hash of the stock committee member,
+matching @committee.members@ in
+@conway-genesis.json@.
+-}
+ccColdKeyHash :: KeyHash ColdCommitteeRole
+ccColdKeyHash =
+    coerceKeyRole (keyHashFromSignKey ccColdSignKey)
+
+{- | Hot credential of the stock committee member,
+for use in @ConwayAuthCommitteeHotKey@ and
+@CommitteeVoter@.
+-}
+ccHotCredential :: Credential HotCommitteeRole
+ccHotCredential =
+    KeyHashObj
+        (coerceKeyRole (keyHashFromSignKey ccHotSignKey))
 
 {- | Derive an Ed25519 signing key from a 32-byte
 seed. The seed must be exactly 32 bytes.

--- a/e2e-test/genesis/conway-genesis.json
+++ b/e2e-test/genesis/conway-genesis.json
@@ -18,7 +18,7 @@
     "ppGovGroup": 0.75,
     "treasuryWithdrawal": 0.67
   },
-  "committeeMinSize": 7,
+  "committeeMinSize": 1,
   "committeeMaxTermLength": 73,
   "govActionLifetime": 6,
   "govActionDeposit": 50000000000,
@@ -33,6 +33,7 @@
   },
   "committee": {
     "members": {
+      "keyHash-c297a7ed0ea787d621057f2ba9f80b37077e932c46a2d6203cd12201": 1000
     },
     "threshold": 0.67
   },

--- a/specs/190-committee-minsize/plan.md
+++ b/specs/190-committee-minsize/plan.md
@@ -1,0 +1,15 @@
+# Plan — Issue 190: stock devnet committee arrangement
+
+## Tech stack
+
+- Language & harness: Haskell (`cardano-node-clients:devnet`, `e2e-tests`)
+- Ledger: `cardano-ledger-api`/`cardano-ledger-conway`
+- Reference implementation: issue #187's `Governance.hs` (landed on `feat/187-devnet-pv11`, unmerged) already proves the CC-hot-key-authorization + committee-vote pattern live against a real devnet. Port the relevant shape, don't re-derive from scratch.
+
+## Slices
+
+### Slice A — Stock genesis fix + enactment proof
+- Patch `e2e-test/genesis/conway-genesis.json`: one CC committee member (cold credential in `committee.members`, real hot-key authorization at runtime), `committeeMinSize: 7 -> 1`. Enumerate every field touched.
+- Add whatever minimal key-material exports (`Devnet.hs`/`Setup.hs`) a consumer needs to authorize the committee hot key and cast its vote — mirror #187's `Governance.hs` pattern (`ConwayAuthCommitteeHotKey`, `CommitteeVoter`) rather than reinventing it.
+- New E2E test (`test/Cardano/Node/Client/E2E/*Spec.hs`): starts a stock `withDevnet` devnet, proposes a real `ParameterChange` (a benign parameter, not tied to PV11 — e.g. bump `maxTxSize` or similar low-risk param), authorizes + votes yes from DRep and CC, asserts the parameter enacted via queried protocol-parameters within the devnet's normal epoch cadence.
+- This is the whole ticket — single slice, single commit.

--- a/specs/190-committee-minsize/spec.md
+++ b/specs/190-committee-minsize/spec.md
@@ -1,0 +1,31 @@
+# Spec — Issue 190: stock devnet committee arrangement makes governance unenactable
+
+## P1 user story
+
+As a consumer of `withDevnet`, I need governance actions (ParameterChange, HardForkInitiation, etc.) proposed and voted on a fresh stock devnet to actually enact, so I can test version-sensitive and parameter-sensitive behavior without a private per-consumer genesis workaround.
+
+## The defect
+
+Stock `e2e-test/genesis/conway-genesis.json` ships `committeeMinSize: 7` with an empty `committee.members: {}`. Under Conway ratification rules, `committeeAccepted` requires the active committee size to meet `committeeMinSize`; with 0 active members against a minimum of 7, this is permanently unsatisfiable. Any governance action requiring committee acceptance (which includes `ParameterChange` and `HardForkInitiation`) sits through its full lifetime with valid DRep votes and a complete pulser run, and never enacts. The failure is silent: proposal-present, votes-registered, and epoch-advancing all look healthy; only the enacted parameter never changes.
+
+## User stories
+
+- **US1**: A consumer starts a stock `withDevnet` devnet, proposes and votes yes on a `ParameterChange`, and the parameter is enacted within the devnet's normal epoch cadence.
+- **US2**: Existing consumers of `withDevnet` see no other behavior change — this is a genesis-arrangement fix, not an API change.
+
+## Functional requirements
+
+- **FR1**: `e2e-test/genesis/conway-genesis.json` gains one harness-generated constitutional committee member (cold + hot credential) and `committeeMinSize` set to `1` (matching the real committee size).
+- **FR2**: The harness (`Devnet.hs`/`Setup.hs`) exposes whatever key material is needed to construct the committee hot-key authorization certificate and cast a committee vote from a consumer's own governance-transaction code (mirroring the pattern issue #187's `Governance.hs` already proved live).
+- **FR3**: A committed test proves the fix: propose + vote + assert enactment of a real `ParameterChange` on a fresh stock devnet, asserted from queried protocol-parameters — never from logs.
+- **FR4**: Genesis-change discipline: enumerate the exact fields changed in `conway-genesis.json`, assert old→new values, and confirm (e.g. via a diff against upstream field-by-field) that nothing else moved.
+
+## Success criteria
+
+- [ ] A ParameterChange proposed + voted on a fresh `withDevnet` devnet enacts (queried-parameter assertion).
+- [ ] Issue #187's `HardForkInitiation` path (already landed via a per-consumer workaround, `workaround-for=lambdasistemi/cardano-node-clients#190`) has a stock committee capable of accepting it — i.e. the fix generalizes, even though #187 does not need to be re-touched as part of this ticket.
+- [ ] No existing `withDevnet`/`withDevnetConfig` consumer's default (PV10, no governance action) behavior changes.
+
+## Non-goals
+
+- Re-deriving or refactoring #187's already-landed PV11 governance transition code (`Governance.hs`) — this ticket only fixes the genesis arrangement it depends on. #187's workaround note becomes stale/removable once this lands, but deleting it is not in scope here.

--- a/specs/190-committee-minsize/tasks.md
+++ b/specs/190-committee-minsize/tasks.md
@@ -1,0 +1,6 @@
+# Tasks — Issue 190: stock devnet committee arrangement
+
+## Slice A — Stock genesis fix + enactment proof
+- [ ] T190-SA1 Patch `e2e-test/genesis/conway-genesis.json`: one CC committee member, `committeeMinSize: 7 -> 1`, field-by-field enumerated.
+- [ ] T190-SA2 Expose/add key material and cert/vote helpers a consumer needs for CC hot-key authorization + committee voting (mirror #187's `Governance.hs` pattern).
+- [ ] T190-SA3 Add and pass a live E2E test: propose + vote + assert enactment of a real `ParameterChange` on a fresh stock `withDevnet` devnet, via queried protocol-parameters.

--- a/specs/190-committee-minsize/tasks.md
+++ b/specs/190-committee-minsize/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — Issue 190: stock devnet committee arrangement
 
 ## Slice A — Stock genesis fix + enactment proof
-- [ ] T190-SA1 Patch `e2e-test/genesis/conway-genesis.json`: one CC committee member, `committeeMinSize: 7 -> 1`, field-by-field enumerated.
-- [ ] T190-SA2 Expose/add key material and cert/vote helpers a consumer needs for CC hot-key authorization + committee voting (mirror #187's `Governance.hs` pattern).
-- [ ] T190-SA3 Add and pass a live E2E test: propose + vote + assert enactment of a real `ParameterChange` on a fresh stock `withDevnet` devnet, via queried protocol-parameters.
+- [X] T190-SA1 Patch `e2e-test/genesis/conway-genesis.json`: one CC committee member, `committeeMinSize: 7 -> 1`, field-by-field enumerated.
+- [X] T190-SA2 Expose/add key material and cert/vote helpers a consumer needs for CC hot-key authorization + committee voting (mirror #187's `Governance.hs` pattern).
+- [X] T190-SA3 Add and pass a live E2E test: propose + vote + assert enactment of a real `ParameterChange` on a fresh stock `withDevnet` devnet, via queried protocol-parameters.

--- a/test/Cardano/Node/Client/E2E/GovernanceEnactmentSpec.hs
+++ b/test/Cardano/Node/Client/E2E/GovernanceEnactmentSpec.hs
@@ -19,8 +19,8 @@ import Data.Maybe.Strict (StrictMaybe (..))
 import Data.OSet.Strict qualified as OSet
 import Data.Sequence.Strict qualified as StrictSeq
 import Data.Set qualified as Set
-import Numeric.Natural (Natural)
 import Lens.Micro ((&), (.~), (^.))
+import Numeric.Natural (Natural)
 import Test.Hspec (Spec, describe, it, shouldBe)
 
 import Cardano.Ledger.Address (

--- a/test/Cardano/Node/Client/E2E/GovernanceEnactmentSpec.hs
+++ b/test/Cardano/Node/Client/E2E/GovernanceEnactmentSpec.hs
@@ -1,0 +1,312 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+{- |
+Module      : Cardano.Node.Client.E2E.GovernanceEnactmentSpec
+Description : E2E test for stock-devnet governance enactment (issue 190)
+License     : Apache-2.0
+-}
+module Cardano.Node.Client.E2E.GovernanceEnactmentSpec (spec) where
+
+import Control.Concurrent (threadDelay)
+import Control.Exception (SomeException, try)
+import Data.Coerce (coerce)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.Maybe.Strict (StrictMaybe (..))
+import Data.OSet.Strict qualified as OSet
+import Data.Sequence.Strict qualified as StrictSeq
+import Data.Set qualified as Set
+import Numeric.Natural (Natural)
+import Lens.Micro ((&), (.~), (^.))
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+import Cardano.Ledger.Address (
+    AccountAddress (..),
+    AccountId (..),
+ )
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
+import Cardano.Ledger.Api (
+    Anchor (..),
+    AnchorData (..),
+    GovAction (..),
+    GovActionId (..),
+    GovActionIx (..),
+    ProposalProcedure (..),
+    Vote (..),
+    Voter (..),
+    VotingProcedure (..),
+    VotingProcedures (..),
+    certsTxBodyL,
+    coinTxOutL,
+    emptyPParamsUpdate,
+    feeTxBodyL,
+    inputsTxBodyL,
+    mkBasicTx,
+    mkBasicTxBody,
+    mkBasicTxOut,
+    outputsTxBodyL,
+    ppMaxTxExUnitsL,
+    ppuMaxTxExUnitsL,
+    proposalProceduresTxBodyL,
+    txIdTx,
+    txIdTxBody,
+    votingProceduresTxBodyL,
+ )
+import Cardano.Ledger.BaseTypes (
+    Network (..),
+    TxIx (..),
+    textToUrl,
+ )
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway.TxCert (
+    ConwayDelegCert (..),
+    ConwayGovCert (..),
+    ConwayTxCert (..),
+    Delegatee (..),
+ )
+import Cardano.Ledger.Core (hashAnnotated)
+import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.DRep (DRep (..))
+import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
+import Cardano.Ledger.TxIn (TxIn (..))
+import Cardano.Ledger.Val (inject)
+
+import Cardano.Node.Client.E2E.Setup (
+    addKeyWitness,
+    ccColdKeyHash,
+    ccColdSignKey,
+    ccHotCredential,
+    ccHotSignKey,
+    genesisAddr,
+    genesisSignKey,
+    keyHashFromSignKey,
+    withDevnet,
+ )
+import Cardano.Node.Client.N2C.Provider (mkN2CProvider)
+import Cardano.Node.Client.N2C.Submitter (mkN2CSubmitter)
+import Cardano.Node.Client.Provider (
+    Provider (..),
+    queryProtocolParams,
+    queryUTxOs,
+ )
+import Cardano.Node.Client.Submitter (
+    SubmitResult (..),
+    Submitter,
+    submitTx,
+ )
+
+{- | The bumped @maxTxExUnits@ memory the test proposes and
+expects to see enacted. Stock genesis value is 140000000.
+@maxTxExUnits@ is in the network/no-stake-pool group, so a
+@ParameterChange@ touching only it needs no SPO vote (unlike
+@maxTxSize@, which is security-relevant).
+-}
+proposedMaxTxExUnitsMem :: Natural
+proposedMaxTxExUnitsMem = 150_000_000
+
+spec :: Spec
+spec = describe "Governance enactment (stock devnet)" $ do
+    it "enacts a voted ParameterChange on a fresh withDevnet devnet" $
+        withDevnet $ \lsqCh ltxsCh -> do
+            let provider = mkN2CProvider lsqCh
+                submitter = mkN2CSubmitter ltxsCh
+
+            pp0 <- queryProtocolParams provider
+            let ExUnits stockMem _ = pp0 ^. ppMaxTxExUnitsL
+            stockMem `shouldBe` 140_000_000
+
+            proposeAndVote provider submitter
+            waitForEnactment provider (90 :: Int)
+  where
+    waitForEnactment :: Provider IO -> Int -> IO ()
+    waitForEnactment _ 0 =
+        error
+            "waitForEnactment: timed out waiting for \
+            \maxTxExUnits ParameterChange enactment"
+    waitForEnactment provider atts = do
+        threadDelay 5_000_000
+        ePP <- try @SomeException (queryProtocolParams provider)
+        case ePP of
+            Right pp -> do
+                let ExUnits mem _ = pp ^. ppMaxTxExUnitsL
+                putStrLn
+                    ( "waitForEnactment poll ["
+                        <> show atts
+                        <> "]: maxTxExUnitsMem="
+                        <> show mem
+                    )
+                if mem == proposedMaxTxExUnitsMem
+                    then pure ()
+                    else waitForEnactment provider (atts - 1)
+            Left err -> do
+                putStrLn ("waitForEnactment poll err: " <> show err)
+                waitForEnactment provider (atts - 1)
+
+{- | Register the genesis stake credential, register and
+self-delegate a DRep, authorize the stock committee hot key,
+propose a benign @maxTxExUnits@ bump, and cast DRep + CC yes
+votes. Mirrors the shape issue #187 proved live.
+-}
+proposeAndVote ::
+    Provider IO ->
+    Submitter IO ->
+    IO ()
+proposeAndVote provider submitter = do
+    let genesisKh = keyHashFromSignKey genesisSignKey
+        khCred :: forall r. Credential r
+        khCred = KeyHashObj (coerce genesisKh)
+        ccColdCred :: Credential ColdCommitteeRole
+        ccColdCred = KeyHashObj ccColdKeyHash
+        ccHotCred :: Credential HotCommitteeRole
+        ccHotCred = ccHotCredential
+        -- The single stake pool registered in the stock
+        -- shelley-genesis.json (@staking.pools@).
+        stockPoolKh :: KeyHash StakePool
+        stockPoolKh =
+            KeyHash
+                "e797e39f0782f92e18b2b46b30244d5d5887661149d5b44d36237c1a"
+
+    utxos <- queryUTxOs provider genesisAddr
+    case utxos of
+        [] -> error "proposeAndVote: no UTxOs at genesisAddr"
+        (initTxIn, initTxOut) : _ -> do
+            let initCoin = initTxOut ^. coinTxOutL
+                fee = Coin 10_000_000
+                drepDeposit = Coin 500_000_000
+                stakeDeposit = Coin 400_000
+
+                stakeRegCert =
+                    ConwayTxCertDeleg $
+                        ConwayRegCert khCred (SJust stakeDeposit)
+                drepCert =
+                    ConwayTxCertGov $
+                        ConwayRegDRep khCred drepDeposit SNothing
+                delegCert =
+                    ConwayTxCertDeleg $
+                        ConwayDelegCert
+                            khCred
+                            (DelegStakeVote stockPoolKh (DRepCredential khCred))
+                ccAuthCert =
+                    ConwayTxCertGov $
+                        ConwayAuthCommitteeHotKey ccColdCred ccHotCred
+
+                change1Coin =
+                    Coin
+                        ( unCoin initCoin
+                            - unCoin fee
+                            - unCoin drepDeposit
+                            - unCoin stakeDeposit
+                        )
+                txBody1 =
+                    mkBasicTxBody
+                        & inputsTxBodyL .~ Set.singleton initTxIn
+                        & outputsTxBodyL
+                            .~ StrictSeq.singleton
+                                (mkBasicTxOut genesisAddr (inject change1Coin))
+                        & feeTxBodyL .~ fee
+                        & certsTxBodyL
+                            .~ StrictSeq.fromList
+                                [ stakeRegCert
+                                , drepCert
+                                , delegCert
+                                , ccAuthCert
+                                ]
+                tx1 =
+                    addKeyWitness genesisSignKey $
+                        addKeyWitness ccColdSignKey $
+                            mkBasicTx txBody1
+
+            res1 <- submitTx submitter tx1
+            case res1 of
+                Submitted _ -> pure ()
+                Rejected err ->
+                    error $
+                        "Tx 1 (registration + CC authorization) rejected: "
+                            <> show err
+            threadDelay 2_000_000
+
+            -- Tx 2: propose the maxTxExUnits memory bump
+            let ppu =
+                    emptyPParamsUpdate @ConwayEra
+                        & ppuMaxTxExUnitsL
+                            .~ SJust (ExUnits proposedMaxTxExUnitsMem 10_000_000_000)
+                propDeposit = Coin 50_000_000_000
+                rewardAcnt = AccountAddress Testnet (AccountId khCred)
+                dummyUrl =
+                    fromMaybe (error "textToUrl failed") $
+                        textToUrl 128 "https://example.com"
+                dummyAnchor =
+                    Anchor dummyUrl (hashAnnotated (AnchorData "dummy"))
+                proposal =
+                    ProposalProcedure
+                        propDeposit
+                        rewardAcnt
+                        (ParameterChange SNothing ppu SNothing)
+                        dummyAnchor
+                tx2In = TxIn (txIdTx tx1) (TxIx 0)
+                change2Coin =
+                    Coin
+                        ( unCoin change1Coin
+                            - unCoin fee
+                            - unCoin propDeposit
+                        )
+                txBody2 =
+                    mkBasicTxBody
+                        & inputsTxBodyL .~ Set.singleton tx2In
+                        & outputsTxBodyL
+                            .~ StrictSeq.singleton
+                                (mkBasicTxOut genesisAddr (inject change2Coin))
+                        & feeTxBodyL .~ fee
+                        & proposalProceduresTxBodyL
+                            .~ OSet.fromList [proposal]
+                tx2 = addKeyWitness genesisSignKey (mkBasicTx txBody2)
+
+            res2 <- submitTx submitter tx2
+            case res2 of
+                Submitted _ -> pure ()
+                Rejected err ->
+                    error $
+                        "Tx 2 (proposal) rejected: " <> show err
+            threadDelay 2_000_000
+
+            -- Tx 3: DRep + CC yes votes
+            let tx3In = TxIn (txIdTx tx2) (TxIx 0)
+                change3Coin = Coin (unCoin change2Coin - unCoin fee)
+                govId =
+                    GovActionId (txIdTxBody txBody2) (GovActionIx 0)
+                voterMap =
+                    Map.fromList
+                        [
+                            ( DRepVoter khCred
+                            , Map.fromList [(govId, voteYes)]
+                            )
+                        ,
+                            ( CommitteeVoter ccHotCred
+                            , Map.fromList [(govId, voteYes)]
+                            )
+                        ]
+                voteYes = VotingProcedure VoteYes SNothing
+                txBody3 =
+                    mkBasicTxBody
+                        & inputsTxBodyL .~ Set.singleton tx3In
+                        & outputsTxBodyL
+                            .~ StrictSeq.singleton
+                                (mkBasicTxOut genesisAddr (inject change3Coin))
+                        & feeTxBodyL .~ fee
+                        & votingProceduresTxBodyL
+                            .~ VotingProcedures voterMap
+                tx3 =
+                    addKeyWitness genesisSignKey $
+                        addKeyWitness ccHotSignKey $
+                            mkBasicTx txBody3
+
+            res3 <- submitTx submitter tx3
+            case res3 of
+                Submitted _ -> pure ()
+                Rejected err ->
+                    error $
+                        "Tx 3 (votes) rejected: " <> show err

--- a/test/main.hs
+++ b/test/main.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import Test.Hspec (hspec)
 
 import Cardano.Node.Client.E2E.ChainSyncSpec qualified as ChainSyncSpec
+import Cardano.Node.Client.E2E.GovernanceEnactmentSpec qualified as GovernanceEnactmentSpec
 import Cardano.Node.Client.E2E.HorizonSpec qualified as HorizonSpec
 import Cardano.Node.Client.E2E.Issue97ReproSpec qualified as Issue97ReproSpec
 import Cardano.Node.Client.E2E.N2CFullSpec qualified as N2CFullSpec
@@ -17,3 +18,4 @@ main = hspec $ do
     UTxOIndexerReconnectSpec.spec
     HorizonSpec.spec
     Issue97ReproSpec.spec
+    GovernanceEnactmentSpec.spec


### PR DESCRIPTION
Resolves #190

Stock `e2e-test/genesis/conway-genesis.json` ships `committeeMinSize: 7` with an empty committee, making `committeeAccepted` permanently unsatisfiable — no governance action can ever enact on a fresh `withDevnet` devnet.