### PR TITLE
Acquire Globals with the N2C provider snapshot

### DIFF
--- a/cardano-node-clients.cabal
+++ b/cardano-node-clients.cabal
@@ -388,11 +388,13 @@ test-suite e2e-tests
     , bytestring
     , cardano-crypto-class
     , cardano-data
+    , cardano-ledger-allegra
     , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-byron
     , cardano-ledger-conway
     , cardano-ledger-core
+    , cardano-ledger-shelley
     , cardano-node-clients
     , cardano-node-clients:devnet
     , cardano-slotting
@@ -406,6 +408,8 @@ test-suite e2e-tests
     , lens
     , microlens
     , network
+    , ouroboros-consensus
+    , ouroboros-consensus:cardano
     , ouroboros-network:api
     , rocksdb-kv-transactions:kv-transactions
     , stm

--- a/lib/Cardano/Node/Client/N2C/Provider.hs
+++ b/lib/Cardano/Node/Client/N2C/Provider.hs
@@ -17,8 +17,10 @@ in Conway) results in a runtime error.
 module Cardano.Node.Client.N2C.Provider (
     -- * Construction
     mkN2CProvider,
+    withAcquiredN2CProviderAndGlobals,
 ) where
 
+import Control.Monad (unless)
 import Data.Bifunctor (first)
 import Data.ByteString.Lazy qualified as LBS
 import Data.Coerce (coerce)
@@ -40,6 +42,7 @@ import Control.Monad.Trans.Except (runExcept)
 import Lens.Micro ((^.))
 
 import Cardano.Ledger.Address (AccountAddress, Addr)
+import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (
     evalTxExUnits,
  )
@@ -49,11 +52,13 @@ import Cardano.Ledger.Api.Tx.Body (
     referenceInputsTxBodyL,
  )
 import Cardano.Ledger.Api.Tx.Out (TxOut, addrTxOutL)
+import Cardano.Ledger.BaseTypes (Globals, systemStart)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core (PParams, bodyTxL)
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.DRep (DRep)
+import Cardano.Ledger.Genesis (NoGenesis (..))
 import Cardano.Ledger.Keys (KeyRole (Staking))
 import Cardano.Ledger.State (
     ChainAccountState,
@@ -95,6 +100,13 @@ import Ouroboros.Consensus.HardFork.History.Qry (
 import Ouroboros.Consensus.Ledger.Query (
     Query (BlockQuery, GetChainPoint, GetSystemStart),
  )
+import Ouroboros.Consensus.Shelley.Ledger.Config (
+    getCompactGenesis,
+ )
+import Ouroboros.Consensus.Shelley.Ledger.Ledger (
+    ShelleyLedgerConfig (shelleyLedgerGlobals),
+    mkShelleyLedgerConfig,
+ )
 import Ouroboros.Consensus.Shelley.Ledger.Query (
     pattern GetAccountState,
     pattern GetCBOR,
@@ -102,6 +114,7 @@ import Ouroboros.Consensus.Shelley.Ledger.Query (
     pattern GetEpochNo,
     pattern GetFilteredDelegationsAndRewardAccounts,
     pattern GetFilteredVoteDelegatees,
+    pattern GetGenesisConfig,
     pattern GetGovState,
     pattern GetUTxOByAddress,
     pattern GetUTxOByTxIn,
@@ -148,56 +161,143 @@ mkN2CProvider ::
     LSQChannel ->
     Provider IO
 mkN2CProvider ch =
+    mkProviderOver $ \use ->
+        withAcquiredLSQ ch $ \acquired ->
+            use (queryAcquiredLSQ acquired)
+
+{- | Build a 'Provider IO' over one already acquired
+LSQ snapshot. Every field, including 'withAcquired'
+and 'queryUpperBoundSlot', reuses the given runner
+and never acquires again.
+-}
+mkAcquiredN2CProvider ::
+    (forall result. Query Block result -> IO result) ->
+    Provider IO
+mkAcquiredN2CProvider runQuery =
+    mkProviderOver $ \use -> use runQuery
+
+{- | Shared provider body. The argument decides how a
+query runner is obtained for each public operation:
+'mkN2CProvider' acquires per operation, while
+'mkAcquiredN2CProvider' reuses one acquired snapshot.
+-}
+mkProviderOver ::
+    ( forall a.
+      ((forall result. Query Block result -> IO result) -> IO a) ->
+      IO a
+    ) ->
+    Provider IO
+mkProviderOver withRunQuery =
     Provider
-        { withAcquired = withAcquiredN2C
+        { withAcquired = withHandle
         , queryProtocolParams =
-            withAcquiredN2C queryProtocolParamsH
+            withHandle queryProtocolParamsH
         , queryLedgerSnapshot =
-            withAcquiredN2C queryLedgerSnapshotH
+            withHandle queryLedgerSnapshotH
         , queryStakeRewards = \credentials ->
-            withAcquiredN2C $ \handle ->
+            withHandle $ \handle ->
                 queryStakeRewardsH handle credentials
         , queryRewardAccounts = \accounts ->
-            withAcquiredN2C $ \handle ->
+            withHandle $ \handle ->
                 queryRewardAccountsH handle accounts
         , queryVoteDelegatees = \credentials ->
-            withAcquiredN2C $ \handle ->
+            withHandle $ \handle ->
                 queryVoteDelegateesH handle credentials
         , queryTreasury =
-            withAcquiredN2C queryTreasuryH
+            withHandle queryTreasuryH
         , queryGovernanceState =
-            withAcquiredN2C queryGovernanceStateH
+            withHandle queryGovernanceStateH
         , queryUTxOs = \addr ->
-            withAcquiredN2C $ \handle ->
+            withHandle $ \handle ->
                 queryUTxOsH handle addr
         , queryUTxOByTxIn = \txins ->
-            withAcquiredN2C $ \handle ->
+            withHandle $ \handle ->
                 queryUTxOByTxInH handle txins
         , evaluateTx = \tx ->
-            withAcquiredN2C $ \handle ->
+            withHandle $ \handle ->
                 evaluateTxH handle tx
         , posixMsToSlot = \ms ->
-            withAcquiredN2C $ \handle ->
+            withHandle $ \handle ->
                 posixMsToSlotH handle ms
         , posixMsCeilSlot = \ms ->
-            withAcquiredN2C $ \handle ->
+            withHandle $ \handle ->
                 posixMsCeilSlotH handle ms
         , queryUpperBoundSlot = \choice ->
-            withAcquiredLSQ ch $ \acquired ->
-                let runQuery :: forall result. Query Block result -> IO result
-                    runQuery = queryAcquiredLSQ acquired
-                 in queryUpperBoundSlotN2C runQuery choice
+            withRunQuery $ \runQuery ->
+                queryUpperBoundSlotN2C runQuery choice
         }
   where
-    withAcquiredN2C ::
+    withHandle ::
         forall a.
         (QueryHandle IO -> IO a) ->
         IO a
-    withAcquiredN2C callback =
-        withAcquiredLSQ ch $ \acquired ->
-            callback $
-                mkN2CQueryHandle $
-                    queryAcquiredLSQ acquired
+    withHandle callback =
+        withRunQuery $
+            callback . mkN2CQueryHandle
+
+{- | Acquire one LSQ snapshot, construct the ledger
+'Globals' from that same snapshot, and run a callback
+with both the 'Globals' and a 'Provider IO' bound to
+the snapshot.
+
+The node answers the current-Conway genesis
+configuration, the top-level system start, and the
+hard-fork interpreter inside one acquisition, so the
+builder inputs, time translation, and any ledger-native
+pre-flight share one provenance. Neither value is
+cached: a later operation asks for a new callback and
+coherently refreshes all of it.
+
+Both values are owned by the callback for its dynamic
+extent and must not escape it — holding them holds the
+LSQ acquisition. Submission and settlement belong
+outside the callback.
+
+Acquisition loss, query decoding failure, an era other
+than current Conway, a past-horizon translation, and a
+system start that disagrees with the queried genesis
+all stay visible; none is replaced by a synthetic value.
+-}
+withAcquiredN2CProviderAndGlobals ::
+    -- | LocalStateQuery channel to the Cardano node
+    LSQChannel ->
+    -- | Callback owning the snapshot 'Globals' and provider
+    (Globals -> Provider IO -> IO a) ->
+    IO a
+withAcquiredN2CProviderAndGlobals ch callback =
+    withAcquiredLSQ ch $ \acquired -> do
+        let runQuery :: forall result. Query Block result -> IO result
+            runQuery = queryAcquiredLSQ acquired
+        compactGenesisResult <-
+            runQuery $
+                BlockQuery $
+                    QueryIfCurrentConway
+                        GetGenesisConfig
+        compactGenesis <-
+            expectConway
+                "withAcquiredN2CProviderAndGlobals/genesis"
+                compactGenesisResult
+        queriedSystemStart <-
+            runQuery GetSystemStart
+        interpreter <-
+            runQuery $
+                BlockQuery $
+                    QueryHardFork GetInterpreter
+        let ledgerConfig :: ShelleyLedgerConfig AllegraEra
+            ledgerConfig =
+                mkShelleyLedgerConfig
+                    (getCompactGenesis compactGenesis)
+                    NoGenesis
+                    (interpreterToEpochInfo interpreter)
+            globals =
+                shelleyLedgerGlobals ledgerConfig
+            provider =
+                mkAcquiredN2CProvider runQuery
+        unless (systemStart globals == queriedSystemStart) $
+            error
+                "withAcquiredN2CProviderAndGlobals: queried \
+                \system start disagrees with genesis"
+        callback globals provider
 
 mkN2CQueryHandle ::
     (forall result. Query Block result -> IO result) ->

--- a/test/Cardano/Node/Client/E2E/ProviderSpec.hs
+++ b/test/Cardano/Node/Client/E2E/ProviderSpec.hs
@@ -8,13 +8,29 @@ License     : Apache-2.0
 -}
 module Cardano.Node.Client.E2E.ProviderSpec (spec) where
 
+import Control.Concurrent (threadDelay)
 import Control.Exception qualified as Exception
 import Control.Monad (void)
+import Data.Aeson qualified as Aeson
+import Data.Bifunctor (first)
+import Data.ByteString qualified as BS
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import Data.Word (Word64, Word8)
-import Lens.Micro ((^.))
+import Lens.Micro ((&), (.~), (^.))
+import System.Directory (
+    copyFile,
+    createDirectoryIfMissing,
+    doesDirectoryExist,
+    getPermissions,
+    listDirectory,
+    setOwnerWritable,
+    setPermissions,
+ )
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
 import System.Timeout (timeout)
 import Test.Hspec (
     Spec,
@@ -27,11 +43,76 @@ import Test.Hspec (
  )
 
 import Cardano.Ledger.Address (AccountAddress)
+import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.Api (
+    inputsTxBodyL,
+    mkBasicTx,
+    mkBasicTxBody,
+ )
 import Cardano.Ledger.Api.PParams (ppMaxTxSizeL)
+import Cardano.Ledger.BaseTypes (Globals (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.DRep (DRep)
+import Cardano.Ledger.Genesis (NoGenesis (..))
 import Cardano.Ledger.Keys (KeyRole (Staking))
+import Cardano.Ledger.Shelley.Genesis (
+    ShelleyGenesis,
+    mkShelleyGlobals,
+ )
+import Cardano.Slotting.EpochInfo.API (
+    EpochInfo (..),
+    epochInfoEpoch,
+    epochInfoFirst,
+    epochInfoSize,
+    epochInfoSlotLength,
+    epochInfoSlotToRelativeTime,
+ )
+import Cardano.Slotting.Slot (EpochSize (..))
+import Cardano.Slotting.Time (
+    RelativeTime (..),
+    SlotLength,
+    SystemStart (..),
+    getSlotLength,
+    mkSlotLength,
+    toRelativeTime,
+ )
+
+import Ouroboros.Consensus.Cardano.Block (
+    CardanoEras,
+    StandardCrypto,
+    pattern QueryIfCurrentConway,
+ )
+import Ouroboros.Consensus.HardFork.Combinator.Ledger.Query (
+    QueryHardFork (GetInterpreter),
+    pattern QueryHardFork,
+ )
+import Ouroboros.Consensus.HardFork.History.EpochInfo (
+    interpreterToEpochInfo,
+ )
+import Ouroboros.Consensus.HardFork.History.Qry (
+    Interpreter,
+    Qry,
+    epochToSize,
+    epochToSlot',
+    interpretQuery,
+    slotToEpoch',
+    slotToSlotLength,
+    slotToWallclock,
+ )
+import Ouroboros.Consensus.Ledger.Query (
+    Query (BlockQuery, GetSystemStart),
+ )
+import Ouroboros.Consensus.Shelley.Ledger.Config (
+    getCompactGenesis,
+ )
+import Ouroboros.Consensus.Shelley.Ledger.Ledger (
+    ShelleyLedgerConfig (shelleyLedgerGlobals),
+    mkShelleyLedgerConfig,
+ )
+import Ouroboros.Consensus.Shelley.Ledger.Query (
+    pattern GetGenesisConfig,
+ )
 
 import Cardano.Node.Client.Address (
     rewardAccountCredential,
@@ -42,11 +123,19 @@ import Cardano.Node.Client.ConwayFixtures (
  )
 import Cardano.Node.Client.E2E.Setup (
     genesisAddr,
+    genesisDir,
     withDevnet,
+    withDevnetFromGenesis,
+ )
+import Cardano.Node.Client.N2C.LocalStateQuery (
+    queryAcquiredLSQ,
+    withAcquiredLSQ,
  )
 import Cardano.Node.Client.N2C.Provider (
     mkN2CProvider,
+    withAcquiredN2CProviderAndGlobals,
  )
+import Cardano.Node.Client.N2C.Types (LSQChannel)
 import Cardano.Node.Client.Provider (
     EpochNo (..),
     LedgerSnapshot (..),
@@ -62,11 +151,136 @@ import Cardano.Node.Client.Provider (
     queryUTxOsAtH,
     queryVoteDelegateesH,
  )
+import Cardano.Node.Client.Validity (ValidityChoice (AutoLongest))
 
 spec :: Spec
-spec =
+spec = do
+    -- The devnet launcher prepares a single fixed temporary
+    -- directory, so a devnet started from a modified genesis
+    -- cannot be nested inside the shared bracket. The
+    -- era-mismatch and bounded-offline examples therefore live
+    -- outside it, in 'ownDevnetSpec'.
+    sharedDevnetSpec
+    ownDevnetSpec
+
+sharedDevnetSpec :: Spec
+sharedDevnetSpec =
     around withDevnet' $
         describe "Provider.N2C" $ do
+            it "acquires real Globals and provider in one LSQ snapshot" $
+                \(lsq, _) -> do
+                    (rawGenesis, rawStart, rawInterpreter) <-
+                        expectWithin "independent raw acquisition" $
+                            independentRawSnapshot lsq
+                    let expectedGlobals =
+                            mkShelleyGlobals
+                                rawGenesis
+                                (independentEpochInfo rawInterpreter)
+                        canonicalGlobals =
+                            canonicalGlobalsFrom
+                                rawGenesis
+                                rawInterpreter
+                    expectWithin "withAcquiredN2CProviderAndGlobals" $
+                        withAcquiredN2CProviderAndGlobals lsq $
+                            \globals provider -> do
+                                assertGlobalsScalars
+                                    globals
+                                    expectedGlobals
+                                assertGlobalsScalars
+                                    globals
+                                    canonicalGlobals
+                                systemStart globals
+                                    `shouldBe` rawStart
+                                snapshot <-
+                                    queryLedgerSnapshot provider
+                                assertEpochInfoAgrees
+                                    (epochInfo globals)
+                                    (epochInfo expectedGlobals)
+                                    (ledgerTipSlot snapshot)
+                                assertDevnetCoordinate
+                                    globals
+                                    snapshot
+                                assertSnapshotProvider provider
+
+            it "keeps Globals and provider stable for the acquired callback lifetime" $
+                \(lsq, _) ->
+                    expectWithin "acquired callback lifetime" $
+                        withAcquiredN2CProviderAndGlobals lsq $
+                            \globals provider -> do
+                                (firstEra, utxosAt) <-
+                                    withAcquired provider $ \handle -> do
+                                        ledger <-
+                                            queryLedgerSnapshotH handle
+                                        utxos <-
+                                            queryUTxOsAtH
+                                                handle
+                                                (Set.singleton genesisAddr)
+                                        pure (ledgerCurrentEra ledger, utxos)
+                                (maxTxSize, treasury) <-
+                                    withAcquired provider $ \handle -> do
+                                        pp <-
+                                            queryProtocolParamsH handle
+                                        treasuryValue <-
+                                            queryTreasuryH handle
+                                        pure
+                                            ( pp ^. ppMaxTxSizeL
+                                            , treasuryValue
+                                            )
+                                snapshot <-
+                                    queryLedgerSnapshot provider
+                                firstEra
+                                    `shouldSatisfy` T.isInfixOf "Conway"
+                                ledgerCurrentEra snapshot
+                                    `shouldBe` firstEra
+                                Map.findWithDefault
+                                    []
+                                    genesisAddr
+                                    utxosAt
+                                    `shouldSatisfy` (not . null)
+                                maxTxSize
+                                    `shouldSatisfy` (> 0)
+                                treasury
+                                    `shouldSatisfy` (>= Coin 0)
+                                -- The one callback 'Globals' is still the
+                                -- coordinate source after several handle
+                                -- groups; no replacement value was needed.
+                                assertDevnetCoordinate globals snapshot
+                                assertSnapshotProvider provider
+
+            it "does not infer system start from current time or a reconstructed timestamp" $
+                \(lsq, _) -> do
+                    (_, rawStart, _) <-
+                        expectWithin "independent raw acquisition" $
+                            independentRawSnapshot lsq
+                    firstStart <-
+                        expectWithin "first acquisition" $
+                            withAcquiredN2CProviderAndGlobals lsq $
+                                \globals _provider ->
+                                    pure (systemStart globals)
+                    threadDelay 2000000
+                    secondStart <-
+                        expectWithin "second acquisition" $
+                            withAcquiredN2CProviderAndGlobals lsq $
+                                \globals _provider ->
+                                    pure (systemStart globals)
+                    firstStart `shouldBe` rawStart
+                    secondStart `shouldBe` rawStart
+                    firstStart `shouldBe` secondStart
+                    firstStart
+                        `shouldSatisfy` (/= posixEpochStart)
+                    firstStart
+                        `shouldSatisfy` (/= forbiddenReconstructedStart)
+                    secondStart
+                        `shouldSatisfy` (/= forbiddenReconstructedStart)
+                    fixture <- syntheticDevnetGlobalsFixture
+                    systemStart fixture
+                        `shouldBe` syntheticSystemStart
+                            syntheticDevnetCoordinate
+                    implementationSource <-
+                        BS.readFile
+                            "lib/Cardano/Node/Client/N2C/Provider.hs"
+                    assertNoClockProvenance implementationSource
+
             it "queryProtocolParams returns valid PParams" $
                 \(lsq, _) -> do
                     let provider =
@@ -307,6 +521,56 @@ spec =
     withDevnet' action =
         withDevnet $ curry action
 
+{- | Examples that must not share the devnet bracket: one starts
+its own pre-Conway devnet, the other is entirely offline.
+-}
+ownDevnetSpec :: Spec
+ownDevnetSpec =
+    describe "Provider.N2C acquisition provenance" $ do
+        it "exposes current-era and interpreter horizon failures" $ do
+            fixture <- syntheticDevnetGlobalsFixture
+            epochInfoSlotToRelativeTime
+                (epochInfo fixture)
+                (SlotNo 200)
+                `shouldSatisfy` isHorizonFailure
+            sourceDir <- genesisDir
+            withSystemTempDirectory "pre-conway-genesis" $ \tmpDir -> do
+                let genesisCopy = tmpDir </> "genesis"
+                copyGenesisTree sourceDir genesisCopy
+                delayConwayHardFork genesisCopy
+                outcome <-
+                    expectWithin "pre-Conway acquisition" $
+                        withDevnetFromGenesis genesisCopy $
+                            \lsq _ ->
+                                Exception.try @Exception.ErrorCall $
+                                    withAcquiredN2CProviderAndGlobals
+                                        lsq
+                                        ( \globals _provider ->
+                                            void $
+                                                Exception.evaluate
+                                                    (systemStart globals)
+                                        )
+                eraMismatchReported outcome
+                    `shouldBe` True
+
+        it "uses one explicitly synthetic coordinate in bounded offline checks" $ do
+            fixture <- syntheticDevnetGlobalsFixture
+            let coordinate = syntheticDevnetCoordinate
+                offline = syntheticOfflineProvider coordinate
+            assertSyntheticCoordinateIdentity coordinate fixture offline
+            -- The one fixture 'Globals' reaches both the mock
+            -- builder and the mock guard through one callback.
+            (builderGlobals, guardGlobals) <-
+                withSyntheticSnapshot fixture offline $
+                    \globals provider -> do
+                        built <-
+                            mockBuilderStep globals provider
+                        guarded <-
+                            mockGuardStep globals
+                        pure (built, guarded)
+            assertGlobalsScalars builderGlobals guardGlobals
+            assertGlobalsScalars builderGlobals fixture
+
 sampleAccounts :: Word8 -> Word8 -> Set.Set AccountAddress
 sampleAccounts keyAccount scriptAccount =
     Set.fromList
@@ -372,6 +636,732 @@ firstTxInsAt addr utxosAt =
                     addr
                     utxosAt
             )
+
+{- | Query compact genesis, system start, and the hard-fork
+interpreter through a test-owned acquisition, independent of
+the provider under test.
+-}
+independentRawSnapshot ::
+    LSQChannel ->
+    IO
+        ( ShelleyGenesis
+        , SystemStart
+        , Interpreter (CardanoEras StandardCrypto)
+        )
+independentRawSnapshot lsq =
+    withAcquiredLSQ lsq $ \acquired -> do
+        genesisResult <-
+            queryAcquiredLSQ acquired $
+                BlockQuery $
+                    QueryIfCurrentConway GetGenesisConfig
+        compactGenesis <-
+            case genesisResult of
+                Right value ->
+                    pure value
+                Left _mismatch ->
+                    fail
+                        "independent genesis query: node not in Conway"
+        start <-
+            queryAcquiredLSQ acquired GetSystemStart
+        interpreter <-
+            queryAcquiredLSQ acquired $
+                BlockQuery $
+                    QueryHardFork GetInterpreter
+        pure
+            ( getCompactGenesis compactGenesis
+            , start
+            , interpreter
+            )
+
+{- | Build an 'EpochInfo' straight from the queried interpreter,
+without the consensus ledger-config path the implementation uses.
+-}
+independentEpochInfo ::
+    Interpreter xs ->
+    EpochInfo (Either T.Text)
+independentEpochInfo interpreter =
+    EpochInfo
+        { epochInfoSize_ = runQry . epochToSize
+        , epochInfoFirst_ = runQry . epochToSlot'
+        , epochInfoEpoch_ = \slot ->
+            fst <$> runQry (slotToEpoch' slot)
+        , epochInfoSlotToRelativeTime_ = \slot ->
+            fst <$> runQry (slotToWallclock slot)
+        , epochInfoSlotLength_ = runQry . slotToSlotLength
+        }
+  where
+    runQry :: Qry a -> Either T.Text a
+    runQry =
+        first (T.pack . show)
+            . interpretQuery interpreter
+
+{- | Construct 'Globals' through the pinned consensus canonical
+path, from independently queried values.
+-}
+canonicalGlobalsFrom ::
+    ShelleyGenesis ->
+    Interpreter (CardanoEras StandardCrypto) ->
+    Globals
+canonicalGlobalsFrom genesis interpreter =
+    shelleyLedgerGlobals ledgerConfig
+  where
+    ledgerConfig :: ShelleyLedgerConfig AllegraEra
+    ledgerConfig =
+        mkShelleyLedgerConfig
+            genesis
+            NoGenesis
+            (interpreterToEpochInfo interpreter)
+
+-- | Compare the ten scalar 'Globals' fields.
+assertGlobalsScalars :: Globals -> Globals -> IO ()
+assertGlobalsScalars observed expected = do
+    slotsPerKESPeriod observed
+        `shouldBe` slotsPerKESPeriod expected
+    stabilityWindow observed
+        `shouldBe` stabilityWindow expected
+    randomnessStabilisationWindow observed
+        `shouldBe` randomnessStabilisationWindow expected
+    securityParameter observed
+        `shouldBe` securityParameter expected
+    maxKESEvo observed
+        `shouldBe` maxKESEvo expected
+    quorum observed
+        `shouldBe` quorum expected
+    maxLovelaceSupply observed
+        `shouldBe` maxLovelaceSupply expected
+    activeSlotCoeff observed
+        `shouldBe` activeSlotCoeff expected
+    networkId observed
+        `shouldBe` networkId expected
+    systemStart observed
+        `shouldBe` systemStart expected
+
+{- | Compare the eleventh field behaviourally: 'EpochInfo' is a
+record of functions and has no 'Eq' instance.
+-}
+assertEpochInfoAgrees ::
+    EpochInfo (Either T.Text) ->
+    EpochInfo (Either T.Text) ->
+    SlotNo ->
+    IO ()
+assertEpochInfoAgrees observed expected tipSlot = do
+    mapM_ compareSlot [SlotNo 0, SlotNo 1, tipSlot]
+    mapM_ compareEpoch [EpochNo 0, EpochNo 1]
+    -- Whether the devnet tip has already passed epoch 1 depends on
+    -- timing, so the paired-failure branch above is not guaranteed
+    -- to be exercised by it. This query is past any interpreter
+    -- horizon the node can hold, so both real paths must expose a
+    -- 'PastHorizon' failure on every run.
+    compareSlot farBeyondHorizon
+    compareEpoch farBeyondHorizonEpoch
+    epochInfoEpoch observed farBeyondHorizon
+        `shouldSatisfy` isPastHorizonFailure
+    epochInfoSize observed farBeyondHorizonEpoch
+        `shouldSatisfy` isPastHorizonFailure
+  where
+    farBeyondHorizon = SlotNo 1000000000
+    farBeyondHorizonEpoch = EpochNo 1000000
+    isPastHorizonFailure :: forall a. Either T.Text a -> Bool
+    isPastHorizonFailure (Left message) = isPastHorizon message
+    isPastHorizonFailure _ = False
+    -- Successful results must agree exactly. A past-horizon
+    -- payload embeds the call stack of whichever construction
+    -- raised it, so paired failures are compared on the pinned
+    -- 'PastHorizon' constructor marker only — the differing
+    -- call-stack detail is ignored, but the failure class is
+    -- still proven, and a mixed success/failure pair fails.
+    sameOutcome ::
+        forall a.
+        (Eq a, Show a) =>
+        Either T.Text a ->
+        Either T.Text a ->
+        IO ()
+    sameOutcome observedResult expectedResult =
+        case (observedResult, expectedResult) of
+            (Right observedValue, Right expectedValue) ->
+                observedValue `shouldBe` expectedValue
+            (Left observedError, Left expectedError) -> do
+                isPastHorizon observedError
+                    `shouldBe` True
+                isPastHorizon expectedError
+                    `shouldBe` True
+            (Left observedError, Right expectedValue) ->
+                expectationFailure $
+                    "callback EpochInfo failed where the independent \
+                    \EpochInfo returned "
+                        <> show expectedValue
+                        <> ": "
+                        <> T.unpack observedError
+            (Right observedValue, Left expectedError) ->
+                expectationFailure $
+                    "callback EpochInfo returned "
+                        <> show observedValue
+                        <> " where the independent EpochInfo failed: "
+                        <> T.unpack expectedError
+    isPastHorizon = T.isInfixOf "PastHorizon"
+    compareSlot slot = do
+        sameOutcome
+            (epochInfoEpoch observed slot)
+            (epochInfoEpoch expected slot)
+        sameOutcome
+            (epochInfoSlotToRelativeTime observed slot)
+            (epochInfoSlotToRelativeTime expected slot)
+        sameOutcome
+            (getSlotLength <$> epochInfoSlotLength observed slot)
+            (getSlotLength <$> epochInfoSlotLength expected slot)
+    compareEpoch epoch = do
+        sameOutcome
+            (epochInfoSize observed epoch)
+            (epochInfoSize expected epoch)
+        sameOutcome
+            (epochInfoFirst observed epoch)
+            (epochInfoFirst expected epoch)
+
+{- | Derive the devnet coordinate from the acquired 'Globals' and
+the acquired provider rather than from literals in the
+implementation.
+-}
+assertDevnetCoordinate :: Globals -> LedgerSnapshot -> IO ()
+assertDevnetCoordinate globals snapshot = do
+    epochInfoSize (epochInfo globals) (EpochNo 0)
+        `shouldBe` Right (EpochSize 100)
+    (getSlotLength <$> epochInfoSlotLength (epochInfo globals) (SlotNo 0))
+        `shouldBe` Right 0.1
+    epochInfoFirst (epochInfo globals) (EpochNo 0)
+        `shouldBe` Right (SlotNo 0)
+    epochInfoEpoch (epochInfo globals) (SlotNo 0)
+        `shouldBe` Right (EpochNo 0)
+    ledgerCurrentEra snapshot
+        `shouldSatisfy` T.isInfixOf "Conway"
+
+{- | Exercise tip, parameters, UTxO, time conversion, upper-bound
+selection, and evaluation through the supplied snapshot provider.
+-}
+assertSnapshotProvider :: Provider IO -> IO ()
+assertSnapshotProvider provider = do
+    pp <- queryProtocolParams provider
+    (pp ^. ppMaxTxSizeL)
+        `shouldSatisfy` (> 0)
+    utxos <- queryUTxOs provider genesisAddr
+    utxos
+        `shouldSatisfy` (not . null)
+    floorSlot <- posixMsToSlot provider 0
+    ceilSlot <- posixMsCeilSlot provider 0
+    floorSlot `shouldBe` SlotNo 0
+    ceilSlot `shouldBe` SlotNo 0
+    upperBound <- queryUpperBoundSlot provider AutoLongest
+    isRightSlot upperBound `shouldBe` True
+    evaluation <-
+        evaluateTx provider $
+            mkBasicTx $
+                mkBasicTxBody
+                    & inputsTxBodyL
+                        .~ Set.fromList (take 1 (fst <$> utxos))
+    Map.size evaluation `shouldBe` 0
+  where
+    isRightSlot =
+        either (const False) (const True)
+
+{- | Explicitly synthetic, test-only devnet coordinate. It is
+never exported by the library, never supplied to the live
+callback, and authoritative only for the bounded interval it
+names.
+-}
+data SyntheticDevnetCoordinate = SyntheticDevnetCoordinate
+    { syntheticSystemStart :: SystemStart
+    , syntheticSlotLength :: SlotLength
+    , syntheticEpochLength :: EpochSize
+    , syntheticConwayStart :: EpochNo
+    , syntheticHorizon :: SlotNo
+    }
+
+-- | Deterministic, non-POSIX-epoch-zero synthetic source record.
+syntheticDevnetCoordinate :: SyntheticDevnetCoordinate
+syntheticDevnetCoordinate =
+    SyntheticDevnetCoordinate
+        { syntheticSystemStart =
+            systemStartFromText syntheticStartText
+        , syntheticSlotLength = mkSlotLength 0.1
+        , syntheticEpochLength = EpochSize 100
+        , syntheticConwayStart = EpochNo 0
+        , syntheticHorizon = SlotNo 199
+        }
+
+-- | The named deterministic synthetic start.
+syntheticStartText :: T.Text
+syntheticStartText = "2030-01-01T00:00:00Z"
+
+-- | POSIX epoch zero, used only as a forbidden-value witness.
+posixEpochStart :: SystemStart
+posixEpochStart =
+    systemStartFromText "1970-01-01T00:00:00Z"
+
+{- | The A-064 reconstructed timestamp. It is a forbidden
+provenance source and appears here only as a witness the live
+value must differ from.
+-}
+forbiddenReconstructedStart :: SystemStart
+forbiddenReconstructedStart =
+    systemStartFromText "2026-07-26T10:59:39Z"
+
+{- | Decode an ISO-8601 instant with Aeson, so the fixture
+obtains typed time values without a direct @time@ dependency.
+-}
+systemStartFromText :: T.Text -> SystemStart
+systemStartFromText text =
+    case Aeson.eitherDecodeStrict encoded of
+        Right value -> SystemStart value
+        Left err ->
+            error $
+                "systemStartFromText: " <> err
+  where
+    encoded =
+        TE.encodeUtf8 $
+            "\"" <> text <> "\""
+
+{- | The one bounded synthetic fixture of this repository. It
+reads the pinned devnet Shelley genesis and replaces only its
+@systemStart@ placeholder with the deterministic synthetic
+start before decoding, then applies the canonical ledger
+constructor. It is defined here and never exported by the
+library.
+-}
+syntheticDevnetGlobalsFixture :: IO Globals
+syntheticDevnetGlobalsFixture = do
+    dir <- genesisDir
+    raw <-
+        BS.readFile (dir </> "shelley-genesis.json")
+    let patched =
+            TE.encodeUtf8 $
+                T.replace
+                    "PLACEHOLDER"
+                    syntheticStartText
+                    (TE.decodeUtf8 raw)
+    case Aeson.eitherDecodeStrict patched of
+        Right genesis ->
+            pure $
+                mkShelleyGlobals
+                    genesis
+                    ( syntheticEpochInfo
+                        syntheticDevnetCoordinate
+                    )
+        Left err ->
+            error $
+                "syntheticDevnetGlobalsFixture: " <> err
+
+{- | Bounded 'EpochInfo' derived from the synthetic source
+record. Slots past the named horizon fail; nothing is
+extrapolated and no safe zone is extended.
+-}
+syntheticEpochInfo ::
+    SyntheticDevnetCoordinate ->
+    EpochInfo (Either T.Text)
+syntheticEpochInfo coordinate =
+    EpochInfo
+        { epochInfoSize_ = \epoch ->
+            withinEpochHorizon epoch $
+                syntheticEpochLength coordinate
+        , epochInfoFirst_ = \epoch ->
+            withinEpochHorizon epoch $
+                SlotNo (unEpochNo epoch * epochLength)
+        , epochInfoEpoch_ = \slot ->
+            withinHorizon slot $
+                EpochNo (unSlotNo slot `div` epochLength)
+        , epochInfoSlotToRelativeTime_ = \slot ->
+            withinHorizon slot $
+                RelativeTime $
+                    fromIntegral (unSlotNo slot) * slotSeconds
+        , epochInfoSlotLength_ = \slot ->
+            withinHorizon slot $
+                syntheticSlotLength coordinate
+        }
+  where
+    epochLength =
+        unEpochSize (syntheticEpochLength coordinate)
+    slotSeconds =
+        getSlotLength (syntheticSlotLength coordinate)
+    horizon =
+        unSlotNo (syntheticHorizon coordinate)
+    withinHorizon :: forall a. SlotNo -> a -> Either T.Text a
+    withinHorizon slot value
+        | unSlotNo slot <= horizon = Right value
+        | otherwise =
+            Left $
+                "synthetic devnet fixture: slot "
+                    <> T.pack (show (unSlotNo slot))
+                    <> " is past the bounded horizon"
+    withinEpochHorizon :: forall a. EpochNo -> a -> Either T.Text a
+    withinEpochHorizon epoch value
+        | unEpochNo epoch * epochLength <= horizon =
+            Right value
+        | otherwise =
+            Left $
+                "synthetic devnet fixture: epoch "
+                    <> T.pack (show (unEpochNo epoch))
+                    <> " is past the bounded horizon"
+
+{- | Offline provider whose POSIX/slot conversion is derived
+from the same synthetic source record, by arithmetic
+independent of the fixture 'EpochInfo'. It shares that
+fixture's bounded coordinate: a candidate slot past
+'syntheticHorizon' fails with the named marker instead of
+being extrapolated. Every other operation fails loudly rather
+than returning fabricated ledger data.
+-}
+syntheticOfflineProvider ::
+    SyntheticDevnetCoordinate ->
+    Provider IO
+syntheticOfflineProvider coordinate =
+    Provider
+        { withAcquired = \_ -> unusedOffline "withAcquired"
+        , queryUTxOs = \_ -> unusedOffline "queryUTxOs"
+        , queryUTxOByTxIn = \_ -> unusedOffline "queryUTxOByTxIn"
+        , queryProtocolParams = unusedOffline "queryProtocolParams"
+        , queryLedgerSnapshot = unusedOffline "queryLedgerSnapshot"
+        , queryStakeRewards = \_ -> unusedOffline "queryStakeRewards"
+        , queryRewardAccounts = \_ -> unusedOffline "queryRewardAccounts"
+        , queryVoteDelegatees = \_ -> unusedOffline "queryVoteDelegatees"
+        , queryTreasury = unusedOffline "queryTreasury"
+        , queryGovernanceState = unusedOffline "queryGovernanceState"
+        , evaluateTx = \_ -> unusedOffline "evaluateTx"
+        , posixMsToSlot =
+            withinProviderHorizon coordinate
+                . syntheticFloorSlot coordinate
+        , posixMsCeilSlot =
+            withinProviderHorizon coordinate
+                . syntheticCeilSlot coordinate
+        , queryUpperBoundSlot = \_ ->
+            unusedOffline "queryUpperBoundSlot"
+        }
+  where
+    -- 'Provider' has strict fields, so an operation outside the
+    -- bounded offline contract must be a real action that throws
+    -- when called, not bottom at construction time.
+    unusedOffline :: forall a. String -> IO a
+    unusedOffline name =
+        Exception.throwIO $
+            Exception.ErrorCall $
+                "synthetic offline provider: "
+                    <> name
+                    <> " is not part of \
+                       \the bounded offline contract"
+
+{- | Bound a computed candidate slot by the same
+'syntheticHorizon' the fixture 'EpochInfo' enforces. A
+candidate past it is a named failure, never a clamp, a
+fallback, or an extrapolated coordinate.
+-}
+withinProviderHorizon ::
+    SyntheticDevnetCoordinate ->
+    SlotNo ->
+    IO SlotNo
+withinProviderHorizon coordinate candidate
+    | unSlotNo candidate
+        <= unSlotNo (syntheticHorizon coordinate) =
+        pure candidate
+    | otherwise =
+        Exception.throwIO $
+            Exception.ErrorCall $
+                "synthetic offline provider: slot "
+                    <> show (unSlotNo candidate)
+                    <> " is past the bounded horizon"
+
+-- | POSIX milliseconds of a slot start, from the source record.
+syntheticSlotStartMs ::
+    SyntheticDevnetCoordinate ->
+    SlotNo ->
+    Integer
+syntheticSlotStartMs coordinate slot =
+    posixMillisecondsOf (syntheticSystemStart coordinate)
+        + toInteger (unSlotNo slot)
+            * slotLengthMilliseconds
+                (syntheticSlotLength coordinate)
+
+-- | Floor POSIX milliseconds to a slot, from the source record.
+syntheticFloorSlot ::
+    SyntheticDevnetCoordinate ->
+    Integer ->
+    SlotNo
+syntheticFloorSlot coordinate ms =
+    SlotNo $
+        fromInteger $
+            max 0 $
+                (ms - startMs) `div` slotMs
+  where
+    startMs =
+        posixMillisecondsOf (syntheticSystemStart coordinate)
+    slotMs =
+        slotLengthMilliseconds (syntheticSlotLength coordinate)
+
+-- | Ceiling POSIX milliseconds to a slot, from the source record.
+syntheticCeilSlot ::
+    SyntheticDevnetCoordinate ->
+    Integer ->
+    SlotNo
+syntheticCeilSlot coordinate ms
+    | (ms - startMs) `mod` slotMs == 0 = floorSlot
+    | otherwise = SlotNo (unSlotNo floorSlot + 1)
+  where
+    floorSlot =
+        syntheticFloorSlot coordinate ms
+    startMs =
+        posixMillisecondsOf (syntheticSystemStart coordinate)
+    slotMs =
+        slotLengthMilliseconds (syntheticSlotLength coordinate)
+
+-- | POSIX milliseconds of a 'SystemStart'.
+posixMillisecondsOf :: SystemStart -> Integer
+posixMillisecondsOf start =
+    round $
+        1000
+            * getRelativeTime
+                ( toRelativeTime
+                    posixEpochStart
+                    (getSystemStart start)
+                )
+
+-- | Slot length in whole milliseconds.
+slotLengthMilliseconds :: SlotLength -> Integer
+slotLengthMilliseconds =
+    round . (* 1000) . getSlotLength
+
+{- | Floor a POSIX millisecond to a slot using only the
+'Globals' 'EpochInfo', independently of the offline provider's
+arithmetic.
+-}
+globalsFloorSlot ::
+    Globals ->
+    SlotNo ->
+    Integer ->
+    Either T.Text SlotNo
+globalsFloorSlot globals horizon ms = do
+    starts <-
+        traverse relativeStart bounded
+    case [slot | (slot, start) <- starts, start <= target] of
+        [] ->
+            Left "globalsFloorSlot: before the fixture origin"
+        below ->
+            Right (maximum below)
+  where
+    bounded =
+        SlotNo <$> [0 .. unSlotNo horizon]
+    relativeStart slot =
+        (,) slot . getRelativeTime
+            <$> epochInfoSlotToRelativeTime
+                (epochInfo globals)
+                slot
+    target =
+        fromInteger
+            (ms - posixMillisecondsOf (systemStart globals))
+            / 1000
+
+{- | Ceiling a POSIX millisecond to a slot using only the
+'Globals' 'EpochInfo'.
+-}
+globalsCeilSlot ::
+    Globals ->
+    SlotNo ->
+    Integer ->
+    Either T.Text SlotNo
+globalsCeilSlot globals horizon ms = do
+    slot <- globalsFloorSlot globals horizon ms
+    start <-
+        getRelativeTime
+            <$> epochInfoSlotToRelativeTime
+                (epochInfo globals)
+                slot
+    pure $
+        if start == target
+            then slot
+            else SlotNo (unSlotNo slot + 1)
+  where
+    target =
+        fromInteger
+            (ms - posixMillisecondsOf (systemStart globals))
+            / 1000
+
+{- | Prove exact provider/'Globals' coordinate identity over the
+whole bounded interval, and named failure past its horizon.
+-}
+assertSyntheticCoordinateIdentity ::
+    SyntheticDevnetCoordinate ->
+    Globals ->
+    Provider IO ->
+    IO ()
+assertSyntheticCoordinateIdentity coordinate fixture offline = do
+    mapM_ assertSlot bounded
+    epochInfoFirst (epochInfo fixture) (EpochNo 0)
+        `shouldBe` Right (SlotNo 0)
+    epochInfoFirst (epochInfo fixture) (EpochNo 1)
+        `shouldBe` Right (SlotNo 100)
+    epochInfoSize (epochInfo fixture) (EpochNo 0)
+        `shouldBe` Right (syntheticEpochLength coordinate)
+    epochInfoEpoch (epochInfo fixture) (SlotNo 0)
+        `shouldBe` Right (syntheticConwayStart coordinate)
+    epochInfoSlotToRelativeTime
+        (epochInfo fixture)
+        (SlotNo (unSlotNo horizon + 1))
+        `shouldSatisfy` isHorizonFailure
+    epochInfoSlotLength
+        (epochInfo fixture)
+        (SlotNo (unSlotNo horizon + 1))
+        `shouldSatisfy` isHorizonFailure
+    -- The provider shares the bounded coordinate: at the POSIX
+    -- start of the first slot past the horizon, both conversions
+    -- fail with the named marker instead of extrapolating.
+    beyondFloor <-
+        Exception.try @Exception.ErrorCall $
+            posixMsToSlot offline beyondHorizonMs
+    beyondCeil <-
+        Exception.try @Exception.ErrorCall $
+            posixMsCeilSlot offline beyondHorizonMs
+    boundedHorizonFailure beyondFloor
+        `shouldBe` True
+    boundedHorizonFailure beyondCeil
+        `shouldBe` True
+  where
+    horizon = syntheticHorizon coordinate
+    bounded = SlotNo <$> [0 .. unSlotNo horizon]
+    beyondHorizonMs =
+        syntheticSlotStartMs
+            coordinate
+            (SlotNo (unSlotNo horizon + 1))
+    slotMs =
+        slotLengthMilliseconds (syntheticSlotLength coordinate)
+    assertSlot slot = do
+        let startMs =
+                syntheticSlotStartMs coordinate slot
+            midMs = startMs + slotMs `div` 2
+        -- exact slot boundary: floor and ceiling agree
+        providerFloor <- posixMsToSlot offline startMs
+        providerCeil <- posixMsCeilSlot offline startMs
+        providerFloor `shouldBe` slot
+        providerCeil `shouldBe` slot
+        globalsFloorSlot fixture horizon startMs
+            `shouldBe` Right slot
+        globalsCeilSlot fixture horizon startMs
+            `shouldBe` Right slot
+        -- inside the slot: floor stays, ceiling advances
+        midFloor <- posixMsToSlot offline midMs
+        midFloor `shouldBe` slot
+        globalsFloorSlot fixture horizon midMs
+            `shouldBe` Right slot
+        -- coordinate derived from the source record
+        epochInfoEpoch (epochInfo fixture) slot
+            `shouldBe` Right
+                (EpochNo (unSlotNo slot `div` 100))
+        (getSlotLength <$> epochInfoSlotLength (epochInfo fixture) slot)
+            `shouldBe` Right 0.1
+        epochInfoSlotToRelativeTime (epochInfo fixture) slot
+            `shouldBe` Right
+                ( RelativeTime $
+                    fromIntegral (unSlotNo slot) * 0.1
+                )
+
+-- | A bounded-horizon failure, not a fabricated coordinate.
+isHorizonFailure :: Either T.Text a -> Bool
+isHorizonFailure (Left message) =
+    T.isInfixOf "past the bounded horizon" message
+isHorizonFailure _ = False
+
+{- | The synthetic provider refused a candidate past its bounded
+horizon with the named marker, rather than returning a slot.
+-}
+boundedHorizonFailure ::
+    Either Exception.ErrorCall SlotNo ->
+    Bool
+boundedHorizonFailure (Left err) =
+    T.isInfixOf
+        "past the bounded horizon"
+        (T.pack (show err))
+boundedHorizonFailure _ = False
+
+{- | Offline analogue of the acquisition callback: one 'Globals'
+and one provider reach every consumer.
+-}
+withSyntheticSnapshot ::
+    Globals ->
+    Provider IO ->
+    (Globals -> Provider IO -> IO a) ->
+    IO a
+withSyntheticSnapshot globals provider callback =
+    callback globals provider
+
+-- | Mock builder step; returns the 'Globals' it was handed.
+mockBuilderStep :: Globals -> Provider IO -> IO Globals
+mockBuilderStep globals provider = do
+    slot <- posixMsToSlot provider 0
+    void $ Exception.evaluate slot
+    pure globals
+
+-- | Mock ledger-native guard step; returns the same 'Globals'.
+mockGuardStep :: Globals -> IO Globals
+mockGuardStep globals = do
+    void $
+        Exception.evaluate
+            (epochInfoEpoch (epochInfo globals) (SlotNo 0))
+    pure globals
+
+-- | Copy a genesis directory tree into a fresh location.
+copyGenesisTree :: FilePath -> FilePath -> IO ()
+copyGenesisTree source target = do
+    createDirectoryIfMissing True target
+    entries <- listDirectory source
+    mapM_ copyEntry entries
+  where
+    copyEntry entry = do
+        let from = source </> entry
+            to = target </> entry
+        isDir <- doesDirectoryExist from
+        if isDir
+            then copyGenesisTree from to
+            else copyFile from to
+
+{- | Move the Conway hard fork one epoch later so the node
+starts before Conway.
+-}
+delayConwayHardFork :: FilePath -> IO ()
+delayConwayHardFork dir = do
+    raw <- BS.readFile configPath
+    let patched =
+            T.replace
+                "\"TestConwayHardForkAtEpoch\": 0"
+                "\"TestConwayHardForkAtEpoch\": 1"
+                (TE.decodeUtf8 raw)
+    permissions <- getPermissions configPath
+    setPermissions configPath (setOwnerWritable True permissions)
+    BS.writeFile configPath (TE.encodeUtf8 patched)
+  where
+    configPath = dir </> "node-config.json"
+
+{- | The era mismatch must surface as the implementation's named
+failure, not as fixture data.
+-}
+eraMismatchReported ::
+    Either Exception.ErrorCall a ->
+    Bool
+eraMismatchReported (Left err) =
+    "era mismatch" `T.isInfixOf` T.pack (show err)
+eraMismatchReported _ = False
+
+{- | The implementation must not read a clock or carry a
+reconstructed timestamp.
+-}
+assertNoClockProvenance :: BS.ByteString -> IO ()
+assertNoClockProvenance source =
+    mapM_ absent forbidden
+  where
+    text = TE.decodeUtf8 source
+    forbidden =
+        [ "getCurrentTime"
+        , "getPOSIXTime"
+        , "getSystemTime"
+        , "getMonotonicTime"
+        , "2026-07-26"
+        ]
+    absent needle =
+        T.isInfixOf needle text
+            `shouldBe` False
 
 slotNumber :: SlotNo -> Word64
 slotNumber (SlotNo slot) =


### PR DESCRIPTION
`cardano-keri`'s ledger-native Phase-1 guard has no way to obtain the same
real time and era provenance that N2C script evaluation already uses. It can
reach a provider, but not the ledger `Globals` behind it — so a pre-flight
check either guesses its own time coordinate or is skipped. This adds the
missing seam, without changing anything that exists today.

## What changes

One additive public callback in `Cardano.Node.Client.N2C.Provider`:

```haskell
withAcquiredN2CProviderAndGlobals ::
    LSQChannel ->
    (Globals -> Provider IO -> IO a) ->
    IO a
```

The callback receives canonical ledger `Globals` and a `Provider IO` whose
every query runs against **one** acquired LocalStateQuery snapshot.

`mkN2CProvider` keeps its exact signature and its per-operation acquisition
behaviour; both providers now share one private builder, so no existing
caller changes. The `e2e-tests` component gains four direct dependencies —
`cardano-ledger-allegra`, `cardano-ledger-shelley`, `ouroboros-consensus`,
`ouroboros-consensus:cardano` — used only so the tests can rebuild the
expected `Globals` independently of the implementation. The library stanza is
untouched.

## Why this boundary

Tip, protocol parameters, UTxO, POSIX/slot conversion, script evaluation, and
any ledger-native pre-flight guard are all views of a moving ledger. If they
are read at different points, a transaction can be built against one
coordinate and validated against another. A returned `(Globals, Provider)`
pair could not honestly promise otherwise, and an environment-lifetime cache
would go stale across a node restart, a changed system start, an advancing
horizon, or an era transition.

Making the acquisition an explicit callback makes that boundary visible:
inside it everything shares provenance, and a later operation asks for a new
callback and refreshes coherently. Nothing is cached. Submission and
settlement polling belong outside the callback, so a long wait never holds
the LSQ acquisition.

## Construction and failures

Inside one `withAcquiredLSQ`, the node answers the current-Conway compact
genesis, the top-level system start, and the hard-fork interpreter. `Globals`
are built by the canonical consensus path (`mkShelleyLedgerConfig` →
`shelleyLedgerGlobals`), and the constructed system start is cross-checked
against the separately queried one.

Failures stay failures: era mismatch outside current Conway, acquisition
loss, query/codec errors, past-horizon translation, and a system start that
disagrees with the genesis are all surfaced. There is no wall-clock
reconstruction, no POSIX-zero fallback, no synthetic production value, no
unsafe safe-zone extension, and no error filtering.

## Tests

Five E2E examples, added test-first:

- all eleven `Globals` fields checked against an expectation built from
  independent raw node queries — ten scalars exactly, `EpochInfo`
  behaviourally;
- `Globals` and provider stay usable across several handle groups within one
  callback lifetime;
- current-era mismatch and interpreter horizon failures remain observable;
- one explicitly synthetic, bounded devnet coordinate (slots `0..199`,
  named failure at `200`) with exact provider/`Globals` coordinate identity
  across the whole interval;
- system start comes from the node, is stable across reacquisition, and is
  neither POSIX zero nor a reconstructed timestamp.

The synthetic fixture is private to the test suite and never exported.

One boundary is worth calling out. The suite passes in a writable checkout
but initially failed inside the packaged Nix check: `copyFile` preserves
source permissions, so a genesis fixture copied out of the Nix store arrives
mode `0444` and the helper that rewrites `node-config.json` hit
`PermissionDenied`. The helper now makes that one copied file writable
explicitly. The packaged check was fixed, not weakened — it is the only place
that class of defect is visible.

## Verification

- Targeted RED → GREEN on `acquires real Globals and provider in one LSQ
  snapshot`.
- Path-scoped Fourmolu, focused HLint (`No hints`), and Cabal formatting
  identity against a formatted temporary copy — all exit 0.
- Full gate, all eight commands from the top, each exit 0:
  `just ci`; `just e2e`; `nix build` of the `build`/`unit`/`e2e`/`lint`
  checks; `nix run` of `.#build`, `.#unit`, `.#e2e`, `.#lint`; and
  `scripts/release/check-version-consistency`
  (`release version contract ok: Cabal 0.1.4.0`).
- Unit: 169 examples, 0 failures, 1 pending. E2E: 25 examples, 0 failures,
  in both the dev-shell and packaged runs.
- Exactly three changed paths, and the `cardano-node-clients.cabal` diff is
  exactly four added `e2e-tests` `build-depends` entries with no removal and
  no other stanza touched.

## Supply chain and follow-up

No library-stanza dependency change and no version bound. Three of the four
added test dependencies are already direct library dependencies; the fourth,
`cardano-ledger-shelley`, is already resolved in the downstream build plan
that builds this package from the same pin.

Downstream pins are deliberately unchanged here: they will be computed only
from this reviewed, pushed commit.

## Links

- `lambdasistemi/cardano-keri#115`
- reviewed A-064 real-`Globals` design and provenance
- A-065 acquisition contract
- A-066 corrected fences (three upstream paths, four direct e2e dependencies)

**No merge requested.** This is opened for review so the commit is fetchable
for downstream pinning.
